### PR TITLE
Add Custom Action `validate-repo-version`

### DIFF
--- a/.github/actions/validate-repo-version/README.md
+++ b/.github/actions/validate-repo-version/README.md
@@ -6,14 +6,13 @@ This action checks that the tags specified in a models `config/versions.json` is
 
 | Name | Type | Description | Required | Default | Example |
 | ---- | ---- | ----------- | -------- | ------- | ------- |
-| `repos-to-check` | `string` | Space-separated list of ACCESS-NRI repositories to check | `true` | N/A | `spack-packages spack-config` |
+| `repo-to-check` | `string` | ACCESS-NRI repositories  to validate associated version in `config/versions.json` | `true` | N/A | `spack-packages spack-config` |
 
 ## Outputs
 
 | Name | Type | Description | Example |
 | ---- | ---- | ----------- | ------- |
-| `spack-packages-version` | `string` | Version of spack-packages from the `config/versions.json` | `"2024.03.12"` |
-| `spack-config-version` | `string` | Version of spack-config from the `config/versions.json` | `"2024.12.22"` |
+| `version` | `string` | Version of the repo from the `config/versions.json` | `"2024.03.12"` |
 
 ## Example
 
@@ -22,9 +21,9 @@ This action checks that the tags specified in a models `config/versions.json` is
 - id: validate
   uses: access-nri/build-cd/.github/actions/validate-repo-version@main
   with:
-    repos-to-check: spack-packages
+    repo-to-check: spack-packages
 
-- run: echo "spack-packages has valid version ${{ steps.validate.outputs.spack-packages-version }} in `config/versions.json`"
+- run: echo "spack-packages has valid version ${{ steps.validate.outputs.version }} in `config/versions.json`"
 
 - if: failure() && steps.validate.outcome == 'failure'
   run: echo "The version in spack-packages is not valid."

--- a/.github/actions/validate-repo-version/README.md
+++ b/.github/actions/validate-repo-version/README.md
@@ -1,0 +1,31 @@
+# Validate Repo Versions Action
+
+This action checks that the tags specified in a models `config/versions.json` is an actual, valid tag for that repository.
+
+## Inputs
+
+| Name | Type | Description | Required | Default | Example |
+| ---- | ---- | ----------- | -------- | ------- | ------- |
+| `repos-to-check` | `string` | Space-separated list of ACCESS-NRI repositories to check | `true` | N/A | `spack-packages spack-config` |
+
+## Outputs
+
+| Name | Type | Description | Example |
+| ---- | ---- | ----------- | ------- |
+| `spack-packages-version` | `string` | Version of spack-packages from the `config/versions.json` | `"2024.03.12"` |
+| `spack-config-version` | `string` | Version of spack-config from the `config/versions.json` | `"2024.12.22"` |
+
+## Example
+
+```yaml
+# ...
+- id: validate
+  uses: access-nri/build-cd/.github/actions/validate-repo-version@main
+  with:
+    repos-to-check: spack-packages
+
+- run: echo "spack-packages has valid version ${{ steps.validate.outputs.spack-packages-version }} in `config/versions.json`"
+
+- if: failure() && steps.validate.outcome == 'failure'
+  run: echo "The version in spack-packages is not valid."
+```

