### PR TITLE
Remove `.path` section from `spack.location.json` `jq`

### DIFF
--- a/scripts/generate-build-metadata.bash
+++ b/scripts/generate-build-metadata.bash
@@ -62,7 +62,7 @@ for pkg in "${packages[@]}"; do
 
   install_path=$(jq --raw-output \
     --arg pkg_hash "$pkg_hash" \
-    'to_entries[] | select(.key == $pkg_hash) | .value.path' \
+    'to_entries[] | select(.key == $pkg_hash) | .value' \
     "$json_dir/spack.location.json"
   )
 


### PR DESCRIPTION
See failed deployment: https://github.com/ACCESS-NRI/ACCESS-OM2/actions/runs/9675328146/job/26695640367#step:6:76

This was an artifact from an old schema for `spack.location.json` when it was something like: 
```json
{
  "wugqmoa7ikae6q7cwi6wuuqocynx6eik": {
    "path": "/g/data/vk83/apps/spack/0.21/release/linux-rocky8-x86_64/intel-2021.10.0/access-om2-git.2024.03.1_2024.03.1-wugqmoa7ikae6q7cwi6wuuqocynx6eik"
  }
}
```
rather than the current:
```json
{
  "wugqmoa7ikae6q7cwi6wuuqocynx6eik": "/g/data/vk83/apps/spack/0.21/release/linux-rocky8-x86_64/intel-2021.10.0/access-om2-git.2024.03.1_2024.03.1-wugqmoa7ikae6q7cwi6wuuqocynx6eik"
}
```

This has been tested locally using the artifact outputs from the above failed deployment. 

In this PR:
* generate-build-metadata.bash: removed '.path' section from install path jq