### PR TITLE
Use `github.head_ref` rather than `github.ref_name` for deployment number

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -214,7 +214,7 @@ jobs:
           next_deployment_number=$(gh api \
             -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" \
             /repos/${{ github.repository }}/deployments \
-            --jq '[.[] | select(.ref == "${{ github.ref_name }}")] | length + 1'
+            --jq '[.[] | select(.ref == "${{ github.head_ref }}")] | length + 1'
           )
           echo "prerelease=pr${{ github.event.pull_request.number }}-${next_deployment_number}" >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
In this PR:
* Instead of using `github.ref_name` (which for `on.pull_request` gives you the merge branch `*/merge`) use the `github.head_ref`, which the source branch. This means we can count deployments correctly. 

See the difference between:
```bash
gh api /repos/ACCESS-NRI/ACCESS-OM2/deployments --jq '[.[] | select(.ref == "86/merge")] | length + 1'  # = 1. incorrect, there is 9 deployments on the branch
gh api /repos/ACCESS-NRI/ACCESS-OM2/deployments --jq '[.[] | select(.ref == "componentize-generic-tracers")] | length + 1'  # = 9. Correct!
```

Closes #170
