### PR TITLE
Checkout caller workflow fix

### DIFF
--- a/.github/workflows/deploy-1-setup.yml
+++ b/.github/workflows/deploy-1-setup.yml
@@ -7,25 +7,16 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       model: ${{ steps.get-model.outputs.model }}
-      version: ${{ steps.get-model-version.outputs.version }}
       env-name: ${{ steps.get-env-name.outputs.env-name }}
     steps:
-      - name: Checkout caller workflow
-        uses: actions/checkout@v4
       - name: Get Model
         id: get-model
         # for the cases where the repo name is in uppercase but the package name is lowercase (eg. access-nri/MOM5)
         run: echo "model=$(echo ${{ github.event.repository.name }} | tr [:upper:] [:lower:])" >> $GITHUB_OUTPUT
-      - name: Get Model Version
-        id: get-model-version
-        # Unfragment the tag history so we can get the latest tag on main
-        run: |
-          git fetch --unshallow
-          echo "version=$(git describe --tags --abbrev=0)" >> $GITHUB_OUTPUT
       - name: Set Spack Env Name String
         id: get-env-name
         # replace occurences of '.' with '_' in environment name as spack doesn't support '.'. Ex: 'access-om2-v1.0.0' -> 'access-om2-v1_0_0'.  
-        run: echo "env-name=$(echo '${{ steps.get-model.outputs.model }}-${{ steps.get-model-version.outputs.version }}' | tr '.' '_')" >> $GITHUB_OUTPUT
+        run: echo "env-name=$(echo '${{ steps.get-model.outputs.model }}-${{ github.ref_name }}' | tr '.' '_')" >> $GITHUB_OUTPUT
   
   setup-deployment-env:
     name: Setup Deployment Environment
@@ -41,7 +32,6 @@ jobs:
         id: get-deployment-environment
         run: echo "deployment-environments=$(jq --compact-output '.environments' ./config/deployment-environment.json)" >> $GITHUB_OUTPUT
 
-  
   deployment:
     name: Deployment
     needs:
@@ -54,7 +44,7 @@ jobs:
     uses: access-nri/build-cd/.github/workflows/deploy-2-start.yml@main
     with:
       model: ${{ needs.setup-spack-env.outputs.model }}
-      version: ${{ needs.setup-spack-env.outputs.version }}
+      version: ${{ github.ref_name }}
       env-name: ${{ needs.setup-spack-env.outputs.env-name }}
       deployment-environment: ${{ matrix.deployment-environment }}
     secrets: inherit

--- a/.github/workflows/deploy-1-setup.yml
+++ b/.github/workflows/deploy-1-setup.yml
@@ -12,9 +12,6 @@ jobs:
     steps:
       - name: Checkout caller workflow
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 1
-          fetch-tags: true
       - name: Get Model
         id: get-model
         # for the cases where the repo name is in uppercase but the package name is lowercase (eg. access-nri/MOM5)


### PR DESCRIPTION
Removing the args to actions/checkout as fetch-tags isn't needed due to the checkout ref being the value of on.push.tags, and fetch-depth being by default 1