### PR TITLE
Use `git reset` rather than `git checkout` for `spack-packages` update

### DIFF
--- a/.github/workflows/deploy-2-start.yml
+++ b/.github/workflows/deploy-2-start.yml
@@ -101,6 +101,7 @@ jobs:
 
           # Update spack-packages
           git -C ${{ steps.path.outputs.spack-packages }} fetch
+          git -C ${{ steps.path.outputs.spack-packages }} checkout --force ${{ steps.versions.outputs.packages }}
           git -C ${{ steps.path.outputs.spack-packages }} reset --hard origin/${{ steps.versions.outputs.packages }}
 
           # Enable spack

--- a/.github/workflows/deploy-2-start.yml
+++ b/.github/workflows/deploy-2-start.yml
@@ -101,7 +101,7 @@ jobs:
 
           # Update spack-packages
           git -C ${{ steps.path.outputs.spack-packages }} fetch
-          git -C ${{ steps.path.outputs.spack-packages }} checkout --force ${{ steps.versions.outputs.packages }}
+          git -C ${{ steps.path.outputs.spack-packages }} reset --hard origin/${{ steps.versions.outputs.packages }}
 
           # Enable spack
           . ${{ steps.path.outputs.spack-config }}/spack-enable.bash


### PR DESCRIPTION
In this PR:
* Replace `git checkout --force` with `git reset --hard origin/$BRANCH` so the deployment targets `spack-packages` always has the remotes history, rather than diverging. 

Closes #165
