### PR TITLE
`spack.yaml` existence check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,6 +96,13 @@ jobs:
         id: version
         run: |
           git checkout ${{ github.base_ref }}
+
+          if [ ! -f spack.yaml ]; then
+            echo "::notice::There is no previous version of the spack.yaml to check, continuing..."
+            git checkout ${{ github.head_ref }}
+            exit 0
+          fi
+
           base_version=$(yq e '${{ env.SPACK_YAML_MODEL_YQ }}' spack.yaml)
 
           git checkout ${{ github.head_ref }}


### PR DESCRIPTION
See failed run: https://github.com/ACCESS-NRI/ACCESS-ESM1.5/actions/runs/9183697365/job/25254826993?pr=5#step:4:20 - this was because it attempts to check for a modification to the spack.yaml SBD version, but the spack.yaml hadn't existed on the base branch yet.

In this PR:
* ci.yml: Add check that continues the CI if there is no spack.yaml to check against on the base branch