### PR TITLE
Removed `@git.VERSION` from Prerelease deployment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,7 +199,7 @@ jobs:
     with:
       type: prerelease
       ref: ${{ github.head_ref }}
-      version: ${{ needs.version-tag.outputs.prerelease }}
+      version: ${{ needs.version.outputs.prerelease }}
       root-sbd: ${{ needs.defaults.outputs.root-sbd }}
     secrets: inherit
 
@@ -216,21 +216,21 @@ jobs:
       - uses: access-nri/actions/.github/actions/pr-comment@main
         with:
           comment: |
-            :rocket: Deploying ${{ inputs.model }} `${{ needs.version-tag.outputs.release }}` as prerelease `${{ needs.version-tag.outputs.prerelease }}`
+            :rocket: Deploying ${{ inputs.model }} `${{ needs.version.outputs.release }}` as prerelease `${{ needs.version.outputs.prerelease }}`
             <details>
             <summary>Details and usage instructions</summary>
 
             This `${{ inputs.model }}` model will be deployed as:
-            * `${{ needs.version-tag.outputs.release }}` as a Release (when merged).
-            * `${{ needs.version-tag.outputs.prerelease }}` as a Prerelease (during this PR).
+            * `${{ needs.version.outputs.release }}` as a Release (when merged).
+            * `${{ needs.version.outputs.prerelease }}` as a Prerelease (during this PR).
 
             This Prerelease is accessible on Gadi using:
             ```bash
             module use /g/data/vk83/prerelease/modules/access-models/
-            module load ${{ needs.defaults.outputs.root-sbd }}/${{ needs.version-tag.outputs.prerelease }}
+            module load ${{ needs.defaults.outputs.root-sbd }}/${{ needs.version.outputs.prerelease }}
             ```
             where the binaries shall be on your `$PATH`.
-            This Prerelease is also accessible on Gadi via `/g/data/vk83/prerelease/apps/spack/0.21/spack` in the `${{ needs.defaults.outputs.root-sbd }}-${{ needs.version-tag.outputs.prerelease }}` environment.
+            This Prerelease is also accessible on Gadi via `/g/data/vk83/prerelease/apps/spack/0.21/spack` in the `${{ needs.defaults.outputs.root-sbd }}-${{ needs.version.outputs.prerelease }}` environment.
             </details>
             :hammer_and_wrench: Using: spack-packages `${{ needs.check-config.outputs.spack-packages-version}}`, spack-config `${{ needs.check-config.outputs.spack-config-version }}`
             <details>

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,8 +155,8 @@ jobs:
             exit 1
           fi
 
-  version-tag:
-    name: Get Version and Tag Prerelease
+  version:
+    name: Get Version
     needs:
       - check-spack-yaml
     runs-on: ubuntu-latest
@@ -184,23 +184,6 @@ jobs:
           number_of_commits=$(git rev-list --count ${{ github.event.pull_request.base.sha }}..HEAD)
           echo "prerelease=pr${{ github.event.pull_request.number }}-${number_of_commits}" >> $GITHUB_OUTPUT
 
-      - name: Tag ${{ steps.version.outputs.release }} for SBD Git Resolution
-        # We create this initial 'Release' tag on the PR as the overall version
-        # of the deployment (for example, `access-om2@git.2024.05.0`) will not
-        # work without the tag in the model repostiory.
-        run: |
-          git config user.name ${{ vars.GH_ACTIONS_BOT_GIT_USER_NAME }}
-          git config user.email ${{ vars.GH_ACTIONS_BOT_GIT_USER_EMAIL }}
-
-          if [ ! $(git tag --list "${{ steps.version.outputs.release }}") ]; then
-            git tag ${{ steps.version.outputs.release }}
-            git push --tags
-            echo "::notice::Pushed prerelease ${{ steps.version.outputs.release }} tag on ${{ github.head_ref }}"
-          else
-            commit=$(git rev-list -n 1 tags/${{ steps.version.outputs.release }})
-            echo "Didn't push prerelease ${{ steps.version.outputs.release }} as one already exists on $commit"
-          fi
-
   # -----------------------------
   # | PRERELEASE DEPLOYMENT JOB |
   # -----------------------------
@@ -210,7 +193,7 @@ jobs:
     # For example, `access-om3-pr13-3` for the deployment of access-om3 based on the third commit on the PR#13.
     needs:
       - defaults  # so we can access `inputs.root-sbd` that could have defaulted to `inputs.model`
-      - version-tag  # implies all the spack.yaml-related checks have passed, has appropriate version for the prerelease build
+      - version  # implies all the spack.yaml-related checks have passed, has appropriate version for the prerelease build
       - check-config  # implies all the json-related checks have passed
     uses: access-nri/build-cd/.github/workflows/deploy-1-setup.yml@main
     with:
@@ -224,7 +207,7 @@ jobs:
     name: Notifier
     needs:
       - defaults  # so we can access `inputs.root-sbd` that could have defaulted to `inputs.model`
-      - version-tag  # implies all the spack.yaml-related checks have passed, has appropriate version for the prerelease build
+      - version  # implies all the spack.yaml-related checks have passed, has appropriate version for the prerelease build
       - check-config  # implies all the json-related checks have passed
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/deploy-2-start.yml
+++ b/.github/workflows/deploy-2-start.yml
@@ -33,6 +33,7 @@ on:
         default: ${{ inputs.model }}
         description: The root SBD that is being used as the modulefile name
 env:
+  SPACK_YAML_SPEC_YQ: .spack.specs[0]
   SPACK_YAML_MODULEFILE_PROJECTION_YQ: .spack.modules.default.tcl.projections.${{ inputs.root-sbd }}
   METADATA_PATH: /opt/metadata
 jobs:
@@ -64,11 +65,14 @@ jobs:
             ${{ secrets.HOST }}
             ${{ secrets.HOST_DATA }}
 
-      - name: Prerelease Modulefile Name
+      - name: Prerelease spack.yaml Modifications
         if: inputs.type == 'prerelease'
         # Modifies the name of the prerelease modulefile to the
-        # `pr<number>-<commit>` style. For example, `access-om3/pr12-2`
+        # `pr<number>-<commit>` style. For example, `access-om3/pr12-2`.
+        # Also removes the `@git.VERSION` specifier for Prereleases so
+        # we don't have to shift tags around.
         run: |
+          yq -i '${{ env.SPACK_YAML_SPEC_YQ }} = (${{ env.SPACK_YAML_SPEC_YQ }} | split("@").[0])' spack.yaml
           yq -i '${{ env.SPACK_YAML_MODULEFILE_PROJECTION_YQ }} = "{name}/${{ inputs.version }}"' spack.yaml
           echo "::notice::Prerelease accessible as module `${{ inputs.model}}/${{ inputs.version }}`"
 


### PR DESCRIPTION
Removes the `@git.VERSION` of a `MODEL@git.VERSION` in the `.spack.specs[0]` section of a `spack.yaml` during a Prerelease. This is so we don't have to move tags between Prerelease and Release. 

Tested the `yq` command locally using a `spack.yaml`. 

In this PR:
* `deploy-2-start.yml`: Now removes the `@git.VERSION` section from Prerelease deploy
* `ci.yml`: No longer needs to do the initial tagging of a prerelease

Closes #100 