### PR TITLE
`Prerelease`: Unique Modulefiles 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,6 +173,7 @@ jobs:
       type: prerelease
       ref: ${{ github.head_ref }}
       version: ${{ needs.version-tag.outputs.prerelease }}
+      root-sbd: ${{ inputs.root-sbd }}
     secrets: inherit
 
   notifier:

--- a/.github/workflows/deploy-1-setup.yml
+++ b/.github/workflows/deploy-1-setup.yml
@@ -15,23 +15,43 @@ on:
         type: string
         required: true
         description: The version for the model being deployed
+      root-sbd:
+        type: string
+        required: false
+        # default: The model name, taken from the callers repository name
+        description: The root SBD that is being used as the modulefile name
 
 jobs:
   setup-spack-env:
     name: Setup Spack Environment
     runs-on: ubuntu-latest
     outputs:
+      # Model name inferred from repository name
       model: ${{ steps.get-model.outputs.model }}
+      # Spack env name in form <model>-<version>
       env-name: ${{ steps.get-env-name.outputs.env-name }}
+      # Root SBD that defaults to the model name
+      root-sbd: ${{ steps.set-root-sbd.outputs.root-sbd }}
     steps:
       - name: Get Model
         id: get-model
         # for the cases where the repo name is in uppercase but the package name is lowercase (eg. access-nri/MOM5)
         run: echo "model=$(echo ${{ github.event.repository.name }} | tr [:upper:] [:lower:])" >> $GITHUB_OUTPUT
+
       - name: Set Spack Env Name String
         id: get-env-name
         # replace occurences of '.' with '_' in environment name as spack doesn't support '.'. Ex: 'access-om2-v1.0.0' -> 'access-om2-v1_0_0'.
         run: echo "env-name=$(echo '${{ steps.get-model.outputs.model }}-${{ inputs.version }}' | tr '.' '_')" >> $GITHUB_OUTPUT
+
+      - name: Set Root SBD Default
+        id: set-root-sbd
+        # We set the default here because we don't have access to the modified repo name in the inputs section yet
+        run: |
+          if [[ "${{ inputs.root-sbd }}" == "" ]]; then
+            echo "root-sbd=${{ steps.get-model.outputs.model }}" >> $GITHUB_OUTPUT
+          else
+            echo "root-sbd=${{ inputs.root-sbd }}" >> $GITHUB_OUTPUT
+          fi
 
   setup-deployment-env:
     name: Setup Deployment Environment
@@ -73,4 +93,5 @@ jobs:
       version: ${{ inputs.version }}
       env-name: ${{ needs.setup-spack-env.outputs.env-name }}
       deployment-environment: ${{ matrix.deployment-environment }}
+      root-sbd: ${{ needs.setup-spack-env.outputs.root-sbd }}
     secrets: inherit

--- a/.github/workflows/deploy-2-start.yml
+++ b/.github/workflows/deploy-2-start.yml
@@ -27,7 +27,13 @@ on:
         type: string
         required: true
         description: The GitHub deployment environment name
-
+      root-sbd:
+        type: string
+        required: false
+        default: ${{ inputs.model }}
+        description: The root SBD that is being used as the modulefile name
+env:
+  SPACK_YAML_MODULEFILE_PROJECTION_YQ: .spack.modules.default.tcl.projections.${{ inputs.root-sbd }}
 jobs:
   deploy-to-environment:
     name: Deploy to ${{ inputs.deployment-environment }}
@@ -53,6 +59,14 @@ jobs:
           hosts: |
             ${{ secrets.HOST }}
             ${{ secrets.HOST_DATA }}
+
+      - name: Prerelease Modulefile Name
+        if: inputs.type == 'prerelease'
+        # Modifies the name of the prerelease modulefile to the
+        # `pr<number>-<commit>` style. For example, `access-om3/pr12-2`
+        run: |
+          yq -i '${{ env.SPACK_YAML_MODULEFILE_PROJECTION_YQ }} = {name}/${{ inputs.version }}' spack.yaml
+          echo "::notice::Prerelease accessible as module `${{ inputs.model}}/${{ inputs.version }}`"
 
       - name: Copy spack.yaml
         run: |


### PR DESCRIPTION
An oversight exists where prereleased models would have the same modulefile name as the soon-to-be-released one. For example, `access-om3/2024.02.1`. This would not change between commits in the PR, which would mean a bunch of deployed prereleases would share the same module name above, with only the first being pointed to. 

This PR adds a step into the deployment workflow in which we modify the version of the root SBD that the model is based on, giving it a unique `<model>/pr<number>-<commit>` style, similar to the `spack env` name. For example, `access-om3/pr12-2`.

We've had to propagate the `root-sbd` input from the `ci` step all the way through the deployment workflow, as the `yq` that overwrites the version may have a different name than the actual name of the model. For example, we used to have `access-om3-virtual` being the root SBD of the `access-om3` model, before it was changed. 