### PR TITLE
Model names replace `.` with `p` for `ACCESS-ESM1.5`

### DIFF
--- a/.github/workflows/ci-closed.yml
+++ b/.github/workflows/ci-closed.yml
@@ -34,8 +34,8 @@ jobs:
         id: version
         # For example, `access-om3-pr12-*`
         run: |
-          repo_name_lower=$(echo ${{ github.event.repository.name }} | tr [:upper:] [:lower:])
-          echo "pattern=${repo_name_lower}-pr${{ github.event.pull_request.number }}-*" >> $GITHUB_OUTPUT
+          repo_name_sanitized=$(echo ${{ github.event.repository.name }} | tr [:upper:] [:lower:] | tr '.' 'p' )
+          echo "pattern=${repo_name_sanitized}-pr${{ github.event.pull_request.number }}-*" >> $GITHUB_OUTPUT
 
   undeploy-prereleases:
     name: Undeploy Prereleases Matching ${{ needs.setup.outputs.version-pattern }}

--- a/.github/workflows/deploy-1-setup.yml
+++ b/.github/workflows/deploy-1-setup.yml
@@ -36,7 +36,8 @@ jobs:
       - name: Get Model
         id: get-model
         # for the cases where the repo name is in uppercase but the package name is lowercase (eg. access-nri/MOM5)
-        run: echo "model=$(echo ${{ github.event.repository.name }} | tr [:upper:] [:lower:])" >> $GITHUB_OUTPUT
+        # and also the cases where there is a '.' in the repo name, which isn't spack-compliant (eg. access-nri/ACCESS-ESM1.5)
+        run: echo "model=$(echo ${{ github.event.repository.name }} | tr [:upper:] [:lower:] | tr '.' 'p')" >> $GITHUB_OUTPUT
 
       - name: Set Spack Env Name String
         id: get-env-name


### PR DESCRIPTION
This PR was created because `ACCESS-NRI/ACCESS-ESM1.5` contains a `.`, which is not `spack env` name compliant. Since we get the model name (and `spack env` name) from the repo name, we need to do further santization. 

In this PR:
* Each model name sourced from the repository name now lowercases and replaces `.` with `p`. 

Closes #67 