--- a/.github/actions/validate-repo-version/action.yml
+++ b/.github/actions/validate-repo-version/action.yml
@@ -1,0 +1,62 @@
+name: Validate Repo Versions
+description: Action that validates that the versions in `config/versions.json` match existing versions in the repository
+inputs:
+  repos-to-check:
+    type: string
+    required: true
+    description: Space-separated list of ACCESS-NRI repositories to check
+outputs:
+  spack-packages-version:
+    value: ${{ steps.versions.outputs.packages }}
+    description: Version of spack-packages from the `config/versions.json`
+  spack-config-version:
+    value: ${{ steps.versions.outputs.config }}
+    description: Version of spack-config from the `config/versions.json`
+runs:
+  using: composite
+  steps:
+    - uses: actions/checkout@v4
+
+    # The next steps checkout the repos to confirm that the versions in
+    # versions.json exist in the repositories.
+    - name: Setup
+      id: versions
+      run: |
+        if [[ "${{ contains(inputs.repos-to-check, 'spack-packages') }}" == "true" ]]; then
+          echo "packages=$(jq --compact-output --raw-output '."spack-packages"' ./config/versions.json)" >> $GITHUB_OUTPUT
+        fi
+
+        if [[ "${{ contains(inputs.repos-to-check, 'spack-config') }}" == "true" ]]; then
+          echo "config=$(jq --compact-output --raw-output '."spack-config"' ./config/versions.json)" >> $GITHUB_OUTPUT
+        fi
+
+    - name: Spack Packages
+      id: spack-packages
+      if: contains(inputs.repos-to-check, 'spack-packages')
+      continue-on-error: true
+      uses: actions/checkout@v4
+      with:
+        repository: access-nri/spack-packages
+        ref: ${{ steps.versions.outputs.packages }}
+        path: packages
+
+    - name: Spack Config
+      id: spack-config
+      if: contains(inputs.repos-to-check, 'spack-config')
+      continue-on-error: true
+      uses: actions/checkout@v4
+      with:
+        repository: access-nri/spack-config
+        ref: ${{ steps.versions.outputs.config }}
+        path: config
+
+    - name: Failure Notifier
+      if: contains(steps.*.outcome, 'failure')
+      run: |
+        if [[ "${{ steps.spack-packages.outcome }}" == "failure" ]]; then
+          echo "::error::spack-packages at the specified ref (${{ steps.versions.outputs.packages }}) doesn't exist."
+        fi
+        if [[ "${{ steps.spack-config.outcome }}" == "failure" ]]; then
+          echo "::error::spack-config at the specified ref (${{ steps.versions.outputs.config }}) doesn't exist."
+        fi
+        exit 1

--- a/.github/actions/validate-repo-version/action.yml
+++ b/.github/actions/validate-repo-version/action.yml
@@ -21,6 +21,7 @@ runs:
     # versions.json exist in the repositories.
     - name: Setup
       id: versions
+      shell: bash
       run: |
         if [[ "${{ contains(inputs.repos-to-check, 'spack-packages') }}" == "true" ]]; then
           echo "packages=$(jq --compact-output --raw-output '."spack-packages"' ./config/versions.json)" >> $GITHUB_OUTPUT
@@ -52,6 +53,7 @@ runs:
 
     - name: Failure Notifier
       if: contains(steps.*.outcome, 'failure')
+      shell: bash
       run: |
         if [[ "${{ steps.spack-packages.outcome }}" == "failure" ]]; then
           echo "::error::spack-packages at the specified ref (${{ steps.versions.outputs.packages }}) doesn't exist."

--- a/.github/actions/validate-repo-version/action.yml
+++ b/.github/actions/validate-repo-version/action.yml
@@ -1,64 +1,49 @@
-name: Validate Repo Versions
-description: Action that validates that the versions in `config/versions.json` match existing versions in the repository
+name: Validate Repo Version
+description: Action that validates that a version in `config/versions.json` matches the version in the repository
 inputs:
-  repos-to-check:
+  repo-to-check:
     type: string
     required: true
-    description: Space-separated list of ACCESS-NRI repositories to check
+    description: ACCESS-NRI repository to validate associated version in `config/versions.json`
 outputs:
-  spack-packages-version:
-    value: ${{ steps.versions.outputs.packages }}
+  version:
+    value: ${{ steps.jq.outputs.version }}
     description: Version of spack-packages from the `config/versions.json`
-  spack-config-version:
-    value: ${{ steps.versions.outputs.config }}
-    description: Version of spack-config from the `config/versions.json`
 runs:
   using: composite
   steps:
+    # Checkout the callers `config/versions.json`
     - uses: actions/checkout@v4
 
-    # The next steps checkout the repos to confirm that the versions in
-    # versions.json exist in the repositories.
+    # Get the version from the `config/versions.json`
     - name: Setup
-      id: versions
+      id: jq
       shell: bash
       run: |
