### PR TITLE
Update PR Description with Prerelease Link

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -285,21 +285,18 @@ jobs:
       - name: PR Description Notifier
         env:
           GH_TOKEN: ${{ github.token }}
-          PR_BODY_FILE_LOCATION: ./body.txt
-          LATEST_PRERELEASE_SECTION_REGEX: "^:rocket: .* :rocket:$"
-          # We can't use many punctuation marks in the Prerelease Section because `sed` treats
-          # the replacement string as a regex string - no special regex chars without escaping
-          LATEST_PRERELEASE_SECTION: ":rocket: The latest prerelease `${{ needs.defaults.outputs.root-sbd }}/${{ needs.check-spack-yaml.outputs.prerelease }}` is here: ${{ steps.comment.outputs.comment-link }} :rocket:"
+          PR_BODY_PATH: ./body.txt
+          PR_BODY_PATH_UPDATED: ./updated.body.txt
+          PRERELEASE_SECTION_REGEX: "^:rocket: .* :rocket:$"
+          PRERELEASE_SECTION: ":rocket: The latest prerelease `${{ needs.defaults.outputs.root-sbd }}/${{ needs.check-spack-yaml.outputs.prerelease }}` is here: ${{ steps.comment.outputs.comment-link }} :rocket:"
         run: |
-          gh pr view ${{ github.event.pull_request.number }} --repo ${{ github.repository }} --json body --jq .body > ${{ env.PR_BODY_FILE_LOCATION }}
+          gh pr view ${{ github.event.pull_request.number }} --repo ${{ github.repository }} --json body --jq .body > ${{ env.PR_BODY_PATH }}
 
-          if grep -q '${{ env.LATEST_PRERELEASE_SECTION_REGEX }}' ${{ env.PR_BODY_FILE_LOCATION }}; then  # there is an existing prerelease section
-            # Replace the existing prerelease section - we use '|' as a delimiter because there are '/' in the replacement string
-            sed -i 's|${{ env.LATEST_PRERELEASE_SECTION_REGEX }}|${{ env.LATEST_PRERELEASE_SECTION }}|g' ${{ env.PR_BODY_FILE_LOCATION }}
+          if grep -q '${{ env.PRERELEASE_SECTION_REGEX }}' ${{ env.PR_BODY_PATH }}; then  # there is an existing prerelease section
+            # Replace the existing prerelease section
+            awk '{gsub(/${{ env.PRERELEASE_SECTION_REGEX }}/, "${{ env.PRERELEASE_SECTION }}")}1' ${{ env.PR_BODY_PATH }} > ${{ env.PR_BODY_PATH_UPDATED }}
           else  # a new section is added
-            echo -e '\n' >> ${{ env.PR_BODY_FILE_LOCATION }}
-            echo '---' >> ${{ env.PR_BODY_FILE_LOCATION }}
-            echo '${{ env.LATEST_PRERELEASE_SECTION }}' >> ${{ env.PR_BODY_FILE_LOCATION }}
+            awk '1; END {print "\n---\n${{ env.PRERELEASE_SECTION }}"}' ${{ env.PR_BODY_PATH }} > ${{ env.PR_BODY_PATH_UPDATED }}
           fi
 
