### PR TITLE
Create Deployment Spack directory name fix

### DIFF
--- a/.github/workflows/create-deployment-spack.yml
+++ b/.github/workflows/create-deployment-spack.yml
@@ -41,7 +41,7 @@ jobs:
         id: strip
         # this step removes the 'release/' part from some spack tags, so our
         # directory structure doesn't contain a 'releases' subdirectory
-        run: echo "version-dir=$(echo '${{ inputs.spack-version }}' | cut --delimiter '/' --fields 2)" >> $GITHUB_OUTPUT
+        run: echo "version-dir=$(echo '${{ inputs.spack-version }}' | cut --delimiter 'v' --fields 2)" >> $GITHUB_OUTPUT
 
       - name: Install
         env:


### PR DESCRIPTION
In this PR:
* We now cut the version name on 'v' rather than '/', leading to the correct version directory name of `0.20`, for example

Closes #35﻿
