### PR TITLE
Add modulerc and README

### DIFF
--- a/tools/modules/README.md
+++ b/tools/modules/README.md
@@ -1,0 +1,14 @@
+The modulerc file was created to address this issue:
+
+https://github.com/ACCESS-NRI/ACCESS-OM2/issues/48
+
+It is not automatically deployed, but placed in `/g/data/vk83/modules/access-models/.modulerc`. Because it affects the access to all deployed models the code was placed here for visibility.
+
+This allows `module use` a single directory, and automatically load all spack generated module files which are in spack version and build architecture specific sub-directories:
+
+```
+$ module use /g/data/vk83/modules/access-models/
+$ module avail access
+----------------- /g/data/vk83/modules/access-models ---------------------
+access-om2-bgc/2024.03.0  access-om2/2023.11.23  access-om2/2024.03.0  
+``

--- a/tools/modules/modulerc
+++ b/tools/modules/modulerc
@@ -1,0 +1,18 @@
+#%Module
+
+set module_directories [glob -type d /g/data/vk83/apps/spack/*/release/modules/linux-rocky8-x86_64/ ]
+
+# Loop over all release module directories
+foreach module_directory $module_directories {
+
+    # Find all the module files
+    set modfiles [split [exec find $module_directory -type f -not -name ".*"] \n]
+    
+    # Create a virtual module for each one
+    foreach modfile $modfiles {
+        set pathElements [file split $modfile]
+        set module_version [file join {*}[lrange $pathElements end-1 end]]
+        # puts stderr "module-virtual $module_version $modfile"
+        module-virtual $module_version $modfile
+    }
+}


### PR DESCRIPTION
The modulerc file was created to address this issue:

https://github.com/ACCESS-NRI/ACCESS-OM2/issues/48

It is not automatically deployed, but placed in `/g/data/vk83/modules/access-models/.modulerc`. Because it affects the access to all deployed models the code was placed here for visibility.

This allows `module use` a single directory, and automatically load all spack generated module files which are in spack version and build architecture specific sub-directories:

```
$ module use /g/data/vk83/modules/access-models/
$ module avail access
----------------- /g/data/vk83/modules/access-models ---------------------
access-om2-bgc/2024.03.0  access-om2/2023.11.23  access-om2/2024.03.0  
``