### PR TITLE
Log Inputs Before Deployment Review

### DIFF
--- a/.github/workflows/create-deployment-spack.yml
+++ b/.github/workflows/create-deployment-spack.yml
@@ -11,16 +11,6 @@ on:
         type: string
         required: true
         description: A version of spack
-      spack-packages-version:
-        type: string
-        required: true
-        default: main
-        description: A version of ACCESS-NRI/spack-packages
-      spack-config-version:
-        type: string
-        required: true
-        default: main
-        description: A version of ACCESS-NRI/spack-config
       deployment-location:
         type: string
         required: true
@@ -63,8 +53,8 @@ jobs:
           ssh ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }} -i ${{ steps.ssh.outputs.private-key-path }} /bin/bash <<'EOT'
           mkdir ${{ env.ROOT_VERSION_LOCATION }} || exit $?
           git -C ${{ env.ROOT_VERSION_LOCATION }} clone -c feature.manyFiles=true ${{ inputs.spack-git-url }} --branch ${{ inputs.spack-version }} --single-branch --depth=1
-          git -C ${{ env.ROOT_VERSION_LOCATION }} clone https://github.com/ACCESS-NRI/spack-packages.git --branch ${{ inputs.spack-packages-version }}
-          git -C ${{ env.ROOT_VERSION_LOCATION }} clone https://github.com/ACCESS-NRI/spack-config.git --branch ${{ inputs.spack-config-version }}
+          git -C ${{ env.ROOT_VERSION_LOCATION }} clone https://github.com/ACCESS-NRI/spack-packages.git
+          git -C ${{ env.ROOT_VERSION_LOCATION }} clone https://github.com/ACCESS-NRI/spack-config.git
           ln -s -r -v ${{ env.ROOT_VERSION_LOCATION }}/spack-config/v${{ steps.strip.outputs.version-dir }}/${{ vars.DEPLOYMENT_TARGET }}/* ${{ env.ROOT_VERSION_LOCATION }}/spack/etc/spack/
           mkdir ${{ env.ROOT_VERSION_LOCATION }}/release
           EOT

--- a/.github/workflows/create-deployment-spack.yml
+++ b/.github/workflows/create-deployment-spack.yml
@@ -11,6 +11,16 @@ on:
         type: string
         required: true
         description: A version of spack
+      spack-packages-version:
+        type: string
+        required: true
+        default: main
+        description: A version of ACCESS-NRI/spack-packages
+      spack-config-version:
+        type: string
+        required: true
+        default: main
+        description: A version of ACCESS-NRI/spack-config
       deployment-location:
         type: string
         required: true
@@ -23,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - run: |
-          echo '::notice::url = `${{ inputs.spack-git-url }}`, spack version = `${{ inputs.spack-version }}`, deployment location = `${{ inputs.deployment-location }}`'
+          echo '::notice::url = `${{ inputs.spack-git-url }}`, spack version = `${{ inputs.spack-version }}`, spack-packages version = `${{ inputs.spack-packages-version }}`, spack-config version = `${{ inputs.spack-config-version }}`, deployment location = `${{ inputs.deployment-location }}`'
 
   create-spack:
     name: Spack
@@ -53,8 +63,8 @@ jobs:
           ssh ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }} -i ${{ steps.ssh.outputs.private-key-path }} /bin/bash <<'EOT'
           mkdir ${{ env.ROOT_VERSION_LOCATION }} || exit $?
           git -C ${{ env.ROOT_VERSION_LOCATION }} clone -c feature.manyFiles=true ${{ inputs.spack-git-url }} --branch ${{ inputs.spack-version }} --single-branch --depth=1
-          git -C ${{ env.ROOT_VERSION_LOCATION }} clone https://github.com/ACCESS-NRI/spack-packages.git
-          git -C ${{ env.ROOT_VERSION_LOCATION }} clone https://github.com/ACCESS-NRI/spack-config.git
+          git -C ${{ env.ROOT_VERSION_LOCATION }} clone https://github.com/ACCESS-NRI/spack-packages.git --branch ${{ inputs.spack-packages-version }}
+          git -C ${{ env.ROOT_VERSION_LOCATION }} clone https://github.com/ACCESS-NRI/spack-config.git --branch ${{ inputs.spack-config-version }}
           ln -s -r -v ${{ env.ROOT_VERSION_LOCATION }}/spack-config/v${{ steps.strip.outputs.version-dir }}/${{ vars.DEPLOYMENT_TARGET }}/* ${{ env.ROOT_VERSION_LOCATION }}/spack/etc/spack/
           mkdir ${{ env.ROOT_VERSION_LOCATION }}/release
           EOT

--- a/.github/workflows/create-deployment-spack.yml
+++ b/.github/workflows/create-deployment-spack.yml
@@ -28,6 +28,13 @@ on:
           A path in the deployment environment where Spack should be created.
           For example, if it is `opt/spack`, spack will be installed under `opt/spack/<spack-version>/`
 jobs:
+  log-inputs:
+    name: Log Inputs
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          echo '::notice::url = `${{ inputs.spack-git-url }}`, spack version = `${{ inputs.spack-version }}`, deployment location = `${{ inputs.deployment-location }}`'
+
   create-spack:
     name: Spack
     runs-on: ubuntu-latest


### PR DESCRIPTION
In this PR:
* Log the inputs before the deployment sign off job so a deployment reviewer will have more information on whether to approve or not
* Removed the `spack-{packages,config}-version` inputs because we force checkout a particular version of those repositories during deployment, anyway

Closes #53