### PR TITLE
create-deployment-spack.yml: Added restricted folder and set ACLs

### DIFF
--- a/.github/workflows/create-deployment-spack.yml
+++ b/.github/workflows/create-deployment-spack.yml
@@ -67,4 +67,10 @@ jobs:
           git -C ${{ env.ROOT_VERSION_LOCATION }} clone https://github.com/ACCESS-NRI/spack-config.git --branch ${{ inputs.spack-config-version }}
           ln -s -r -v ${{ env.ROOT_VERSION_LOCATION }}/spack-config/v${{ steps.strip.outputs.version-dir }}/${{ vars.DEPLOYMENT_TARGET }}/* ${{ env.ROOT_VERSION_LOCATION }}/spack/etc/spack/
           mkdir ${{ env.ROOT_VERSION_LOCATION }}/release
+
+          # Create restricted folders
+          mkdir -p ${{ env.ROOT_VERSION_LOCATION }}/restricted/ukmo/release
+          mkdir -p ${{ env.ROOT_VERSION_LOCATION }}/restricted/ukmo/source_cache
+          # Only accessible to people in vk83_w, ki32_mosrs
+          setfacl -m "g:vk83_w:r-X,g:ki32_mosrs:r-X,g:vk83:---,other::---,d:g:vk83_w:r-X,d:g:ki32_mosrs:r-X,d:g:vk83:---,d:other::---" restricted
           EOT

--- a/.github/workflows/create-deployment-spack.yml
+++ b/.github/workflows/create-deployment-spack.yml
@@ -71,6 +71,9 @@ jobs:
           # Create restricted folders
           mkdir -p ${{ env.ROOT_VERSION_LOCATION }}/restricted/ukmo/release
           mkdir -p ${{ env.ROOT_VERSION_LOCATION }}/restricted/ukmo/source_cache
-          # Only accessible to people in vk83_w, ki32_mosrs
-          setfacl -m "g:vk83_w:r-X,g:ki32_mosrs:r-X,g:vk83:---,other::---,d:g:vk83_w:r-X,d:g:ki32_mosrs:r-X,d:g:vk83:---,d:other::---" restricted
+          mkdir -p $tempdir/$user/restricted/spack-stage
+
+          setfacl --recursive -m \
+            "g:vk83_w:r-X,g:ki32_mosrs:r-X,g:vk83:---,other::---,d:g:vk83_w:r-X,d:g:ki32_mosrs:r-X,d:g:vk83:---,d:other::---" \
+            ${{ env.ROOT_VERSION_LOCATION }}/restricted $tempdir/$user/restricted
           EOT


### PR DESCRIPTION
In this PR:
* Create a ACL-restricted `restricted/ukmo` folder with `source_cache` and `release` directories within it
* Created a ACL-restricted `$tempdir/$user/restricted` directory for the `build_stage`

Closes #74 