### PR TITLE
Escape `-`-delimited `jq`

### DIFF
--- a/.github/workflows/deploy-1-setup.yml
+++ b/.github/workflows/deploy-1-setup.yml
@@ -45,7 +45,7 @@ jobs:
           if [[ "${{ inputs.type }}" == "release" ]]; then
             echo "deployment-environments=$(jq --compact-output '.environments' ./config/deployment-environment.json)" >> $GITHUB_OUTPUT
           else if [[ "${{ inputs.type }}" == "prerelease" ]]; then
-            echo "deployment-environments=$(jq --compact-output '.prerelease-environments' ./config/deployment-environment.json)" >> $GITHUB_OUTPUT
+            echo "deployment-environments=$(jq --compact-output '."prerelease-environments"' ./config/deployment-environment.json)" >> $GITHUB_OUTPUT
           else
             echo "::error::The 'type' input was invalid. Check the inputs documentation."
             exit 1


### PR DESCRIPTION
Similar to the merged `undeploy-1-setup.yml` fix, except it was a regression in `deploy-1-setup.yml`, as well. 