### PR TITLE
Non-`@git.` Version Fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,6 +128,7 @@ jobs:
         # this step checks that the versions of the packages themselves match with the
         #  names of the modules. For example, access-om3@git.2023.12.12 matches with the
         #  modulefile access-om3/2023.12.12 (specifically, the version strings match)
+        # TODO: Move this into the `scripts` directory - it's getting unweildly.
         run: |
           FAILED='false'
           DEPS=$(yq ".spack.modules.default.tcl.include | join(\" \")" spack.yaml)
@@ -138,13 +139,15 @@ jobs:
             if [[ "$DEP" == "${{ needs.defaults.outputs.root-sbd }}" ]]; then
               DEP_VER=$(yq '.spack.specs[0] | split("@git.") | .[1]' spack.yaml)
             else
-              DEP_VER=$(yq ".spack.packages.\"$DEP\".require[0] | split(\"@git.\") | .[1]" spack.yaml)
+              # Capture the section after '@git.' or '@' (if it's not a git-attributed version) for a given dependency.
+              # Ex. '@git.2024.02.11' -> '2024.02.11', '@access-esm1.5' -> 'access-esm1.5'
+              DEP_VER=$(yq ".spack.packages.\"$DEP\".require[0] | match(\"^@(?:git.)?(.*)\").captures[0].string" spack.yaml)
             fi
 
             MODULE_VER=$(yq ".spack.modules.default.tcl.projections.\"$DEP\" | split(\"/\") | .[1]" spack.yaml)
 
             if [[ "$DEP_VER" != "$MODULE_VER" ]]; then
-              echo "::error::Version of dependency and projection do not match ($DEP_VER != $MODULE_VER)"
+              echo "::error::$DEP: Version of dependency and projection do not match ($DEP_VER != $MODULE_VER)"
               FAILED='true'
             fi
           done


### PR DESCRIPTION
More detail in the linked issue, but essentially we are going from a string-based split in `yq` to a regex-based match. This is because we want to split on two possible conditions - we want the thing after `@git.` or just `@` if there is no following `git.`. 

Explanatory note: `match(...)` in `yq` returns a kind of yucky bit of yaml that we have to further interrogate to get the actual captured string. For example:
```yaml
string: '@access-esm1.5'
offset: 0
length: 14
captures:
  - string: access-esm1.5
    offset: 1
    length: 13
```
Hence the `captures[0].string` bit. 

Further explanatory note: we have to quote the `"` because functions only accept `"..."` arguments, not `'...'`. But we have to use `"..."` to quote the entire `yq` filter string because we want to interpret the `$DEP` variable. And we have to do that because `yq` doesn't have the nice syntax for variable substitution like `jq` does (`jq --arg name $var ...` is much better).  

In this PR:
* ci.ymls `check-spack-yaml` job: Updated splitting logic, added better error logs, added TODO

Closes #82 