### PR TITLE
`release_provenance`: Changed requirement to `psycopg2-binary`

### DIFF
--- a/tools/release_provenance/requirements.txt
+++ b/tools/release_provenance/requirements.txt
@@ -1,2 +1,2 @@
 sqlalchemy==1.4.49
-psycopg2==2.9.9
+psycopg2-binary==2.9.9


### PR DESCRIPTION
When running the old `requirements.txt` on my local computer, I get an error, even though it works on the runner. 
When I convert to the binary version, it works on the local computer, so I'm updating the `requirements.txt`. 