### PR TITLE
Quote Hyphenated `spack-config` `jq` Property

### DIFF
--- a/.github/workflows/settings-2-deploy.yml
+++ b/.github/workflows/settings-2-deploy.yml
@@ -45,7 +45,7 @@ jobs:
           updates=$(jq --compact-output --raw-output \
             --arg env "${{ inputs.deployment-environment }}" \
             --arg type "${{ inputs.spack-type }}" \
-            '.deployment[$env][$type] | to_entries[] | "\(.key) \(.value.spack-config)"' \
+            '.deployment[$env][$type] | to_entries[] | "\(.key) \(.value."spack-config")"' \
             ${{ env.CONFIG_SETTINGS_PATH }}
           )
 


### PR DESCRIPTION
See failing run https://github.com/ACCESS-NRI/build-cd/actions/runs/11007422156/job/30563335709

This is due to not escaping a hyphenated property name like `spack-config` in `"\(.value.spack-config)"`. 

In this PR:
- Update usages of `spack-config` property to be escaped, like `"\(.value."spack-config")"`
