### PR TITLE
Dynamic `spack` version in Deployment Comment

### DIFF
--- a/.github/actions/validate-repo-version/action.yml
+++ b/.github/actions/validate-repo-version/action.yml
@@ -27,12 +27,8 @@ runs:
           exit 1
         fi
 
-        # We omit the 'releases/v' from the spack branch in versions.json, so we add it back here.
-        if [[ "${{ inputs.repo-to-check }}" == "spack" ]]; then
-          echo "version=releases/v${version}" >> $GITHUB_OUTPUT
-        else
-          echo "version=${version}" >> $GITHUB_OUTPUT
-        fi
+        echo "version=${version}" >> $GITHUB_OUTPUT
+        echo "spack-branch-version=releases/v${version}" >> $GITHUB_OUTPUT
 
     # Verify that the repository exists at the given ref
     - name: Version Check
@@ -40,7 +36,9 @@ runs:
       uses: actions/checkout@v4
       with:
         repository: access-nri/${{ inputs.repo-to-check }}
-        ref: ${{ steps.jq.outputs.version }}
+        # In the case where we are checking spack, we need to add the
+        # 'releases/v' to the ref name, obtained in the previous step
+        ref: ${{ inputs.repo-to-check == 'spack' && steps.jq.outputs.spack-branch-version || steps.jq.outputs.version }}
         path: repo
 
     - name: Version Check Failure Notifier

--- a/.github/actions/validate-repo-version/action.yml
+++ b/.github/actions/validate-repo-version/action.yml
@@ -8,7 +8,7 @@ inputs:
 outputs:
   version:
     value: ${{ steps.jq.outputs.version }}
-    description: Version of spack-packages from the `config/versions.json`
+    description: Version of `inputs.repo-to-check` from the `config/versions.json`
 runs:
   using: composite
   steps:
@@ -23,7 +23,13 @@ runs:
         version=$(jq --compact-output --raw-output '."${{ inputs.repo-to-check }}"' ./config/versions.json)
 
         if [[ "${version}" == "null" ]]; then
+          echo "::error::There is no `${{ inputs.repo-to-check }}` in `./config/versions.json`"
           exit 1
+        fi
+
+        # We omit the 'releases/v' from the spack branch in versions.json, so we add it back here.
+        if [[ "${{ inputs.repo-to-check }}" == "spack" ]]; then
+          echo "version=releases/v${version}" >> $GITHUB_OUTPUT
         else
           echo "version=${version}" >> $GITHUB_OUTPUT
         fi
@@ -34,16 +40,12 @@ runs:
       uses: actions/checkout@v4
       with:
         repository: access-nri/${{ inputs.repo-to-check }}
-        ref: ${{ steps.versions.outputs.packages }}
+        ref: ${{ steps.jq.outputs.version }}
         path: repo
 
-    - name: Failure Notifier
-      if: failure()
+    - name: Version Check Failure Notifier
+      if: failure() && steps.check.outcome == 'failure'
       shell: bash
       run: |
-        if [[ "${{ steps.jq.outcome }}" == "failure" ]]; then
-          echo "::error::There is no ${{ inputs.repo-to-check }} in `config/versions.json`, or the file doesn't exist."
-        elif [[ "${{ steps.check.outcome }}" == "failure" ]]; then
-          echo "::error::${{ inputs.repo-to-check }} at the specified ref (${{ steps.versions.outputs.packages }}) doesn't exist."
-        fi
+        echo "::error::`${{ inputs.repo-to-check }}` at the specified ref (`${{ steps.jq.outputs.version }}`) doesn't exist."
         exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,7 @@ jobs:
     name: Check Config Fields
     runs-on: ubuntu-latest
     outputs:
+      spack-version: ${{ steps.spack.outputs.version }}
       spack-packages-version: ${{ steps.spack-packages.outputs.version }}
       spack-config-version:  ${{ steps.spack-config.outputs.version }}
       config-settings-failures: ${{ steps.settings.outputs.failures }}
