### PR TITLE
Added debug and fresh install flags to `spack install`

### DIFF
--- a/.github/workflows/deploy-2-start.yml
+++ b/.github/workflows/deploy-2-start.yml
@@ -52,7 +52,7 @@ jobs:
           module load intel-compiler/2019.5.281
           spack env create ${{ inputs.env-name }} ${{ vars.SPACK_YAML_LOCATION }}/spack.yaml
           spack env activate ${{ inputs.env-name }}
-          spack install || exit $?
+          spack --debug install --fresh || exit $?
           spack find --paths > ${{ vars.SPACK_LOCATION }}/var/spack/environments/${{ inputs.env-name }}/spack.location.txt
           spack env deactivate
           module unload intel-compiler/2019.5.281


### PR DESCRIPTION
In this PR:
* added --debug flag so we get more output in CD pipeline
* added --fresh flag so install doesn't having clashing `package@git.version=spack_version` tags 

Should close https://github.com/ACCESS-NRI/ACCESS-OM2/issues/15