### PR TITLE
Deploy to a `spack` specified by `.spack` in `config/versions.json`

### DIFF
--- a/.github/actions/get-deploy-paths/README.md
+++ b/.github/actions/get-deploy-paths/README.md
@@ -1,0 +1,40 @@
+# Get Deploy Paths Action
+
+This action constructs paths relevant to a deployment of `spack`.
+
+## Inputs
+
+| Name | Type | Description | Required | Default | Example |
+| ---- | ---- | ----------- | -------- | ------- | ------- |
+| `spack-installs-root-path` | `string` | Path to a directory within which all versions of spack are installed | `true` | N/A | `"/some/dir/apps/spack"` |
+| `spack-version` | `string` | Version of spack deployed. Used to construct a specific spack installation path, in conjunction with `spack-installs-root-path`. | `true` | N/A | `"0.21"` |
+| `deployment-environment` | `string` | Name of the GitHub deployment target environment | `true` | N/A | `"Gadi Prerelease"` |
+
+## Outputs
+
+| Name | Type | Description | Example |
+| ---- | ---- | ----------- | ------- |
+| `root` | `string` | Path to the root of a specific deployment of `spack`. This path contains `spack-{packages,config}` repositories as well. | `"/some/dir/apps/spack/0.21"` |
+| `spack` | `string` | Path to a specific installation of `spack`. | `"/some/dir/apps/spack/0.21/spack"` |
+| `spack-config` | `string` | Path to the ACCESS-NRI/spack-config repository associated with the install of spack. | `"/some/dir/apps/spack/0.21/spack-config"` |
+| `spack-packages` | `string` | Path to the ACCESS-NRI/spack-packages repository associated with the install of spack. | `"/some/dir/apps/spack/0.21/spack-packages"` |
+
+## Example
+
+```yaml
+# ...
+jobs:
+  get-paths:
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.deployment-environment }}
+    steps:
+      - name: Get Deployment Paths
+        id: paths
+        uses: access-nri/build-cd/.github/actions/get-deploy-paths@main
+        with:
+          spack-installs-root-path: ${{ vars.SPACK_INSTALLS_ROOT_PATH }}
+          spack-version: "0.21"
+          deployment-environment: ${{ inputs.deployment-environment }}
+
+      - run: echo 'Spack is installed in `${{ steps.paths.outputs.spack }}` and spack-packages is installed in `${{ steps.paths.outputs.spack-packages }}`'
+```

--- a/.github/actions/get-deploy-paths/action.yml
+++ b/.github/actions/get-deploy-paths/action.yml
@@ -1,0 +1,52 @@
+name: Get Deployment Paths
+description: Action that returns important paths for a spack install on a deployment target.
+author: Tommy Gatti
+inputs:
+  spack-installs-root-path:
+    type: string
+    required: true
+    # For example, `some/apps/spack` is the root, `some/apps/spack/0.21/` is a specific spack deployment, `some/apps/spack/0.21/spack` is a specific spack install.
+    description: Path to a directory within which all versions of spack are installed
+  spack-version:
+    type: string
+    required: true
+    description: |
+      Version of spack deployed.
+      Used to construct a specific spack installation path, in conjunction with `spack-installs-root-path`.
+  deployment-environment:
+    type: string
+    required: true
+    # Used for logging, essentially
+    description: Name of the GitHub deployment target environment
+outputs:
+  root:
+    description: |
+      Path to the root of a specific deployment of `spack`.
+      This path contains `spack-{packages,config}` repositories as well.
+    value: ${{ steps.path.outputs.root }}
+  spack:
+    description: Path to a specific installation of `spack`.
+    value: ${{ steps.path.outputs.spack }}
+  spack-config:
+    description: Path to the ACCESS-NRI/spack-config repository associated with the install of spack.
+    value: ${{ steps.path.outputs.spack-config }}
+  spack-packages:
+    description: Path to the ACCESS-NRI/spack-packages repository associated with the install of spack.
+    value: ${{ steps.path.outputs.spack-config }}
+runs:
+  using: composite
+  steps:
+    - name: Get ${{ inputs.deployment-environment }} Remote Paths
+      id: path
+      shell: bash
+      run: |
+        if [ -z "${{ inputs.spack-installs-root-path }}" ]; then
+          echo '::error::`spack-installs-root-path` does not exist in `${{ github.repository }}`s `${{ inputs.deployment-environment }}` environment. Check Environment vars.'
+          exit 1
+        fi
+
+        root=${{ inputs.spack-installs-root-path }}/${{ inputs.spack-version }}
+        echo "root=$root" >> $GITHUB_OUTPUT
+        echo "spack=$root/spack" >> $GITHUB_OUTPUT
+        echo "spack-config=$root/spack-config" >> $GITHUB_OUTPUT
+        echo "spack-packages=$root/spack-packages" >> $GITHUB_OUTPUT

