### PR TITLE
deploy-2-start.yml: Added ssh setup steps for each job

### DIFF
--- a/.github/workflows/deploy-2-start.yml
+++ b/.github/workflows/deploy-2-start.yml
@@ -29,12 +29,23 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.version }}
+      - name: Setup ssh
+        run: |
+          mkdir -p ~/.ssh
+          chmod 700 ~/.ssh
+          echo '${{ secrets.SSH_KEY }}' > ~/.ssh/priv.key
+          chmod 600 ~/.ssh/priv.key
+          ssh-keyscan ${{ secrets.HOST }} >> ~/.ssh/known_hosts
+          ssh-keyscan ${{ secrets.HOST_DATA }} >> ~/.ssh/known_hosts
+          chmod 600 ~/.ssh/known_hosts 
       - name: Copy spack.yaml
-        run: rsync spack.yaml ${{ secrets.USER }}@${{ secrets.HOST_DATA }}:${{ vars.SPACK_YAML_LOCATION }}
+        run: rsync -e 'ssh -i ~/.ssh/priv.key' \
+               spack.yaml \
+               ${{ secrets.USER }}@${{ secrets.HOST_DATA }}:${{ vars.SPACK_YAML_LOCATION }}
       - name: Deploy on gadi
         # ssh into deployment environment, create and activate the env, install the spack.yaml. 
         run: |
-          ssh ${{ secrets.USER}}@${{ secrets.HOST }} /bin/bash <<'EOT'
+          ssh ${{ secrets.USER}}@${{ secrets.HOST }} -i ~/.ssh/deploy.priv /bin/bash <<'EOT'
           . ${{ vars.SPACK_LOCATION }}/share/spack/setup-env.sh
           module load intel-compiler/2019.5.281
           spack env create ${{ inputs.env-name }} ${{ vars.SPACK_YAML_LOCATION }}/spack.yaml
@@ -54,9 +65,17 @@ jobs:
     permissions:
       contents: write
     steps:
+      - name: Setup ssh
+        run: |
+          mkdir -p ~/.ssh
+          chmod 700 ~/.ssh
+          echo '${{ secrets.SSH_KEY }}' > ~/.ssh/priv.key
+          chmod 600 ~/.ssh/priv.key
+          ssh-keyscan ${{ secrets.HOST_DATA }} >> ~/.ssh/known_hosts
+          chmod 600 ~/.ssh/known_hosts 
       - name: Get Release Metadata
         run: |
-          rsync \
+          rsync -e 'ssh -i ~/.ssh/priv.key' \
             '${{ secrets.USER}}@${{ secrets.HOST_DATA }}:${{ vars.SPACK_LOCATION }}/var/spack/environments/${{ inputs.env-name }}/spack.*' \
             ${{ vars.RELEASE_LOCATION }}/${{ inputs.env-name }}
       - name: Create Release


### PR DESCRIPTION
Ported the ssh code from the access-nri/test project to the deployment workflow. 

Closes #6 