### PR TITLE
Updated `build_stage` directory

### DIFF
--- a/.github/workflows/create-deployment-spack.yml
+++ b/.github/workflows/create-deployment-spack.yml
@@ -71,9 +71,9 @@ jobs:
           # Create restricted folders
           mkdir -p ${{ env.ROOT_VERSION_LOCATION }}/restricted/ukmo/release
           mkdir -p ${{ env.ROOT_VERSION_LOCATION }}/restricted/ukmo/source_cache
-          mkdir -p $tempdir/$user/restricted/spack-stage
+          mkdir -p $TMPDIR/restricted/spack-stage
 
           setfacl --recursive -m \
             "g:vk83_w:r-X,g:ki32_mosrs:r-X,g:vk83:---,other::---,d:g:vk83_w:r-X,d:g:ki32_mosrs:r-X,d:g:vk83:---,d:other::---" \
-            ${{ env.ROOT_VERSION_LOCATION }}/restricted $tempdir/$user/restricted
+            ${{ env.ROOT_VERSION_LOCATION }}/restricted $TMPDIR/restricted
           EOT


### PR DESCRIPTION
See failed run: https://github.com/ACCESS-NRI/build-cd/actions/runs/9120599869/job/25078248668#step:4:153

I substituted the values in the `spack config get config` for `build_stage`, which were actually spack-specific not global environment variables. See https://spack.readthedocs.io/en/latest/config_yaml.html

In this PR:
* Replaced `$user` with `$USER` and `$tempdir` with it's inferred `$TMPDIR`. 

Comes after this PR: https://github.com/ACCESS-NRI/build-cd/issues/74
