### PR TITLE
Fix Regression in Deployment Paths Action

### DIFF
--- a/.github/actions/get-deploy-paths/action.yml
+++ b/.github/actions/get-deploy-paths/action.yml
@@ -32,7 +32,7 @@ outputs:
     value: ${{ steps.path.outputs.spack-config }}
   spack-packages:
     description: Path to the ACCESS-NRI/spack-packages repository associated with the install of spack.
-    value: ${{ steps.path.outputs.spack-config }}
+    value: ${{ steps.path.outputs.spack-packages }}
 runs:
   using: composite
   steps:


### PR DESCRIPTION
See failed run: https://github.com/ACCESS-NRI/ACCESS-ESM1.5/actions/runs/9770348055/job/26971411007?pr=5#step:8:37 - specifically where the same `spack-config` repository is checked out twice, rather than one `spack-packages` and one `spack-config`. 

In the action, we set the output of both `spack-packages` and `spack-config` to the output of the `spack-packages` step. This is incorrect. 

In this PR:
* action.yml: make `outputs.spack-packages` actually output spack-packages