### PR TITLE
Replace Spack Environments Location

### DIFF
--- a/.github/workflows/deploy-2-start.yml
+++ b/.github/workflows/deploy-2-start.yml
@@ -115,7 +115,7 @@ jobs:
 
       - name: Get metadata from ${{ inputs.deployment-environment }}
         env:
-          SPACK_ENV_PATH: ${{ steps.path.outputs.spack }}/var/spack/environments/${{ inputs.env-name }}
+          SPACK_ENV_PATH: ${{ steps.path.outputs.spack }}/../environments/${{ inputs.env-name }}
         run: |
           ssh ${{ secrets.USER}}@${{ secrets.HOST }} -i ${{ steps.ssh.outputs.private-key-path }} /bin/bash <<'EOT'
           . ${{ steps.path.outputs.spack-config }}/spack-enable.bash
@@ -162,7 +162,7 @@ jobs:
       - name: Get Release Metadata
         env:
           # TODO: Can we put both envs above in a $GITHUB_ENV file instead?
-          SPACK_ENV_PATH: ${{ steps.path.outputs.spack }}/var/spack/environments/${{ inputs.env-name }}
+          SPACK_ENV_PATH: ${{ steps.path.outputs.spack }}/../environments/${{ inputs.env-name }}
         run: |
           rsync -e 'ssh -i ${{ steps.ssh.outputs.private-key-path }}' \
             '${{ secrets.USER}}@${{ secrets.HOST_DATA }}:${{ env.SPACK_ENV_PATH }}/spack.*' \

--- a/.github/workflows/undeploy-2-start.yml
+++ b/.github/workflows/undeploy-2-start.yml
@@ -45,7 +45,7 @@ jobs:
         run: |
           ssh ${{ secrets.USER}}@${{ secrets.HOST }} -i ${{ steps.ssh.outputs.private-key-path }} /bin/bash <<'EOT'
           . ${{ steps.path.outputs.spack-config }}/spack-enable.bash
-          envs=$(find ${{ steps.path.outputs.spack }}/var/spack/environments -type d -name '${{ inputs.env-name }}' -printf '%f ')
+          envs=$(find ${{ steps.path.outputs.spack }}/../environments -type d -name '${{ inputs.env-name }}' -printf '%f ')
 
           for env in $envs; do
             spack env activate $env


### PR DESCRIPTION
See failed metadata collection here: https://github.com/ACCESS-NRI/ACCESS-OM2/actions/runs/11226577720/job/31207356990?pr=82

Due to https://github.com/ACCESS-NRI/spack-config/releases/tag/2024.09.13 and later, the environments section has been moved from `$spack/var/spack/environments` to `$spack/../environments`. This PR reflects that change. 
