### PR TITLE
Update Prerelease 0.22 spack-config to 2024.11.27

### DIFF
--- a/config/settings.json
+++ b/config/settings.json
@@ -15,7 +15,7 @@
       "Prerelease": {
         "0.22": {
           "spack": "21da7d7e2b5e2680cd9d2e0a2fb4a7d13d8baa9d",
-          "spack-config": "2024.11.11"
+          "spack-config": "2024.11.27"
         }
       }
     }


### PR DESCRIPTION
In this PR:
* Update the `spack-config` for `Prerelease 0.22` to [`2024.11.27`](https://github.com/ACCESS-NRI/spack-config/releases/tag/2024.11.27)
