### PR TITLE
`ACCESS-OM3` `esmf` OOM Parallelism Fix

### DIFF
--- a/.github/workflows/deploy-2-start.yml
+++ b/.github/workflows/deploy-2-start.yml
@@ -78,17 +78,25 @@ jobs:
         # ssh into deployment environment, create and activate the env, install the spack.yaml.
         run: |
           ssh ${{ secrets.USER}}@${{ secrets.HOST }} -i ${{ steps.ssh.outputs.private-key-path }} /bin/bash <<'EOT'
+          # Update spack-packages/config
           git -C ${{ vars.SPACK_PACKAGES_LOCATION }} fetch
           git -C ${{ vars.SPACK_PACKAGES_LOCATION }} checkout --force ${{ steps.versions.outputs.packages }}
           git -C ${{ vars.SPACK_CONFIG_LOCATION }} fetch
           git -C ${{ vars.SPACK_CONFIG_LOCATION }} checkout --force ${{ steps.versions.outputs.config }}
+
+          # Enable spack
           . ${{ vars.SPACK_CONFIG_LOCATION }}/spack-enable.bash
+
+          # Create environment and build model
           spack env create ${{ inputs.env-name }} ${{ vars.SPACK_YAML_LOCATION }}/spack.yaml
           spack env activate ${{ inputs.env-name }}
           spack --debug install --fresh || exit $?
           spack module tcl refresh --delete-tree -y
+
+          # Obtain metadata
           spack find --paths > ${{ vars.SPACK_LOCATION }}/var/spack/environments/${{ inputs.env-name }}/spack.location
           spack find --format '{name}@{version} {prefix}' | jq --raw-input --null-input '[inputs | split(" ") | {(.[0]):(.[1])}] | add' > ${{ vars.SPACK_LOCATION }}/var/spack/environments/${{ inputs.env-name }}/spack.location.json
+
           spack env deactivate
           echo "$(date): Deployed ${{ inputs.model }} ${{ inputs.version }} with spack-packages ${{ steps.versions.outputs.packages }}, spack-config ${{ steps.versions.outputs.config }}" >> ${{ vars.SPACK_RELEASE_LOCATION }}/release.log
           EOT

--- a/.github/workflows/deploy-2-start.yml
+++ b/.github/workflows/deploy-2-start.yml
@@ -90,7 +90,7 @@ jobs:
           # Create environment and build model
           spack env create ${{ inputs.env-name }} ${{ vars.SPACK_YAML_LOCATION }}/spack.yaml
           spack env activate ${{ inputs.env-name }}
-          spack --debug install --fresh --jobs 4 || exit $?
+          spack --debug install --fresh ${{ vars.SPACK_INSTALL_PARALLEL_JOBS }} || exit $?
           spack module tcl refresh --delete-tree -y
 
           # Obtain metadata

--- a/.github/workflows/deploy-2-start.yml
+++ b/.github/workflows/deploy-2-start.yml
@@ -90,7 +90,7 @@ jobs:
           # Create environment and build model
           spack env create ${{ inputs.env-name }} ${{ vars.SPACK_YAML_LOCATION }}/spack.yaml
           spack env activate ${{ inputs.env-name }}
-          spack --debug install --fresh || exit $?
+          spack --debug install --fresh --jobs 4 || exit $?
           spack module tcl refresh --delete-tree -y
 
           # Obtain metadata


### PR DESCRIPTION
The deployment of ACCESS-OM3 is failing because it is being killed by `Gadi`s OOMKiller when installing `esmf`. This PR explicitly turns down the parallelism to `--jobs 4` to reduce the memory used. 

See the failures here: https://github.com/ACCESS-NRI/ACCESS-OM3/pull/5

Closes ACCESS-NRI/ACCESS-OM3#8