### PR TITLE
Return All Deployment Results

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -213,6 +213,7 @@ jobs:
           # See https://docs.github.com/en/rest/deployments/deployments?apiVersion=2022-11-28#list-deployments
           next_deployment_number=$(gh api \
             -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" \
+            --paginate \
             /repos/${{ github.repository }}/deployments \
             --jq '[.[] | select(.ref == "${{ github.head_ref }}")] | length + 1'
           )


### PR DESCRIPTION
See equal deployment numbers https://github.com/ACCESS-NRI/ACCESS-ESM1.6/pull/10#issuecomment-2499625946 and https://github.com/ACCESS-NRI/ACCESS-ESM1.6/pull/10#issuecomment-2499635474. 

This is due to the default pagination in `gh api` calls to be 30 per page, and only the first page. So as deployments are made in this branch, some are evicted to the second page. 

This PR adds the `--paginate` flag to the `gh api` call, which attempts to return all the results. 