@@ -77,6 +78,12 @@ jobs:
         uses: access-nri/build-cd/.github/actions/validate-repo-version@main
         with:
           repo-to-check: spack-config
+
+      - name: Validate spack version
+        id: spack
+        uses: access-nri/build-cd/.github/actions/validate-repo-version@main
+        with:
+          repo-to-check: spack
 
       - name: Checkout build-cd Config
         uses: actions/checkout@v4
@@ -239,14 +246,15 @@ jobs:
             module load ${{ needs.defaults.outputs.root-sbd }}/${{ needs.check-spack-yaml.outputs.prerelease }}
             ```
             where the binaries shall be on your `$PATH`.
-            This Prerelease is also accessible on Gadi via `/g/data/vk83/prerelease/apps/spack/0.22/spack` in the `${{ needs.defaults.outputs.root-sbd }}-${{ needs.check-spack-yaml.outputs.prerelease }}` environment.
+            This Prerelease is also accessible on Gadi via `/g/data/vk83/prerelease/apps/spack/${{ needs.check-config.outputs.spack-version }}/spack` in the `${{ needs.defaults.outputs.root-sbd }}-${{ needs.version.outputs.prerelease }}` environment.
             </details>
 
-            :hammer_and_wrench: Using: spack-packages `${{ needs.check-config.outputs.spack-packages-version}}`, spack-config `${{ needs.check-config.outputs.spack-config-version }}`
+            :hammer_and_wrench: Using: spack `${{ needs.check-config.outputs.spack-version }}`, spack-packages `${{ needs.check-config.outputs.spack-packages-version}}`, spack-config `${{ needs.check-config.outputs.spack-config-version }}`
             <details>
             <summary>Details</summary>
 
             It will be deployed using:
+            * `access-nri/spack` on branch [`${{ needs.check-config.outputs.spack-version }}`](https://github.com/ACCESS-NRI/spack/tree/releases/v${{ needs.check-config.outputs.spack-version }})
             * `access-nri/spack-packages` version [`${{ needs.check-config.outputs.spack-packages-version }}`](https://github.com/ACCESS-NRI/spack-packages/releases/tag/${{ needs.check-config.outputs.spack-packages-version }})
             * `access-nri/spack-config` version [`${{ needs.check-config.outputs.spack-config-version }}`](https://github.com/ACCESS-NRI/spack-config/releases/tag/${{ needs.check-config.outputs.spack-config-version }})
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,12 +73,6 @@ jobs:
         with:
           repo-to-check: spack-packages
 
-      - name: Validate spack-config version
-        id: spack-config
-        uses: access-nri/build-cd/.github/actions/validate-repo-version@main
-        with:
-          repo-to-check: spack-config
-
       - name: Validate spack version
         id: spack
         uses: access-nri/build-cd/.github/actions/validate-repo-version@main
@@ -91,6 +85,17 @@ jobs:
           repository: ACCESS-NRI/build-cd
           ref: main
           path: cd
+
+      - name: Get spack-config version
+        id: spack-config
+        # TODO: For future targets, we need to know which target we are using by this point
+        run: |
+          version=$(jq --compact-output --raw-output \
+            --arg spack_version "${{ steps.spack.outputs.version }}" \
+            '.deployment.Gadi.Prerelease[$spack_version]."spack-config"' cd/config/settings.json
+          )
+          echo $version
+          echo "version=$version" >> $GITHUB_OUTPUT
 
       - name: Validate build-cd config/settings.json
         id: settings


### PR DESCRIPTION
We didn't have the infrastructure in place before to be able to get the spack version into the deployment comment - it used to have to be manually updated. This PR makes this not the case anymore. 

In this PR:

- **ci.yml: We now validate the spack version and pass it to the deployment comment**
- **validate-repo-version: Can now verify spack version existence, fixed incorrect templating**

Closes #110
