### PR TITLE
CD: Root SBD Defaults

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -10,6 +10,13 @@ on:
         type: string
         required: true
         description: The model that is being tested and deployed
+      root-sbd:
+        type: string
+        required: false
+        # default: The ${{ inputs.model }} above
+        description: |
+          The name of the root Spack Bundle Definition, if it is different from the model name.
+          This is often a package named similarly in ACCESS-NRI/spack-packages.
   # Callers usually have the trigger:
   # push:
   #   branches:
@@ -22,6 +29,22 @@ on:
 env:
   SPACK_YAML_MODEL_YQ: .spack.specs[0]
 jobs:
+  defaults:
+    name: Set Defaults
+    # Unfortunately, you can't set a dynamic default value based on `inputs` yet
+    runs-on: ubuntu-latest
+    outputs:
+      root-sbd: ${{ steps.root-sbd.outputs.default }}
+    steps:
+      - name: root-sbd
+        id: root-sbd
+        run: |
+          if [ -z "${{ inputs.root-sbd }}" ]; then
+            echo "default=${{ inputs.model }}" >> $GITHUB_OUTPUT
+          else
+            echo "default=${{ inputs.root-sbd }}" >> $GITHUB_OUTPUT
+          fi
+
   push-tag:
     name: Tag Deployment
     runs-on: ubuntu-latest
@@ -49,11 +72,13 @@ jobs:
   deploy-release:
     name: Deploy Release
     needs:
+      - defaults
       - push-tag
     uses: access-nri/build-cd/.github/workflows/deploy-1-setup.yml@main
     with:
       ref: ${{ github.ref_name }}
       version: ${{ needs.push-tag.outputs.name }}
+      root-sbd: ${{ needs.defaults.outputs.root-sbd }}
     secrets: inherit
     permissions:
       contents: write

--- a/.github/workflows/deploy-1-setup.yml
+++ b/.github/workflows/deploy-1-setup.yml
@@ -17,7 +17,7 @@ on:
         description: The version for the model being deployed
       root-sbd:
         type: string
-        required: false
+        required: true
         description: The root SBD that is being used as the modulefile name
 
 jobs:

--- a/.github/workflows/deploy-2-start.yml
+++ b/.github/workflows/deploy-2-start.yml
@@ -29,8 +29,7 @@ on:
         description: The GitHub deployment environment name
       root-sbd:
         type: string
-        required: false
-        default: ${{ inputs.model }}
+        required: true
         description: The root SBD that is being used as the modulefile name
 env:
   SPACK_YAML_SPEC_YQ: .spack.specs[0]


### PR DESCRIPTION
This issue stems from this line:
https://github.com/ACCESS-NRI/build-cd/blob/d7c57427766587787f130fe84ad455cde1752fcc/.github/workflows/deploy-2-start.yml#L33
We cannot set dynamic defaults like this, only a basic string default. 

The CI pipeline already creates it's own `inputs.root-sbd` default (essentially `inputs.model-name`), as it is required for editing the modulefile name to be in `pr` format for Prereleases.
The CD pipeline also requires this, but we hadn't added it. Details on the underlying cause are in the linked issue. 

In this PR:
* Made `cd.yml` set a dynamic `inputs.root-sbd` default based on `inputs.model`
* Made all `inputs.root-sbd` required

 - [x] We will also have to delete and manually upload the `meta-db` entries that did not contain the correct `model` name. Currently, that seems to be all deployed models last month. 
 - [x] Will also need to link a `ACCESS-NRI/access-esm1.5` PR that adds the (now required) `inputs.root-sbd` argument. 

Closes #102