### PR TITLE
Update `spack-config` for `Gadi Prerelease 0.22` to `2024.10.03`

### DIFF
--- a/config/settings.json
+++ b/config/settings.json
@@ -15,7 +15,7 @@
       "Prerelease": {
         "0.22": {
           "spack": "21da7d7e2b5e2680cd9d2e0a2fb4a7d13d8baa9d",
-          "spack-config": "2024.07.05"
+          "spack-config": "2024.10.03"
         }
       }
     }


### PR DESCRIPTION
In this PR:
* Update `spack-config` of `Gadi Prerelease 0.22` to `2024.10.03`