-          gh pr edit ${{ github.event.pull_request.number }} --repo ${{ github.repository }} --body-file ${{ env.PR_BODY_FILE_LOCATION }}
+          gh pr edit ${{ github.event.pull_request.number }} --repo ${{ github.repository }} --body-file ${{ env.PR_BODY_PATH }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -247,7 +247,9 @@ jobs:
     permissions:
       pull-requests: write
     steps:
-      - uses: access-nri/actions/.github/actions/pr-comment@main
+      - name: PR Comment Notifier
+        id: comment
+        uses: access-nri/actions/.github/actions/pr-comment@main
         with:
           comment: |
             :rocket: Deploying ${{ inputs.model }} `${{ needs.check-spack-yaml.outputs.release }}` as prerelease `${{ needs.check-spack-yaml.outputs.prerelease }}` with commit ${{ github.event.pull_request.head.sha }}
@@ -279,3 +281,25 @@ jobs:
 
             If this is not what was expected, commit changes to `config/versions.json`.
             </details>
+
+      - name: PR Description Notifier
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_BODY_FILE_LOCATION: ./body.txt
+          LATEST_PRERELEASE_SECTION_REGEX: "^:rocket: .* :rocket:$"
+          # We can't use many punctuation marks in the Prerelease Section because `sed` treats
+          # the replacement string as a regex string - no special regex chars without escaping
+          LATEST_PRERELEASE_SECTION: ":rocket: The latest prerelease `${{ needs.defaults.outputs.root-sbd }}/${{ needs.check-spack-yaml.outputs.prerelease }}` is here: ${{ steps.comment.outputs.comment-link }} :rocket:"
+        run: |
+          gh pr view ${{ github.event.pull_request.number }} --repo ${{ github.repository }} --json body --jq .body > ${{ env.PR_BODY_FILE_LOCATION }}
+
+          if grep -q '${{ env.LATEST_PRERELEASE_SECTION_REGEX }}' ${{ env.PR_BODY_FILE_LOCATION }}; then  # there is an existing prerelease section
+            # Replace the existing prerelease section - we use '|' as a delimiter because there are '/' in the replacement string
+            sed -i 's|${{ env.LATEST_PRERELEASE_SECTION_REGEX }}|${{ env.LATEST_PRERELEASE_SECTION }}|g' ${{ env.PR_BODY_FILE_LOCATION }}
+          else  # a new section is added
+            echo -e '\n' >> ${{ env.PR_BODY_FILE_LOCATION }}
+            echo '---' >> ${{ env.PR_BODY_FILE_LOCATION }}
+            echo '${{ env.LATEST_PRERELEASE_SECTION }}' >> ${{ env.PR_BODY_FILE_LOCATION }}
+          fi
+
+          gh pr edit ${{ github.event.pull_request.number }} --repo ${{ github.repository }} --body-file ${{ env.PR_BODY_FILE_LOCATION }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -292,10 +292,15 @@ jobs:
         run: |
           gh pr view ${{ github.event.pull_request.number }} --repo ${{ github.repository }} --json body --jq .body > ${{ env.PR_BODY_PATH }}
 
+          # `awk` is a series of `CONDITION { ACTION }` pairs. No 'CONDITION' means 'TRUE', no '{ ACTION }' means 'print'.
           if grep -q '${{ env.PRERELEASE_SECTION_REGEX }}' ${{ env.PR_BODY_PATH }}; then  # there is an existing prerelease section
             # Replace the existing prerelease section
+            # `{gsub(...)}`. Always attempt substitution on each line, then:
+            # `1`. Always do the default action '{ print }').
             awk '{gsub(/${{ env.PRERELEASE_SECTION_REGEX }}/, "${{ env.PRERELEASE_SECTION }}")}1' ${{ env.PR_BODY_PATH }} > ${{ env.PR_BODY_PATH_UPDATED }}
           else  # a new section is added
+            # `1;` -> `TRUE { print }`. Always do the default action (aka 'print') for each line.
+            # `END {print(...)}`. If end of file, print the prerelease section.
             awk '1; END {print "\n---\n${{ env.PRERELEASE_SECTION }}"}' ${{ env.PR_BODY_PATH }} > ${{ env.PR_BODY_PATH_UPDATED }}
           fi
 


### PR DESCRIPTION
## Background

In this PR:
* Add a new step to the `notifier` job that updates the PR description with the latest attempted Prerelease. It'll look something like this:

----

🚀 The latest prerelease `access-om2/pr86-12` is [here](https://github.com/ACCESS-NRI/ACCESS-OM2/pull/86#issuecomment-2490129613) 🚀

----

## Testing

Tested `awk` and `gh` commands locally. 
Tested the entire step in my own org, with both creation and update steps: https://github.com/codegat-test-org/test/actions/runs/11962762802/job/33351840627 for PR https://github.com/codegat-test-org/test/pull/22

Closes #152
