### PR TITLE
Import Commit Signing Keys for Workflow Commits

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -61,13 +61,22 @@ jobs:
         # is of the form `<model>@git.<version>`.
         run: echo "name=$(yq '${{ env.SPACK_YAML_MODEL_YQ }} | split("@git.") | .[1]' spack.yaml)" >> $GITHUB_OUTPUT
 
+      - name: Import Commit-Signing Key
+        uses: crazy-max/ghaction-import-gpg@01dd5d3ca463c7f10f7f4f7b4f177225ac661ee4  # v6.1.0
+        with:
+          gpg_private_key: ${{ secrets.GH_ACTIONS_BOT_GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.GH_ACTIONS_BOT_GPG_PASSPHRASE }}
+          git_config_global: true
+          git_committer_name: ${{ vars.GH_ACTIONS_BOT_GIT_USER_NAME }}
+          git_committer_email: ${{ vars.GH_ACTIONS_BOT_GIT_USER_EMAIL }}
+          git_user_signingkey: true
+          git_commit_gpgsign: true
+          git_tag_gpgsign: true
+
       - name: Push Tag
-        # NOTE: Regarding the config user.name/user.email, see https://github.com/actions/checkout/pull/1184
         run: |
-          git config user.name ${{ vars.GH_ACTIONS_BOT_GIT_USER_NAME }}
-          git config user.email ${{ vars.GH_ACTIONS_BOT_GIT_USER_EMAIL }}
-          git tag ${{ steps.tag.outputs.name }} --force
-          git push --tags --force
+          git tag ${{ steps.tag.outputs.name }}
+          git push --tags
 
   deploy-release:
     name: Deploy Release

--- a/.github/workflows/ci-comment.yml
+++ b/.github/workflows/ci-comment.yml
@@ -91,11 +91,20 @@ jobs:
           versioning-scheme: calver-minor
           bump-type: ${{ steps.setup.outputs.bump }}
 
+      - name: Import Commit-Signing Key
+        uses: crazy-max/ghaction-import-gpg@01dd5d3ca463c7f10f7f4f7b4f177225ac661ee4  # v6.1.0
+        with:
+          gpg_private_key: ${{ secrets.GH_ACTIONS_BOT_GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.GH_ACTIONS_BOT_GPG_PASSPHRASE }}
+          git_config_global: true
+          git_committer_name: ${{ vars.GH_ACTIONS_BOT_GIT_USER_NAME }}
+          git_committer_email: ${{ vars.GH_ACTIONS_BOT_GIT_USER_EMAIL }}
+          git_user_signingkey: true
+          git_commit_gpgsign: true
+          git_tag_gpgsign: true
+
       - name: Update, Commit and Push the Bump
         run: |
-          git config user.name ${{ vars.GH_ACTIONS_BOT_GIT_USER_NAME }}
-          git config user.email ${{ vars.GH_ACTIONS_BOT_GIT_USER_EMAIL }}
-
           yq -i '${{ env.SPACK_YAML_MODEL_YQ }} = "${{ inputs.root-sbd }}@git.${{ steps.bump.outputs.after }}"' spack.yaml
           yq -i '${{ env.SPACK_YAML_MODEL_PROJECTION_YQ }} = "{name}/${{ steps.bump.outputs.after }}"' spack.yaml
           git add spack.yaml


### PR DESCRIPTION
In this PR:
* Import commit-signing key using org secrets across the pipeline
* Remove force pushes

Closes #115