### PR TITLE
Add `!redeploy` Comment Command

### DIFF
--- a/.github/actions/validate-repo-version/README.md
+++ b/.github/actions/validate-repo-version/README.md
@@ -7,6 +7,7 @@ This action checks that the tags specified in a models `config/versions.json` is
 | Name | Type | Description | Required | Default | Example |
 | ---- | ---- | ----------- | -------- | ------- | ------- |
 | `repo-to-check` | `string` | ACCESS-NRI repository to validate associated version in `config/versions.json` | `true` | N/A | `spack-packages` |
+| `pr` | `number` | The pull request number that contains the `config/versions.json` | `true` | N/A | 12 |
 
 ## Outputs
 
@@ -22,8 +23,9 @@ This action checks that the tags specified in a models `config/versions.json` is
   uses: access-nri/build-cd/.github/actions/validate-repo-version@main
   with:
     repo-to-check: spack-packages
+    pr: 12
 
-- run: echo "spack-packages has valid version ${{ steps.validate.outputs.version }} in `config/versions.json`"
+- run: echo "spack-packages has valid version ${{ steps.validate.outputs.version }} in PR#12's `config/versions.json`"
 
 - if: failure() && steps.validate.outcome == 'failure'
   run: echo "The version in spack-packages is not valid."

--- a/.github/actions/validate-repo-version/action.yml
+++ b/.github/actions/validate-repo-version/action.yml
@@ -5,6 +5,10 @@ inputs:
     type: string
     required: true
     description: ACCESS-NRI repository to validate associated version in `config/versions.json`
+  pr:
+    type: number
+    required: true
+    description: The pull request number that contains the config/versions.json
 outputs:
   version:
     value: ${{ steps.jq.outputs.version }}
@@ -14,6 +18,8 @@ runs:
   steps:
     # Checkout the callers `config/versions.json`
     - uses: actions/checkout@v4
+      with:
+        ref: ${{ inputs.pr }}
 
     # Get the version from the `config/versions.json`
     - name: Setup

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,6 +131,8 @@ jobs:
         id: commenter
         uses: access-nri/actions/.github/actions/commenter-permission-check@main
         with:
+          # This means that commenters who use `!redeploy` must have at least `write` perms
+          # in the repository. `write` is probably the best fit. 
           minimum-permission: write
 
       - name: React to Comment

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,12 +111,14 @@ jobs:
         uses: access-nri/build-cd/.github/actions/validate-repo-version@main
         with:
           repo-to-check: spack-packages
+          pr: ${{ inputs.pr }}
 
       - name: Validate spack version
         id: spack
         uses: access-nri/build-cd/.github/actions/validate-repo-version@main
         with:
           repo-to-check: spack
+          pr: ${{ inputs.pr }}
 
       - name: Checkout build-cd Config
         uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,6 @@ name: CI
 run-name: ${{ inputs.model }} CI
 # NOTE: This workflow requires:
 # permissions.pull-requests:write
-# permissions.contents:write
 # secrets:inherit with an appropriate GitHub Environment for deployment in the caller
 on:
   workflow_call:
@@ -30,7 +29,10 @@ on:
   #   paths:
   #     - config/**
   #     - spack.yaml
-
+  # issue_comment:
+  #   types:
+  #     - created
+  #     - edited
 env:
   SPACK_YAML_MODEL_YQ: .spack.specs[0]
 jobs:
@@ -265,8 +267,8 @@ jobs:
   # -----------------------------
   prerelease-deploy:
     name: Deploy to Prerelease
-    # This will create a `spack` environment with the name `<model>-pr<pull request number>-<commit number>`.
-    # For example, `access-om3-pr13-3` for the deployment of access-om3 based on the third commit on the PR#13.
+    # This will create a `spack` environment with the name `<model>-pr<pull request number>-<deployment number>`.
+    # For example, `access-om3-pr13-3` for the third deployment on the PR#13.
     needs:
       - defaults  # so we can access `inputs.root-sbd` that could have defaulted to `inputs.model`
       - check-spack-yaml  # implies all the spack.yaml-related checks have passed, has appropriate version for the prerelease build
