### PR TITLE
ci.yml: Set `GH_TOKEN` before using `gh`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,6 +199,8 @@ jobs:
 
       - name: Generate Versions
         id: version
+        env:
+          GH_TOKEN: ${{ github.token }}
         # This step generates the release and prerelease version numbers.
         # The release is a general version number from the spack.yaml, looking the
         # same as a regular release build. Ex. 'access-om2@git.2024.01.1' -> '2024.01.1'


### PR DESCRIPTION
See failed run https://github.com/ACCESS-NRI/ACCESS-OM2/actions/runs/11848633200/job/33020508429?pr=86#step:7:16

This is due to not setting the `GH_TOKEN` environment variable in the step where `gh` is used. This PR adds the appropriate variable. 
