### PR TITLE
Undeploy Job jq fix

### DIFF
--- a/.github/workflows/undeploy-1-setup.yml
+++ b/.github/workflows/undeploy-1-setup.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Get Environments
         id: get-deployment-environment
-        run: echo "deployment-environments=$(jq --compact-output '.prerelease-environments' ./config/deployment-environment.json)" >> $GITHUB_OUTPUT
+        run: echo "deployment-environments=$(jq --compact-output '."prerelease-environments"' ./config/deployment-environment.json)" >> $GITHUB_OUTPUT
 
 
   undeployment:


### PR DESCRIPTION
In this PR:
- Modified `jq` query - we now escape fields that are delimited by `-` using `""`
