### PR TITLE
Added `[d:]g:vk83_um:r-X` to restricted folders during `spack` creation

### DIFF
--- a/.github/workflows/create-deployment-spack.yml
+++ b/.github/workflows/create-deployment-spack.yml
@@ -74,6 +74,6 @@ jobs:
           mkdir -p $TMPDIR/restricted/spack-stage
 
           setfacl --recursive -m \
-            "g:vk83_w:r-X,g:ki32_mosrs:r-X,g::---,other::---,d:g:vk83_w:r-X,d:g:ki32_mosrs:r-X,d:g::---,d:other::---" \
+            "g:vk83_w:r-X,g:ki32_mosrs:r-X,g:vk83_um:r-X,g::---,other::---,d:g:vk83_w:r-X,d:g:ki32_mosrs:r-X,d:g:vk83_um:r-X,d:g::---,d:other::---" \
             ${{ env.ROOT_VERSION_LOCATION }}/restricted $TMPDIR/restricted
           EOT


### PR DESCRIPTION
See rationale in linked issue.

In this PR:
- Add `[d:]g:vk83_um:r-X` to the `setfacl` call in `create-deployment-spack.yml`

Closes #131