@@ -331,7 +333,7 @@ jobs:
           PR_BODY_PATH: ./body.txt
           PR_BODY_PATH_UPDATED: ./updated.body.txt
           PRERELEASE_SECTION_REGEX: "^:rocket: .* :rocket:$"
-          PRERELEASE_SECTION: ":rocket: The latest prerelease `${{ needs.defaults.outputs.root-sbd }}/${{ needs.check-spack-yaml.outputs.prerelease }}` is here: ${{ steps.comment.outputs.comment-link }} :rocket:"
+          PRERELEASE_SECTION: ":rocket: The latest prerelease `${{ needs.defaults.outputs.root-sbd }}/${{ needs.check-spack-yaml.outputs.prerelease }}` at ${{ needs.defaults.outputs.head-sha }} is here: ${{ steps.comment.outputs.comment-link }} :rocket:"
         run: |
           gh pr view ${{ inputs.pr }} --repo ${{ github.repository }} --json body --jq .body > ${{ env.PR_BODY_PATH }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,15 +94,21 @@ jobs:
 
       - name: Branch metadata
         id: branch
-        # Essentially, count all the deployment entries that match the given branch.
+        # Essentially, count all the deployment entries that match the given branch, as well as
+        # all the `!redeploy` comments, to get the next deployment number.
         # See https://docs.github.com/en/rest/deployments/deployments?apiVersion=2022-11-28#list-deployments
         run: |
-          next_deployment_number=$(gh api \
+          pr_deployments=$(gh api \
             -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" \
             --paginate \
             /repos/${{ github.repository }}/deployments \
-            --jq '[.[] | select(.ref == "${{ steps.pr.outputs.head }}")] | length + 1'
+            --jq '[.[] | select(.ref == "${{ steps.pr.outputs.head }}")] | length'
           )
+          comment_deployments=$(gh pr view ${{ inputs.pr }} --repo ${{ github.repository }} \
+            --json comments \
+            --jq '[.comments[] | select(.body | startswith("!redeploy"))] | length'
+          )
+          next_deployment_number=$((pr_deployments + comment_deployments + 1))
           echo "Next Deployment Number is $next_deployment_number"
           echo "next-deployment-number=$next_deployment_number" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,10 @@ on:
         description: |
           The name of the root Spack Bundle Definition, if it is different from the model name.
           This is often a package named similarly in ACCESS-NRI/spack-packages.
+      pr:
+        type: string
+        required: true
+        description: The pull request number that will be deployed as a prerelease
   # Callers usually have the trigger:
   # pull_request:
   #   branches:
@@ -32,12 +36,17 @@ env:
 jobs:
   defaults:
     name: Set Defaults
-    # Unfortunately, you can't set a dynamic default value based on `inputs` yet
+    # Unfortunately, you can't set a dynamic default value based on `inputs` yet.
+    # We also set the PR metadata here because it's used in multiple places,
+    # including the deploy reusable workflow, which can't access the `env` context.
     runs-on: ubuntu-latest
     outputs:
       root-sbd: ${{ steps.root-sbd.outputs.default }}
+      head-ref: ${{ steps.pr.outputs.head }}
+      head-sha: ${{ steps.pr.outputs.sha }}
+      base-ref: ${{ steps.pr.outputs.base }}
     steps:
-      - name: root-sbd
+      - name: root-sbd default
         id: root-sbd
         run: |
           if [[ "${{ inputs.root-sbd }}" == "" ]]; then
@@ -45,6 +54,33 @@ jobs:
           else
             echo "default=${{ inputs.root-sbd }}" >> $GITHUB_OUTPUT
           fi
+
+      - name: PR metadata
+        id: pr
+        run: |
+          pr_metadata=$(gh pr view ${{ inputs.pr }} --repo ${{ github.repository }} --json headRefName,headRefOid,baseRefName)
+          if [ -z "$pr_metadata" ]; then
+            echo "::error::Failed to get PR ${{ inputs.pr }} metadata."
+            exit 1
+          fi
+
+          head=$(jq --null-input --raw-output --compact-output
+            --argjson pr "$pr_metadata" \
+            '$pr.headRefName'
+          )
+          sha=$(jq --null-input --raw-output --compact-output \
+            --argjson pr "$pr_metadata" \
+            '$pr.headRefOid'
+          )
+          base=$(jq --null-input --raw-output --compact-output \
+            --argjson pr "$pr_metadata" \
+            '$pr.baseRefName'
+          )
+
+          echo "PR ${{ inputs.pr }} with '$head' ('$sha') -> '$base'"
+          echo "head=$head" >> $GITHUB_OUTPUT
+          echo "sha=$sha" >> $GITHUB_OUTPUT
+          echo "base=$base" >> $GITHUB_OUTPUT
 
   check-config:
     name: Check Config Fields

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,13 @@
 name: CI
 run-name: ${{ inputs.model }} CI
 # NOTE: This workflow requires:
-# permissions.pull-requests:write
-# secrets:inherit with an appropriate GitHub Environment for deployment in the caller
+# For the pull_request version of the workflow:
+#   permissions.pull-requests:write
+#   secrets:inherit with an appropriate GitHub Environment for deployment in the caller
+# For the !redeploy issue_comment version of the workflow:
+#   permissions.pull-requests:write
+#   permissions.statuses:write
+#   secrets:inherit with an appropriate GitHub Environment for deployment in the caller
 on:
   workflow_call:
     inputs:
@@ -39,14 +44,17 @@ jobs:
   defaults:
     name: Set Defaults
     # Unfortunately, you can't set a dynamic default value based on `inputs` yet.
-    # We also set the PR metadata here because it's used in multiple places,
+    # We also set the PR and branch metadata here because it's used in multiple places,
     # including the deploy reusable workflow, which can't access the `env` context.
     runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
     outputs:
       root-sbd: ${{ steps.root-sbd.outputs.default }}
       head-ref: ${{ steps.pr.outputs.head }}
       head-sha: ${{ steps.pr.outputs.sha }}
       base-ref: ${{ steps.pr.outputs.base }}
+      next-deployment-number: ${{ steps.branch.outputs.next-deployment-number }}
     steps:
       - name: root-sbd default
         id: root-sbd
@@ -66,7 +74,7 @@ jobs:
             exit 1
           fi
 
-          head=$(jq --null-input --raw-output --compact-output
+          head=$(jq --null-input --raw-output --compact-output \
             --argjson pr "$pr_metadata" \
             '$pr.headRefName'
           )
@@ -84,8 +92,61 @@ jobs:
           echo "sha=$sha" >> $GITHUB_OUTPUT
           echo "base=$base" >> $GITHUB_OUTPUT
 
+      - name: Branch metadata
+        id: branch
+        # Essentially, count all the deployment entries that match the given branch.
+        # See https://docs.github.com/en/rest/deployments/deployments?apiVersion=2022-11-28#list-deployments
+        run: |
+          next_deployment_number=$(gh api \
+            -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" \
+            --paginate \
+            /repos/${{ github.repository }}/deployments \
+            --jq '[.[] | select(.ref == "${{ steps.pr.outputs.head }}")] | length + 1'
+          )
+          echo "Next Deployment Number is $next_deployment_number"
+          echo "next-deployment-number=$next_deployment_number" >> $GITHUB_OUTPUT
+
+  redeploy-pre:
+    name: '!redeploy Pending'
+    if: github.event_name == 'issue_comment' && startsWith(github.event.comment.body, '!redeploy')
+    needs:
+      - defaults
+    runs-on: ubuntu-latest
+    permissions:
+      statuses: write
+      pull-requests: write
+    outputs:
+      # String to differentiate the status of redeploys vs other checks
+      commit-status-context: ${{ steps.commit-status-args.outputs.context }}
+      # String to describe the overall check
+      commit-status-description: ${{ steps.commit-status-args.outputs.description }}
+    steps:
+      - name: React to Comment
+        uses: access-nri/actions/.github/actions/react-to-comment@main
+        with:
+          token: ${{ github.token }}
+          reaction: rocket
+
+      - name: Set Commit Status Args
+        id: commit-status-args
+        # We don't want to use history expansion (the '!')
+        shell: bash +H {0}
+        run: |
+          echo 'context=!redeploy Number ${{ needs.defaults.outputs.next-deployment-number }}' >> $GITHUB_OUTPUT
+          echo 'description=Redeploy Prerelease' >> $GITHUB_OUTPUT
+
+      - name: Set Commit Status Pending
+        uses: myrotvorets/set-commit-status-action@3730c0a348a2ace3c110851bed53331bc6406e9f  # v2.0.1
+        with:
+          status: pending
+          sha: ${{ needs.defaults.outputs.head-sha }}
+          context: ${{ steps.commit-status-args.outputs.context }}
+          description: ${{ steps.commit-status-args.outputs.description }}
+
   check-config:
     name: Check Config Fields
+    needs:
+      - defaults
     runs-on: ubuntu-latest
     outputs:
       spack-version: ${{ steps.spack.outputs.version }}
@@ -97,7 +158,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           path: model
-          ref: ${{ inputs.pr }}
+          ref: ${{ needs.defaults.outputs.head-ref }}
 
       - name: Validate ${{ github.repository }} config/versions.json
         uses: access-nri/schema/.github/actions/validate-with-schema@main
@@ -111,14 +172,14 @@ jobs:
         uses: access-nri/build-cd/.github/actions/validate-repo-version@main
         with:
           repo-to-check: spack-packages
-          pr: ${{ inputs.pr }}
+          pr: ${{ needs.defaults.outputs.head-ref }}
 
       - name: Validate spack version
         id: spack
         uses: access-nri/build-cd/.github/actions/validate-repo-version@main
         with:
           repo-to-check: spack
-          pr: ${{ inputs.pr }}
+          pr: ${{ needs.defaults.outputs.head-ref }}
 
       - name: Checkout build-cd Config
         uses: actions/checkout@v4
@@ -160,7 +221,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ref: ${{ inputs.pr }}
+          ref: ${{ needs.defaults.outputs.head-ref }}
 
       - name: Validate ACCESS-NRI spack.yaml Restrictions
         uses: access-nri/schema/.github/actions/validate-with-schema@main
@@ -244,8 +305,6 @@ jobs:
 
       - name: Generate Versions
         id: version
-        env:
-          GH_TOKEN: ${{ github.token }}
         # This step generates the release and prerelease version numbers.
         # The release is a general version number from the spack.yaml, looking the
         # same as a regular release build. Ex. 'access-om2@git.2024.01.1' -> '2024.01.1'
@@ -253,16 +312,7 @@ jobs:
         # Ex. Pull Request #12 with 2 deployments on branch -> `pr12-2`.
         run: |
           echo "release=$(yq '${{ env.SPACK_YAML_MODEL_YQ }} | split("@git.") | .[1]' spack.yaml)" >> $GITHUB_OUTPUT
-
-          # Essentially, count all the deployment entries that match the given branch.
-          # See https://docs.github.com/en/rest/deployments/deployments?apiVersion=2022-11-28#list-deployments
-          next_deployment_number=$(gh api \
-            -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" \
-            --paginate \
-            /repos/${{ github.repository }}/deployments \
-            --jq '[.[] | select(.ref == "${{ needs.defaults.outputs.head-ref }}")] | length + 1'
-          )
-          echo "prerelease=pr${{ inputs.pr }}-${next_deployment_number}" >> $GITHUB_OUTPUT
+          echo "prerelease=pr${{ inputs.pr }}-${{ needs.defaults.outputs.next-deployment-number }}" >> $GITHUB_OUTPUT
 
   # -----------------------------
   # | PRERELEASE DEPLOYMENT JOB |
@@ -282,6 +332,35 @@ jobs:
       version: ${{ needs.check-spack-yaml.outputs.prerelease }}
       root-sbd: ${{ needs.defaults.outputs.root-sbd }}
     secrets: inherit
+
+  redeploy-post:
+    name: '!redeploy Status ${{ needs.prerelease-deploy.result }}'
+    # Always set the commit status after the redeploy job - don't want an always pending status!
+    # successful redeploy = successful commit status
+    # failed, skipped, cancelled redeploy = failure commit status
+    if: always() && needs.redeploy-pre.result == 'success'
+    needs:
+      - defaults  # to get access to the head-sha
+      - redeploy-pre  # to get the initial commit status context and description
+      - prerelease-deploy  # to get the overall status of this workflow
+    runs-on: ubuntu-latest
+    permissions:
+      statuses: write  # so we can set the commit status!
+      pull-requests: write  # so we can react to the comment
+    steps:
+      - name: React to Comment
+        uses: access-nri/actions/.github/actions/react-to-comment@main
+        with:
+          token: ${{ github.token }}
+          reaction: ${{ needs.prerelease-deploy.result == 'success' && '+1' || '-1' }}
+
+      - name: Set commit status from workflow ${{ needs.prerelease-deploy.result }}
+        uses: myrotvorets/set-commit-status-action@3730c0a348a2ace3c110851bed53331bc6406e9f  # v2.0.1
+        with:
+          status: ${{ needs.prerelease-deploy.result == 'success' && 'success' || 'failure' }}
+          sha: ${{ needs.defaults.outputs.head-sha }}
+          context: ${{ needs.redeploy-pre.outputs.commit-status-context }}
+          description: ${{ needs.redeploy-pre.outputs.commit-status-description }}
 
   notifier:
     name: Notifier

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,11 +127,23 @@ jobs:
       # String to describe the overall check
       commit-status-description: ${{ steps.commit-status-args.outputs.description }}
     steps:
+      - name: Check commenter permissions
+        id: commenter
+        uses: access-nri/actions/.github/actions/commenter-permission-check@main
+        with:
+          minimum-permission: write
+
       - name: React to Comment
         uses: access-nri/actions/.github/actions/react-to-comment@main
         with:
           token: ${{ github.token }}
-          reaction: rocket
+          reaction: ${{ steps.commenter.outputs.has-permission == 'true' && 'rocket' || '-1' }}
+
+      - name: Exit if no write permissions
+        if: steps.commenter.outputs.has-permission == 'false'
+        run: |
+          echo "User ${{ github.event.comment.user.login }} doesn't have 'write' permission on ${{ github.repository }}, not allowing deployment"
+          exit 1
 
       - name: Set Commit Status Args
         id: commit-status-args

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,6 +95,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           path: model
+          ref: ${{ inputs.pr }}
 
       - name: Validate ${{ github.repository }} config/versions.json
         uses: access-nri/schema/.github/actions/validate-with-schema@main
@@ -155,6 +156,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          ref: ${{ inputs.pr }}
 
       - name: Validate ACCESS-NRI spack.yaml Restrictions
         uses: access-nri/schema/.github/actions/validate-with-schema@main
@@ -166,17 +168,17 @@ jobs:
       - name: Check Model Version Modified
         id: version-modified
         run: |
-          git checkout ${{ github.base_ref }}
+          git checkout ${{ needs.defaults.outputs.base-ref }}
 
           if [ ! -f spack.yaml ]; then
-            echo "::notice::There is no previous version of the spack.yaml to check, continuing..."
-            git checkout ${{ github.head_ref }}
+            echo "::notice::There is no previous version of the spack.yaml to check at ${{ needs.defaults.outputs.base-ref }}, continuing..."
+            git checkout ${{ needs.defaults.outputs.head-ref }}
             exit 0
           fi
 
           base_version=$(yq e '${{ env.SPACK_YAML_MODEL_YQ }}' spack.yaml)
 
-          git checkout ${{ github.head_ref }}
+          git checkout ${{ needs.defaults.outputs.head-ref }}
           current_version=$(yq e '${{ env.SPACK_YAML_MODEL_YQ }}' spack.yaml)
           echo "current=${current_version}" >> $GITHUB_OUTPUT
 
@@ -189,6 +191,7 @@ jobs:
         if: failure() && steps.version-modified.outcome == 'failure'
         uses: access-nri/actions/.github/actions/pr-comment@main
         with:
+          pr: ${{ inputs.pr }}
           comment: |
             The model version in the `spack.yaml` has not been updated.
             Either update it manually, or comment the following to have it updated and committed automatically:
@@ -253,9 +256,9 @@ jobs:
             -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" \
             --paginate \
             /repos/${{ github.repository }}/deployments \
-            --jq '[.[] | select(.ref == "${{ github.head_ref }}")] | length + 1'
+            --jq '[.[] | select(.ref == "${{ needs.defaults.outputs.head-ref }}")] | length + 1'
           )
-          echo "prerelease=pr${{ github.event.pull_request.number }}-${next_deployment_number}" >> $GITHUB_OUTPUT
+          echo "prerelease=pr${{ inputs.pr }}-${next_deployment_number}" >> $GITHUB_OUTPUT
 
   # -----------------------------
   # | PRERELEASE DEPLOYMENT JOB |
@@ -271,7 +274,7 @@ jobs:
     uses: access-nri/build-cd/.github/workflows/deploy-1-setup.yml@main
     with:
       type: prerelease
-      ref: ${{ github.head_ref }}
+      ref: ${{ needs.defaults.outputs.head-ref }}
       version: ${{ needs.check-spack-yaml.outputs.prerelease }}
       root-sbd: ${{ needs.defaults.outputs.root-sbd }}
     secrets: inherit
@@ -290,8 +293,9 @@ jobs:
         id: comment
         uses: access-nri/actions/.github/actions/pr-comment@main
         with:
+          pr: ${{ inputs.pr }}
           comment: |
-            :rocket: Deploying ${{ inputs.model }} `${{ needs.check-spack-yaml.outputs.release }}` as prerelease `${{ needs.check-spack-yaml.outputs.prerelease }}` with commit ${{ github.event.pull_request.head.sha }}
+            :rocket: Deploying ${{ inputs.model }} `${{ needs.check-spack-yaml.outputs.release }}` as prerelease `${{ needs.check-spack-yaml.outputs.prerelease }}` with commit ${{ needs.defaults.outputs.head-sha }}
             ${{ needs.check-config.outputs.config-settings-failures != '' && ':warning:There are issues with the `build-cd` deployment configuration. If this is unexpected, let @ACCESS-NRI/model-release know.' || '' }}
             <details>
             <summary>Details and usage instructions</summary>
@@ -329,7 +333,7 @@ jobs:
           PRERELEASE_SECTION_REGEX: "^:rocket: .* :rocket:$"
           PRERELEASE_SECTION: ":rocket: The latest prerelease `${{ needs.defaults.outputs.root-sbd }}/${{ needs.check-spack-yaml.outputs.prerelease }}` is here: ${{ steps.comment.outputs.comment-link }} :rocket:"
         run: |
-          gh pr view ${{ github.event.pull_request.number }} --repo ${{ github.repository }} --json body --jq .body > ${{ env.PR_BODY_PATH }}
+          gh pr view ${{ inputs.pr }} --repo ${{ github.repository }} --json body --jq .body > ${{ env.PR_BODY_PATH }}
 
           # `awk` is a series of `CONDITION { ACTION }` pairs. No 'CONDITION' means 'TRUE', no '{ ACTION }' means 'print'.
           if grep -q '${{ env.PRERELEASE_SECTION_REGEX }}' ${{ env.PR_BODY_PATH }}; then  # there is an existing prerelease section
@@ -345,4 +349,4 @@ jobs:
 
           cat ${{ env.PR_BODY_PATH_UPDATED }}
 
-          gh pr edit ${{ github.event.pull_request.number }} --repo ${{ github.repository }} --body-file ${{ env.PR_BODY_PATH_UPDATED }}
+          gh pr edit ${{ inputs.pr }} --repo ${{ github.repository }} --body-file ${{ env.PR_BODY_PATH_UPDATED }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -270,7 +270,7 @@ jobs:
             module load ${{ needs.defaults.outputs.root-sbd }}/${{ needs.check-spack-yaml.outputs.prerelease }}
             ```
             where the binaries shall be on your `$PATH`.
-            This Prerelease is also accessible on Gadi via `/g/data/vk83/prerelease/apps/spack/${{ needs.check-config.outputs.spack-version }}/spack` in the `${{ needs.defaults.outputs.root-sbd }}-${{ needs.version.outputs.prerelease }}` environment.
+            This Prerelease is also accessible on Gadi via `/g/data/vk83/prerelease/apps/spack/${{ needs.check-config.outputs.spack-version }}/spack` in the `${{ needs.defaults.outputs.root-sbd }}-${{ needs.check-spack-yaml.outputs.prerelease }}` environment.
             </details>
 
             :hammer_and_wrench: Using: spack `${{ needs.check-config.outputs.spack-version }}`, spack-packages `${{ needs.check-config.outputs.spack-packages-version}}`, spack-config `${{ needs.check-config.outputs.spack-config-version }}`


### PR DESCRIPTION
## Background

See https://github.com/ACCESS-NRI/model-deployment-template/pull/9#discussion_r1853234344 - instructions for people to add empty commits to redeploy their model is a bit fiddly. So, create a ChatOps command to redeploy, instead. 

The majority of this PR is updating the `ci.yml` job to handle an explicit `inputs.pr` rather than inferring from `github.event.pull_request`/`github.[head|base]_ref`, since we now offer two entrypoints into `ci.yml` - `on.pull_request`, and `on.issue_comment` (specifically, commenting `!redeploy`). 

We also have `redeploy-pre`/`redeploy-post` jobs added when the trigger is a `!redeploy` comment, in which we set the HEAD commit status to pending, run the rest of the `ci.yml`, then update the HEAD commit again based on the prerelease deployment status.

In this PR:
- `ci.yml`
  - Updated deployment comment prerelease version templating, references #146
  - Added new required input `pr`, set pr metadata in `defaults`  and clone all repos at `inputs.pr`, replace all `github.*` contexts with `inputs.pr`/`needs.default.outputs.*`
  - Add `redeploy-pre` and `redeploy-post` jobs that handle commit status updates on `!redeploy`
- `validate-repo-version` action: Added new required input `pr`, updated references in `ci.yml`

## Requirements for Model Deployment Repositories

Before merge, there must be updates to deployment repositories like so:

```diff
 jobs:
   pr-ci:
     name: CI
-    if: github.event_name == 'pull_request' && github.event.action != 'closed'
+    if: >-
+      (github.event_name == 'pull_request' && github.event.action != 'closed') ||
+      (github.event_name == 'issue_comment' && startsWith(github.event.comment.body, '!redeploy'))
     uses: access-nri/build-cd/.github/workflows/ci.yml@main
     with:
       model: ${{ vars.NAME }}
       # root-sbd: if different from vars.NAME
+      pr: ${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.event.issue.number }}
     permissions:
       pull-requests: write
       contents: write
+      statuses: write
     secrets: inherit
 
   pr-comment:
     name: Comment
-    if: github.event_name == 'issue_comment'
+    if: github.event_name == 'issue_comment' && startsWith(github.event.comment.body, '!bump') 
     uses: access-nri/build-cd/.github/workflows/ci-comment.yml@main
     with:
       model: ${{ vars.NAME }}
       # root-sbd: if different from vars.NAME
```

## Testing

- The majority of testing was done in this PR: https://github.com/ACCESS-NRI/ACCESS-TEST/pull/7 - note the successes at the end!
- All `gh` commands were tested locally

-----

Closes #173
Closes #146