-        if [[ "${{ contains(inputs.repos-to-check, 'spack-packages') }}" == "true" ]]; then
-          echo "packages=$(jq --compact-output --raw-output '."spack-packages"' ./config/versions.json)" >> $GITHUB_OUTPUT
+        version=$(jq --compact-output --raw-output '."${{ inputs.repo-to-check }}"' ./config/versions.json)
+
+        if [[ "${version}" == "null" ]]; then
+          exit 1
+        else
+          echo "version=${version}" >> $GITHUB_OUTPUT
         fi
 
-        if [[ "${{ contains(inputs.repos-to-check, 'spack-config') }}" == "true" ]]; then
-          echo "config=$(jq --compact-output --raw-output '."spack-config"' ./config/versions.json)" >> $GITHUB_OUTPUT
-        fi
-
-    - name: Spack Packages
-      id: spack-packages
-      if: contains(inputs.repos-to-check, 'spack-packages')
-      continue-on-error: true
+    # Verify that the repository exists at the given ref
+    - name: Version Check
+      id: check
       uses: actions/checkout@v4
       with:
-        repository: access-nri/spack-packages
+        repository: access-nri/${{ inputs.repo-to-check }}
         ref: ${{ steps.versions.outputs.packages }}
-        path: packages
-
-    - name: Spack Config
-      id: spack-config
-      if: contains(inputs.repos-to-check, 'spack-config')
-      continue-on-error: true
-      uses: actions/checkout@v4
-      with:
-        repository: access-nri/spack-config
-        ref: ${{ steps.versions.outputs.config }}
-        path: config
+        path: repo
 
     - name: Failure Notifier
-      if: contains(steps.*.outcome, 'failure')
+      if: failure()
       shell: bash
       run: |
-        if [[ "${{ steps.spack-packages.outcome }}" == "failure" ]]; then
-          echo "::error::spack-packages at the specified ref (${{ steps.versions.outputs.packages }}) doesn't exist."
-        fi
-        if [[ "${{ steps.spack-config.outcome }}" == "failure" ]]; then
-          echo "::error::spack-config at the specified ref (${{ steps.versions.outputs.config }}) doesn't exist."
+        if [[ "${{ steps.jq.outcome }}" == "failure" ]]; then
+          echo "::error::There is no ${{ inputs.repo-to-check }} in `config/versions.json`, or the file doesn't exist."
+        elif [[ "${{ steps.check.outcome }}" == "failure" ]]; then
+          echo "::error::${{ inputs.repo-to-check }} at the specified ref (${{ steps.versions.outputs.packages }}) doesn't exist."
         fi
         exit 1

--- a/README.md
+++ b/README.md
@@ -4,13 +4,15 @@ This repository houses reusable workflows for the building and deployment of ACC
 
 ## Overview
 
-This repository is broken down into two folders: `config` and `.github/workflows`.
+This repository is broken down into two folders: `config` and `.github`.
 
 `config` contains information on the deployment environments that the models deploy to, which is currently just the name of the deployment target. This is used by the aforementioned deployment workflows to gather secrets and configuration details from the associated GitHub Environment.
 
 `.github/workflows` houses validation and reusable deployment workflows that are called by ACCESS-NRI model repositories. Currently, only [ACCESS-NRI/ACCESS-OM2](https://github.com/ACCESS-NRI/access-om2) is supported.
 
-Below is a brief summary of the three pipelines, `deploy-*`, `undeploy-*` and `validate-json`.
+`.github/actions` houses custom actions to do with convenience checks for deployment. More information on these actions can be found in `.github/actions/*/README.md`.
+
+Below is a brief summary of the three pipelines in `.github/workflows`: `deploy-*`, `undeploy-*` and `validate-json`.
 
 ### `deploy-*`
 


### PR DESCRIPTION
In this PR:
* Added a new action `validate-repo-version` that essentially is functionality pulled out from ACCESS-OM2s deployment logic: https://github.com/ACCESS-NRI/ACCESS-OM2/blob/bf1f97ca75b942dd08506b88197cf0feaa1c694d/.github/workflows/ci.yml#L28-L74
* Added updates to `README.md`

References ACCESS-NRI/ACCESS-OM3#2