### PR TITLE
GitHub Environment name fix

### DIFF
--- a/.github/workflows/deploy-2-start.yml
+++ b/.github/workflows/deploy-2-start.yml
@@ -39,9 +39,10 @@ jobs:
           ssh-keyscan ${{ secrets.HOST_DATA }} >> ~/.ssh/known_hosts
           chmod 600 ~/.ssh/known_hosts 
       - name: Copy spack.yaml
-        run: rsync -e 'ssh -i ~/.ssh/priv.key' \
-               spack.yaml \
-               ${{ secrets.USER }}@${{ secrets.HOST_DATA }}:${{ vars.SPACK_YAML_LOCATION }}
+        run: |
+          rsync -e 'ssh -i ~/.ssh/priv.key' \
+            spack.yaml \
+            ${{ secrets.USER }}@${{ secrets.HOST_DATA }}:${{ vars.SPACK_YAML_LOCATION }}
       - name: Deploy on gadi
         # ssh into deployment environment, create and activate the env, install the spack.yaml. 
         run: |

--- a/config/deployment-environment.json
+++ b/config/deployment-environment.json
@@ -1,6 +1,6 @@
 {
     "$schema": "./deployment-environment.schema.json",
     "environments": [
-        "gadi"
+        "Gadi"
     ]
 }


### PR DESCRIPTION
The name of the environment in build-cd is 'Gadi' not 'gadi', it's instead creating an environment in ACCESS-OM2 named 'gadi'. This PR uses the same capitalization.