### PR TITLE
`config/settings.json` Pipeline Fixes

### DIFF
--- a/.github/actions/validate-deployment-settings/action.yml
+++ b/.github/actions/validate-deployment-settings/action.yml
@@ -134,8 +134,21 @@ runs:
       run: |
         gh repo clone access-nri/spack-config ${{ env.CHECKOUT_DIR }} -- --no-checkout --bare --filter=blob:none
 
-        if ! git -C ${{ env.CHECKOUT_DIR }} tag -l $spack_config_tag; then
-          msg="Tag $spack_config_tag does not exist in access-nri/spack-config"
+        # Get all the tags associated with every `spack-config` in the inputs.settings-path
+        spack_config_tags=$(jq --compact-output --raw-output \
+          '[.deployment.Gadi[][]."spack-config"] | join(" ")' \
+          ${{ inputs.settings-path }}
+        )
+
+        for spack_config_tag in $spack_config_tags; do
+          if [ ! $(git -C ${{ env.CHECKOUT_DIR }} tag -l "$spack_config_tag") ]; then
+            echo "::${{ inputs.error-level }}::Tag $spack_config_tag does not exist in access-nri/spack-config"
+            failed=true
+          fi
+        done
+
+        if [ -n "$failed" ]; then
+          msg="Some tags referenced do not exist in access-nri/spack-config. Check the workflow logs."
           echo "::${{ inputs.error-level }}::$msg"
           echo "msg=$msg" >> $GITHUB_OUTPUT
         fi

--- a/.github/workflows/settings-1-update.yml
+++ b/.github/workflows/settings-1-update.yml
@@ -85,6 +85,8 @@ jobs:
     env:
       GH_TOKEN: ${{ github.token }}
     steps:
+      - uses: actions/checkout@v4
+
       - name: Get merged PR number
         id: pr
         # Get the most-recently merged PR and comment the workflow run link

--- a/.github/workflows/settings-2-deploy.yml
+++ b/.github/workflows/settings-2-deploy.yml
@@ -100,7 +100,8 @@ jobs:
           set +e
           while read -ra update; do
             version=${update[0]}
-            new_commit=${update[1]}
+            new_tag=${update[1]}
+
             current_head_commit=$(git -C ${{ secrets.SPACK_INSTALLS_ROOT_LOCATION }}/$version/spack-config rev-parse HEAD)
 
             if [ $? -eq 128 ]; then
@@ -110,8 +111,11 @@ jobs:
 
             git -C ${{ secrets.SPACK_INSTALLS_ROOT_LOCATION }}/$version/spack-config fetch
 
+            # Parse the above spack-config tag as a commit hash, for easy comparison. The '^{}' syntax gives the hash of the tagged commit, not the hash of the tag itself
+            new_commit=$(git -C ${{ secrets.SPACK_INSTALLS_ROOT_LOCATION }}/$version/spack-config rev-parse "${new_tag}^{}")
+
             if [[ "$current_head_commit" != "$new_commit" ]]; then
-              git -C ${{ secrets.SPACK_INSTALLS_ROOT_LOCATION }}/$version/spack-config checkout $new_commit
+              git -C ${{ secrets.SPACK_INSTALLS_ROOT_LOCATION }}/$version/spack-config checkout $new_tag
               if [ $? -ne 0 ]; then
                 echo "::error::Error: ${{ inputs.deployment-environment }} ${{ inputs.spack-type }} $version spack-config failed checkout from $current_head_commit to $new_commit"
               else


### PR DESCRIPTION
This PR fixes a few small bugs, each confined to their own file. 

Namely:
* The `spack-config` tag check was just listing the tags but not actually checking for their existence in the `spack-config` repo. This PR actually checks each tag. Fixed in https://github.com/ACCESS-NRI/build-cd/pull/161/commits/9563eaf9ee3fdfb68a1c2b538a8dac66123bcc97
* When updating the version of `spack-config`, we were comparing the current `HEAD` hash against the git tag name, rather than the hash associated with the git tag. This would lead to the annotation erroneously stating that the `spack-config` version was always "changing" when in actual fact we were checking out the same tag that we were on. Fixed in https://github.com/ACCESS-NRI/build-cd/pull/161/commits/f4fd81c37f2b49f35c1a08cd85094d0daab5ca4c
* We attempt to link the deployment of settings to the newly-closed PR, but we hadn't checked out a repo before running `gh`. Whoops! Fixed in https://github.com/ACCESS-NRI/build-cd/pull/161/commits/3efad6bb8c273be3504e93f1d46d50eb7b2ffdb2

In this PR:

- **validate-deployment-settings: loop around tags in settings.json, update condition**
- **settings-2-deploy: Convert spack-config tag into commit for version comparison**
- **settings-1-update.yml: Checkout repo before using `gh`**

Closes #160
