### PR TITLE
Update Projection Check to Allow Variants

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,7 +175,9 @@ jobs:
           for DEP in $DEPS; do
             DEP_VER=''
             if [[ "$DEP" == "${{ needs.defaults.outputs.root-sbd }}" ]]; then
-              DEP_VER=$(yq '.spack.specs[0] | split("@git.") | .[1]' spack.yaml)
+              # The model version is the bit after '@git.', before any later, space-separated, optional variants.
+              # For example, in 'MODEL@git.VERSION type=ACCESS ~debug' the version is 'VERSION'.
+              DEP_VER=$(yq '.spack.specs[0] | capture(".+@git\.(?<version>[^ ]+).*") | .version' spack.yaml)
             else
               # Capture the section after '@git.' or '@' (if it's not a git-attributed version) and before a possible '=' for a given dependency.
               # Ex. '@git.2024.02.11' -> '2024.02.11', '@access-esm1.5' -> 'access-esm1.5', '@git.2024.05.21=access-esm1.5' -> '2024.05.21'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -177,7 +177,7 @@ jobs:
             if [[ "$DEP" == "${{ needs.defaults.outputs.root-sbd }}" ]]; then
               # The model version is the bit after '@git.', before any later, space-separated, optional variants.
               # For example, in 'MODEL@git.VERSION type=ACCESS ~debug' the version is 'VERSION'.
-              DEP_VER=$(yq '.spack.specs[0] | capture(".+@git\.(?<version>[^ ]+).*") | .version' spack.yaml)
+              DEP_VER=$(yq '.spack.specs[0] | capture(".+@git\\.(?<version>[^ ]+).*") | .version' spack.yaml)
             else
               # Capture the section after '@git.' or '@' (if it's not a git-attributed version) and before a possible '=' for a given dependency.
               # Ex. '@git.2024.02.11' -> '2024.02.11', '@access-esm1.5' -> 'access-esm1.5', '@git.2024.05.21=access-esm1.5' -> '2024.05.21'


### PR DESCRIPTION
## Background

In this PR:

* Update the model projection version check so it can ignore later, optional, space-separated variants in the `spack.specs` string. We use a regex capture group because they can do more than a `split` function. 

For example, given the `spack.yaml`s `spack.spec[0]` being `MODEL@git.VERSION type=thingo +variant1 ~debug` or `MODEL@git.VERSION`, both versions will be `VERSION`. 

## Testing

To test this regex, I validated it using regex101: https://regex101.com/r/cbQMyG/1.
I also validated it against ACCESS-OM2's `spack.yaml`. 

References #180
