### PR TITLE
Update schema version for `spack.yaml` checking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,7 +88,7 @@ jobs:
       - name: Validate ACCESS-NRI spack.yaml Restrictions
         uses: access-nri/schema/.github/actions/validate-with-schema@main
         with:
-          schema-version: 1-0-0
+          schema-version: 1-0-1
           schema-location: au.org.access-nri/model/spack/environment/deployment
           data-location: ./spack.yaml
 


### PR DESCRIPTION
In this PR:
* ci.yml: Now uses new spack.yaml schema `1-0-1` from ACCESS-NRI/schema#30