### PR TITLE
Multiline GitHub Output Fix

### DIFF
--- a/.github/workflows/settings-2-deploy.yml
+++ b/.github/workflows/settings-2-deploy.yml
@@ -42,7 +42,7 @@ jobs:
           updates=$(jq --compact-output --raw-output \
             --arg env "${{ inputs.deployment-environment }}" \
             --arg type "${{ inputs.spack-type }}" \
-            '.deployment[$env][$type] | to_entries[] | "\(.key) \(.value.spack-config"' \
+            '.deployment[$env][$type] | to_entries[] | "\(.key) \(.value.spack-config)"' \
             ${{ env.CONFIG_SETTINGS_PATH }}
           )
 

--- a/.github/workflows/settings-2-deploy.yml
+++ b/.github/workflows/settings-2-deploy.yml
@@ -34,7 +34,10 @@ jobs:
           )
 
           echo "$updates"
-          echo "updates=$updates" >> $GITHUB_OUTPUT
+          # For multiline output, use a heredoc. See https://github.com/orgs/community/discussions/116619#discussioncomment-8994849
+          echo "updates<<EOF" >> $GITHUB_OUTPUT
+          echo "$updates" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
 
       - name: Setup spack-config updates
         id: spack-config
@@ -47,7 +50,10 @@ jobs:
           )
 
           echo "$updates"
-          echo "updates=$updates" >> $GITHUB_OUTPUT
+          # For multiline output, use a heredoc. See https://github.com/orgs/community/discussions/116619#discussioncomment-8994849
+          echo "updates<<EOF" >> $GITHUB_OUTPUT
+          echo "$updates" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
 
       - name: Setup SSH
         id: ssh


### PR DESCRIPTION
There was an error processing multiline GitHub output, so we have to use a heredoc like in https://github.com/orgs/community/discussions/116619#discussioncomment-8994849. A simplified example of both is presented in this workflow: https://github.com/codegat-test-org/test/actions/runs/11004389439

In this PR:
- Put in missing ')' in `spack-config jq`
- Use a heredoc for multiline GITHUB_OUTPUT

Closes #135
