### PR TITLE
Rework `settings-2-deploy.yml` to Remove Local Reading of Files on Remote

### DIFF
--- a/.github/actions/validate-deployment-settings/action.yml
+++ b/.github/actions/validate-deployment-settings/action.yml
@@ -87,7 +87,7 @@ runs:
           fi
         done
 
-        if [ -n $failed ]; then
+        if [ -n "$failed" ]; then
           msg="Some commits referenced do not exist in access-nri/spack. Check the workflow logs."
           echo "::${{ inputs.error-level }}::$msg"
           echo "msg=$msg" >> $GITHUB_OUTPUT

--- a/.github/workflows/settings-2-deploy.yml
+++ b/.github/workflows/settings-2-deploy.yml
@@ -23,6 +23,8 @@ jobs:
       - name: Setup spack updates
         id: spack
         # TODO: Since we can't format this json as an input for this job (see the earlier workflow) we need to do it here
+        # Create a newline-separated list of strings of the form "MAJOR_VERSION COMMIT_HASH" so we
+        # update the remotes MAJOR_VERSION/spack to COMMIT_HASH. Ex: "0.20 y7834gtbf3jf3434rr34r34ru"
         run: |
           updates=$(jq --compact-output --raw-output \
             --arg env "${{ inputs.deployment-environment }}" \

--- a/.github/workflows/settings-2-deploy.yml
+++ b/.github/workflows/settings-2-deploy.yml
@@ -27,21 +27,12 @@ jobs:
           updates=$(jq --compact-output --raw-output \
             --arg env "${{ inputs.deployment-environment }}" \
             --arg type "${{ inputs.spack-type }}" \
-            '.deployment[$env][$type].spack' \
-            ${{ env.CONFIG_SETTINGS_PATH }}
-          )
-          versions=$(jq --compact-output --raw-output \
-            --arg env "${{ inputs.deployment-environment }}" \
-            --arg type "${{ inputs.spack-type }}" \
-            '.deployment[$env][$type].spack | keys | @sh' \
+            '.deployment[$env][$type].spack | to_entries[] | "\(.key) \(.value)"' \
             ${{ env.CONFIG_SETTINGS_PATH }}
           )
 
           echo "$updates"
-          echo "$versions"
-
           echo "updates=$updates" >> $GITHUB_OUTPUT
-          echo "versions=$versions" >> $GITHUB_OUTPUT
 
       - name: Setup SSH
         id: ssh
@@ -55,14 +46,10 @@ jobs:
         run: |
           ssh ${{ secrets.USER}}@${{ secrets.HOST }} -i ${{ steps.ssh.outputs.private-key-path }} /bin/bash <<'EOT'
           set +e
-          for version in ${{ steps.spack.outputs.versions }}; do
-            new_commit=$(jq --compact-output --raw-output \
-              --arg v "$version" \
-              --arg env "${{ inputs.deployment-environment }}" \
-              --arg type "${{ inputs.spack-type }}" \
-              '.deployment[$env][$type].spack[$v]' \
-              ${{ env.CONFIG_SETTINGS_PATH }}
-            )
+          while read -ra update; do
+            version=${update[0]}
+            new_commit=${update[1]}
+
             current_head_commit=$(git -C ${{ secrets.SPACK_INSTALLS_ROOT_LOCATION }}/$version/spack rev-parse HEAD)
             if [ $? -eq 128 ]; then
               # FIXME: Deploy spack instances in this job too.
@@ -82,5 +69,5 @@ jobs:
             else
               echo "::notice::Unchanged: ${{ inputs.deployment-environment }} ${{ inputs.spack-type }} $version spack left at $current_head_commit"
             fi
-          done
+          done <<< "${{ steps.spack.outputs.updates }}"
           EOT


### PR DESCRIPTION
This PR fixes the issue of attempting to read runner-local `config/settings.json` on a remote target (such as `Gadi`). Whoops. 

In this PR:
* Move local reading of `config/settings.json` into earlier, pre-`ssh` connection step
* Remove `versions` output to a step since we don't really need it. 
* Use `while read ... done <<< "$newline_separated_things"` since it's super cool
* Quoted a variable in `if [ -n "$failed" ]` because `-n` doesn't work properly without quotes

Closes #129