--- a/.github/workflows/deploy-2-start.yml
+++ b/.github/workflows/deploy-2-start.yml
@@ -59,17 +59,11 @@ jobs:
 
       - name: Get ${{ inputs.deployment-environment }} Remote Paths
         id: path
-        run: |
-          if [ -z "${{ vars.SPACK_INSTALLS_ROOT_LOCATION }}" ]; then
-            echo '::error::`vars.SPACK_INSTALLS_ROOT_LOCATION` does not exist in `${{ github.repository }}`s `${{ inputs.deployment-environment }}` environment'
-            exit 1
-          fi
-
-          root=${{ vars.SPACK_INSTALLS_ROOT_LOCATION }}/${{ steps.versions.outputs.spack }}
-          echo "root=$root" >> $GITHUB_OUTPUT
-          echo "spack=$root/spack" >> $GITHUB_OUTPUT
-          echo "spack-packages=$root/spack-packages" >> $GITHUB_OUTPUT
-          echo "spack-config=$root/spack-config" >> $GITHUB_OUTPUT
+        uses: access-nri/build-cd/.github/actions/get-deploy-paths@main
+        with:
+          spack-installs-root-path: ${{ vars.SPACK_INSTALLS_ROOT_LOCATION }}
+          spack-version: ${{ steps.versions.outputs.spack }}
+          deployment-environment: ${{ inputs.deployment-environment }}
 
       - name: Setup SSH
         id: ssh

--- a/.github/workflows/deploy-2-start.yml
+++ b/.github/workflows/deploy-2-start.yml
@@ -89,7 +89,7 @@ jobs:
         run: |
           rsync -e 'ssh -i ${{ steps.ssh.outputs.private-key-path }}' \
             spack.yaml \
-            ${{ secrets.USER }}@${{ secrets.HOST_DATA }}:${{ vars.SPACK_YAML_LOCATION }}
+            ${{ secrets.USER }}@${{ secrets.HOST_DATA }}:${{ vars.SPACK_YAML_LOCATION }}/${{ inputs.model }}.spack.yaml
 
       - name: Deploy to ${{ inputs.deployment-environment }}
         # ssh into deployment environment, create and activate the env, install the spack.yaml.
@@ -111,7 +111,7 @@ jobs:
           . ${{ steps.path.outputs.spack-config }}/spack-enable.bash
 
           # Create environment and build model
-          spack env create ${{ inputs.env-name }} ${{ vars.SPACK_YAML_LOCATION }}/spack.yaml
+          spack env create ${{ inputs.env-name }} ${{ vars.SPACK_YAML_LOCATION }}/${{ inputs.model }}.spack.yaml
           spack env activate ${{ inputs.env-name }}
           spack --debug install --fresh ${{ vars.SPACK_INSTALL_PARALLEL_JOBS }} || exit $?
           spack module tcl refresh -y

--- a/.github/workflows/deploy-2-start.yml
+++ b/.github/workflows/deploy-2-start.yml
@@ -60,6 +60,11 @@ jobs:
       - name: Get ${{ inputs.deployment-environment }} Remote Paths
         id: path
         run: |
+          if [ -z "${{ vars.SPACK_INSTALLS_ROOT_LOCATION }}" ]; then
+            echo '::error::`vars.SPACK_INSTALLS_ROOT_LOCATION` does not exist in `${{ github.repository }}`s `${{ inputs.deployment-environment }}` environment'
+            exit 1
+          fi
+
           root=${{ vars.SPACK_INSTALLS_ROOT_LOCATION }}/${{ steps.versions.outputs.spack }}
           echo "root=$root" >> $GITHUB_OUTPUT
           echo "spack=$root/spack" >> $GITHUB_OUTPUT
