### PR TITLE
`gh pr edit` the right `--body-file` for PR Prerelease Description

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -305,4 +305,6 @@ jobs:
             awk '1; END {print "\n---\n${{ env.PRERELEASE_SECTION }}"}' ${{ env.PR_BODY_PATH }} > ${{ env.PR_BODY_PATH_UPDATED }}
           fi
 
-          gh pr edit ${{ github.event.pull_request.number }} --repo ${{ github.repository }} --body-file ${{ env.PR_BODY_PATH }}
+          cat ${{ env.PR_BODY_PATH_UPDATED }}
+
+          gh pr edit ${{ github.event.pull_request.number }} --repo ${{ github.repository }} --body-file ${{ env.PR_BODY_PATH_UPDATED }}


### PR DESCRIPTION
See strange PR description: https://github.com/ACCESS-NRI/ACCESS-ESM1.6/pull/11#issue-2674047568

In this PR:
* Update the PR description with the updated body file, rather than the original one!
