### PR TITLE
Undeploy Workflow Reads from new `config/settings.json`

### DIFF
--- a/.github/workflows/undeploy-1-setup.yml
+++ b/.github/workflows/undeploy-1-setup.yml
@@ -20,7 +20,10 @@ jobs:
 
       - name: Get Environments
         id: get-deployment-environment
-        run: echo "deployment-environments=$(jq --compact-output '."prerelease-environments"' ./config/deployment-environment.json)" >> $GITHUB_OUTPUT
+        # Note: We run under the assumption that all Prerelease Environments have 'Prerelease'
+        # appended to their GitHub Environment name, which is set out in our deployment template
+        # https://github.com/ACCESS-NRI/model-deployment-template/blob/main/README.md?plain=1#L41
+        run: echo "deployment-environments=$(jq --compact-output '.deployment | keys[] | "\(.) Prerelease"' ./config/settings.json)" >> $GITHUB_OUTPUT
 
 
   undeployment:


### PR DESCRIPTION
In this PR:
* Undeploy workflow now gets list of Prerelease Environments from `config/settings.json` introduced in #98

`jq` was tested locally on https://github.com/ACCESS-NRI/build-cd/blob/main/config/settings.json

Closes #126