@@ -96,6 +101,12 @@ jobs:
         # ssh into deployment environment, create and activate the env, install the spack.yaml.
         run: |
           ssh ${{ secrets.USER}}@${{ secrets.HOST }} -i ${{ steps.ssh.outputs.private-key-path }} /bin/bash <<'EOT'
+          # Check that a suitable deployment location exists
+          if [ ! -d "${{ steps.path.outputs.root }}" ]; then
+            echo '::error::A deployment of spack does not exist in `${{ steps.path.outputs.root }}` for `${{ inputs.deployment-environment }}`'
+            exit 1
+          fi
+
           # Update spack-packages/config
           git -C ${{ steps.path.outputs.spack-packages }} fetch
           git -C ${{ steps.path.outputs.spack-packages }} checkout --force ${{ steps.versions.outputs.packages }}

--- a/.github/workflows/deploy-2-start.yml
+++ b/.github/workflows/deploy-2-start.yml
@@ -50,11 +50,21 @@ jobs:
         with:
           ref: ${{ inputs.ref }}
 
-      - name: Get packages and config versions
+      - name: Get Versions From config/versions.json
         id: versions
         run: |
+          echo "spack=$(jq --compact-output --raw-output '.spack' ./config/versions.json)" >> $GITHUB_OUTPUT
           echo "packages=$(jq --compact-output --raw-output '."spack-packages"' ./config/versions.json)" >> $GITHUB_OUTPUT
           echo "config=$(jq --compact-output --raw-output '."spack-config"' ./config/versions.json)" >> $GITHUB_OUTPUT
+
+      - name: Get ${{ inputs.deployment-environment }} Remote Paths
+        id: path
+        run: |
+          root=${{ vars.SPACK_INSTALLS_ROOT_LOCATION }}/${{ steps.versions.outputs.spack }}
+          echo "root=$root" >> $GITHUB_OUTPUT
+          echo "spack=$root/spack" >> $GITHUB_OUTPUT
+          echo "spack-packages=$root/spack-packages" >> $GITHUB_OUTPUT
+          echo "spack-config=$root/spack-config" >> $GITHUB_OUTPUT
 
       - name: Setup SSH
         id: ssh
@@ -74,7 +84,7 @@ jobs:
         run: |
           yq -i '${{ env.SPACK_YAML_SPEC_YQ }} = (${{ env.SPACK_YAML_SPEC_YQ }} | split("@").[0])' spack.yaml
           yq -i '${{ env.SPACK_YAML_MODULEFILE_PROJECTION_YQ }} = "{name}/${{ inputs.version }}"' spack.yaml
-          echo "::notice::Prerelease accessible as module `${{ inputs.model}}/${{ inputs.version }}`"
+          echo '::notice::Prerelease accessible as module `${{ inputs.model}}/${{ inputs.version }}`'
 
       - name: Copy spack.yaml
         run: |
@@ -87,13 +97,13 @@ jobs:
         run: |
           ssh ${{ secrets.USER}}@${{ secrets.HOST }} -i ${{ steps.ssh.outputs.private-key-path }} /bin/bash <<'EOT'
           # Update spack-packages/config
-          git -C ${{ vars.SPACK_PACKAGES_LOCATION }} fetch
-          git -C ${{ vars.SPACK_PACKAGES_LOCATION }} checkout --force ${{ steps.versions.outputs.packages }}
-          git -C ${{ vars.SPACK_CONFIG_LOCATION }} fetch
-          git -C ${{ vars.SPACK_CONFIG_LOCATION }} checkout --force ${{ steps.versions.outputs.config }}
+          git -C ${{ steps.path.outputs.spack-packages }} fetch
+          git -C ${{ steps.path.outputs.spack-packages }} checkout --force ${{ steps.versions.outputs.packages }}
+          git -C ${{ steps.path.outputs.spack-config }} fetch
+          git -C ${{ steps.path.outputs.spack-config }} checkout --force ${{ steps.versions.outputs.config }}
 
           # Enable spack
