### PR TITLE
deploy-*.yml: Added ref and updated version inputs

### DIFF
--- a/.github/workflows/deploy-1-setup.yml
+++ b/.github/workflows/deploy-1-setup.yml
@@ -7,10 +7,15 @@ on:
         required: false
         default: release
         description: The type of deployment - either 'release' or 'prerelease'
+      ref:
+        type: string
+        required: true
+        description: The git commit-ish ref where the `spack.yaml` is located
       version:
         type: string
         required: true
-        description: The version of the model being deployed
+        description: The version for the model being deployed
+
 jobs:
   setup-spack-env:
     name: Setup Spack Environment
@@ -64,6 +69,7 @@ jobs:
     with:
       type: ${{ inputs.type }}
       model: ${{ needs.setup-spack-env.outputs.model }}
+      ref: ${{ inputs.ref }}
       version: ${{ inputs.version }}
       env-name: ${{ needs.setup-spack-env.outputs.env-name }}
       deployment-environment: ${{ matrix.deployment-environment }}

--- a/.github/workflows/deploy-2-start.yml
+++ b/.github/workflows/deploy-2-start.yml
@@ -11,10 +11,14 @@ on:
         type: string
         required: true
         description: The model to deploy
+      ref:
+        type: string
+        required: true
+        description: The git commit-ish ref where the `spack.yaml` is located
       version:
         type: string
         required: true
-        description: The version of the model to deploy
+        description: The version for the model being deployed
       env-name:
         type: string
         required: true
@@ -33,7 +37,7 @@ jobs:
       # Deployment
       - uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.version }}
+          ref: ${{ inputs.ref }}
 
       - name: Get packages and config versions
         id: versions


### PR DESCRIPTION
In this PR:
* We were using version as a git ref, when that is no longer applicable. This is now split into the `ref` input, and the `version` input. 

References #40