### PR TITLE
Update `Prerelease 0.22 spack-config` to `2024.11.11`

### DIFF
--- a/config/settings.json
+++ b/config/settings.json
@@ -15,7 +15,7 @@
       "Prerelease": {
         "0.22": {
           "spack": "21da7d7e2b5e2680cd9d2e0a2fb4a7d13d8baa9d",
-          "spack-config": "2024.10.17"
+          "spack-config": "2024.11.11"
         }
       }
     }


### PR DESCRIPTION
Test out updates to the configuration of spack in `Prerelease 0.22`. See https://github.com/ACCESS-NRI/spack-config/releases/tag/2024.11.11.