-          . ${{ vars.SPACK_CONFIG_LOCATION }}/spack-enable.bash
+          . ${{ steps.path.outputs.spack-config }}/spack-enable.bash
 
           # Create environment and build model
           spack env create ${{ inputs.env-name }} ${{ vars.SPACK_YAML_LOCATION }}/spack.yaml
@@ -102,18 +112,18 @@ jobs:
           spack module tcl refresh -y
 
           # Obtain metadata
-          spack find --paths > ${{ vars.SPACK_LOCATION }}/var/spack/environments/${{ inputs.env-name }}/spack.location
-          spack find --format '{hash} {prefix}' | jq --raw-input --null-input '[inputs | split(" ") | {(.[0]): (.[1])}] | add' > ${{ vars.SPACK_LOCATION }}/var/spack/environments/${{ inputs.env-name }}/spack.location.json
+          spack find --paths > ${{ steps.path.outputs.spack }}/var/spack/environments/${{ inputs.env-name }}/spack.location
+          spack find --format '{hash} {prefix}' | jq --raw-input --null-input '[inputs | split(" ") | {(.[0]): (.[1])}] | add' > ${{ steps.path.outputs.spack }}/var/spack/environments/${{ inputs.env-name }}/spack.location.json
 
           spack env deactivate
-          echo "$(date): Deployed ${{ inputs.model }} ${{ inputs.version }} with spack-packages ${{ steps.versions.outputs.packages }}, spack-config ${{ steps.versions.outputs.config }}" >> ${{ vars.SPACK_RELEASE_LOCATION }}/release.log
+          echo "$(date): Deployed ${{ inputs.model }} ${{ inputs.version }} with spack-packages ${{ steps.versions.outputs.packages }}, spack-config ${{ steps.versions.outputs.config }}" >> ${{ steps.path.outputs.root }}/release.log
           EOT
 
       # Release
       - name: Get Release Metadata
         run: |
           rsync -e 'ssh -i ${{ steps.ssh.outputs.private-key-path }}' \
-            '${{ secrets.USER}}@${{ secrets.HOST_DATA }}:${{ vars.SPACK_LOCATION }}/var/spack/environments/${{ inputs.env-name }}/spack.*' \
+            '${{ secrets.USER}}@${{ secrets.HOST_DATA }}:${{ steps.path.outputs.spack }}/var/spack/environments/${{ inputs.env-name }}/spack.*' \
             ./${{ inputs.env-name }}
 
       - name: Upload Metadata Artifact

--- a/.github/workflows/undeploy-2-start.yml
+++ b/.github/workflows/undeploy-2-start.yml
@@ -26,16 +26,11 @@ jobs:
 
       - name: Get ${{ inputs.deployment-environment }} Remote Paths
         id: path
-        run: |
-          if [ -z "${{ vars.SPACK_INSTALLS_ROOT_LOCATION }}" ]; then
-            echo '::error::`vars.SPACK_INSTALLS_ROOT_LOCATION` does not exist in `${{ github.repository }}`s `${{ inputs.deployment-environment }}` environment'
-            exit 1
-          fi
-
-          root=${{ vars.SPACK_INSTALLS_ROOT_LOCATION }}/${{ steps.versions.outputs.spack }}
-          echo "root=$root" >> $GITHUB_OUTPUT
-          echo "spack=$root/spack" >> $GITHUB_OUTPUT
-          echo "spack-config=$root/spack-config" >> $GITHUB_OUTPUT
+        uses: access-nri/build-cd/.github/actions/get-deploy-paths@main
+        with:
+          spack-installs-root-path: ${{ vars.SPACK_INSTALLS_ROOT_LOCATION }}
+          spack-version: ${{ steps.versions.outputs.spack }}
+          deployment-environment: ${{ inputs.deployment-environment }}
 
       - name: Setup SSH
         id: ssh

--- a/.github/workflows/undeploy-2-start.yml
+++ b/.github/workflows/undeploy-2-start.yml
@@ -16,6 +16,27 @@ jobs:
     runs-on: ubuntu-latest
     environment: ${{ inputs.deployment-environment }}
     steps:
