### PR TITLE
Get git URL of package without concretizing

### DIFF
--- a/.github/workflows/deploy-2-start.yml
+++ b/.github/workflows/deploy-2-start.yml
@@ -127,8 +127,7 @@ jobs:
           # Get the repos associated with the packages for the build database
           jq -n '{}' > ${{ env.SPACK_ENV_PATH }}/build-db-pkgs.json
           for pkg in ${{ vars.BUILD_DB_PACKAGES }}; do
-            # TODO: Is there a way to get the git attribute without concretizing?
-            pkg_repo_url=$(spack python -c "import spack.spec; print(spack.spec.Spec('$pkg').concretized().package.git)")
+            pkg_repo_url=$(spack python -c "import spack.spec; print(spack.spec.Spec('$pkg').package_class.git)")
 
             # We get the version of $pkg from spack.lock, and then strip
             # potential 'git.' and '=VERSION' parts from 'git.TAG=VERSION'


### PR DESCRIPTION
In this PR:
* Instead of freshly concretizing the packages in `vars.BUILD_DB_PACKAGES` to get the git URL, use the `package_class` attribute. This means that instead of waiting 14 minutes for reconcretization of some packages, it will be almost instant. 

Closes #147
