### PR TITLE
ci.yml: Update `MODULE_VER` creation logic to allow for multiple `/` in module name 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,7 +144,8 @@ jobs:
               DEP_VER=$(yq ".spack.packages.\"$DEP\".require[0] | match(\"^@(?:git.)?([^=]*)\").captures[0].string" spack.yaml)
             fi
 
-            MODULE_VER=$(yq ".spack.modules.default.tcl.projections.\"$DEP\" | split(\"/\") | .[1]" spack.yaml)
+            MODULE_NAME=$(yq ".spack.modules.default.tcl.projections.\"$DEP\"" spack.yaml)
+            MODULE_VER="${MODULE_NAME#*/}"  # Get 'version' from 'name/version' module, even if version contains '/'
 
             if [[ "$DEP_VER" != "$MODULE_VER" ]]; then
               echo "::error::$DEP: Version of dependency and projection do not match ($DEP_VER != $MODULE_VER)"


### PR DESCRIPTION
See failed https://github.com/ACCESS-NRI/ACCESS-OM2/actions/runs/10483277546/job/29035729585?pr=76

Given the update in https://github.com/ACCESS-NRI/schema/pull/34, we now allow more `/` in modulefile names. However, the check that the version of the package matches the version of the projection used a naive `split on /` method, which would not keep later `/`s. 

In this PR:
* Update the section getting the module version to use bash parameter splitting to split on the first `/` and keep the rest. 

References https://github.com/ACCESS-NRI/ACCESS-OM2/pull/76