+      - uses: actions/checkout@v4
+
+      - name: Get Versions From config/versions.json
+        id: versions
+        run: |
+          echo "spack=$(jq --compact-output --raw-output '.spack' ./config/versions.json)" >> $GITHUB_OUTPUT
+          echo "config=$(jq --compact-output --raw-output '."spack-config"' ./config/versions.json)" >> $GITHUB_OUTPUT
+
+      - name: Get ${{ inputs.deployment-environment }} Remote Paths
+        id: path
+        run: |
+          if [ -z "${{ vars.SPACK_INSTALLS_ROOT_LOCATION }}" ]; then
+            echo '::error::`vars.SPACK_INSTALLS_ROOT_LOCATION` does not exist in `${{ github.repository }}`s `${{ inputs.deployment-environment }}` environment'
+            exit 1
+          fi
+
+          root=${{ vars.SPACK_INSTALLS_ROOT_LOCATION }}/${{ steps.versions.outputs.spack }}
+          echo "root=$root" >> $GITHUB_OUTPUT
+          echo "spack=$root/spack" >> $GITHUB_OUTPUT
+          echo "spack-config=$root/spack-config" >> $GITHUB_OUTPUT
+
       - name: Setup SSH
         id: ssh
         uses: access-nri/actions/.github/actions/setup-ssh@main
@@ -30,8 +51,8 @@ jobs:
         id: undeploy
         run: |
           ssh ${{ secrets.USER}}@${{ secrets.HOST }} -i ${{ steps.ssh.outputs.private-key-path }} /bin/bash <<'EOT'
-          . ${{ vars.SPACK_CONFIG_LOCATION }}/spack-enable.bash
-          envs=$(find ${{ vars.SPACK_LOCATION }}/var/spack/environments -type d -name '${{ inputs.env-name }}' -printf '%f ')
+          . ${{ steps.path.outputs.spack-config }}/spack-enable.bash
+          envs=$(find ${{ steps.path.outputs.spack }}/var/spack/environments -type d -name '${{ inputs.env-name }}' -printf '%f ')
 
           for env in $envs; do
             spack env activate $env
@@ -46,7 +67,7 @@ jobs:
         if: always()
         run: |
           if [[ "${{ steps.undeploy.outcome }}" == "success" ]]; then
-            echo "::notice::Deployment ${{ inputs.env-name }} was successfully removed from ${{ inputs.deployment-environment }}, found at ${{ vars.SPACK_LOCATION }}"
+            echo "::notice::Deployment ${{ inputs.env-name }} was successfully removed from ${{ inputs.deployment-environment }}, found at ${{ steps.path.outputs.spack }}"
           else
-            echo "::error::Deployment ${{ inputs.env-name }} couldn't be removed from ${{ inputs.deployment-environment}}, found at ${{ vars.SPACK_LOCATION }}. Please check manually."
+            echo "::error::Deployment ${{ inputs.env-name }} couldn't be removed from ${{ inputs.deployment-environment}}, found at ${{ steps.path.outputs.spack }}. Please check manually."
           fi


### PR DESCRIPTION
Instead of having to create `vars` for each full `spack`, `spack-packages` and `spack-config` path on the deployment target, have a single `vars.SPACK_INSTALLS_ROOT_LOCATION` and piecewise construct the above paths using the `.spack` version field in `config/versions.json`. This also means that we don't have to update the above vars when we want to deploy to a different version of spack, and users will have the freedom to pick a deployed version of spack to pre/release to. 

For example, for `spack-packages` version, the full path change from a `vars.SPACK_PACKAGES_LOCATION` to `vars.SPACK_INSTALLS_ROOT_LOCATION/<spack version>/spack-packages`.

 - [ ] Will need to update `vars.SPACK_INSTALLS_ROOT_LOCATION` in our existing `Gadi [Prerelease]` in `ACCESS-OM2`, `ACCESS-OM2-BGC`, `ACCESS-OM3`, `ACCESS-ESM1.5` and then remove `vars.SPACK_*_LOCATION` when it's merged. 

In this PR:
* `deploy-2-start.yml`: Deploy paths created in step using .spack version

Closes #93 