### PR TITLE
Can't create a release due to erroneous `./` in artifact upload location

### DIFF
--- a/.github/workflows/deploy-2-start.yml
+++ b/.github/workflows/deploy-2-start.yml
@@ -148,10 +148,10 @@ jobs:
           generate_release_notes: true
           fail_on_unmatched_files: true
           files: |
-            ./${{ env.METADATA_PATH }}/spack.yaml
-            ./${{ env.METADATA_PATH }}/spack.lock
-            ./${{ env.METADATA_PATH }}/spack.location
-            ./${{ env.METADATA_PATH }}/spack.location.json
+            ${{ env.METADATA_PATH }}/spack.yaml
+            ${{ env.METADATA_PATH }}/spack.lock
+            ${{ env.METADATA_PATH }}/spack.location
+            ${{ env.METADATA_PATH }}/spack.location.json
 
       - name: Release Metadata
         id: metadata


### PR DESCRIPTION
See failed run: https://github.com/ACCESS-NRI/ACCESS-OM2/actions/runs/9673293440/job/26688521873#step:4:19
This is due to creating a release that searches for files in `./${{ env.METADATA_PATH }}/*`. However, `env.METADATA_PATH` is set to `/opt/metadata` which means that the final path is invalid: `.//opt/metadata/*`. 

In this PR:
* deploy-2-start.yml: Removed prepended current directory for Release files