### PR TITLE
Remove deletion of Modulefile tree upon deployment

### DIFF
--- a/.github/workflows/deploy-2-start.yml
+++ b/.github/workflows/deploy-2-start.yml
@@ -91,7 +91,7 @@ jobs:
           spack env create ${{ inputs.env-name }} ${{ vars.SPACK_YAML_LOCATION }}/spack.yaml
           spack env activate ${{ inputs.env-name }}
           spack --debug install --fresh ${{ vars.SPACK_INSTALL_PARALLEL_JOBS }} || exit $?
-          spack module tcl refresh --delete-tree -y
+          spack module tcl refresh -y
 
           # Obtain metadata
           spack find --paths > ${{ vars.SPACK_LOCATION }}/var/spack/environments/${{ inputs.env-name }}/spack.location


### PR DESCRIPTION
Despite being in an environment, `--delete-tree` works globally and therefore older deployment modules are removed.

In this PR:
* `deploy-2-start.yml`: Removed `--delete-tree` option

References ACCESS-NRI/ACCESS-OM2#65