### PR TITLE
Deployment Number Pagination Fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,7 +109,10 @@ jobs:
             --json comments \
             --jq '[.comments[] | select(.body | startswith("!redeploy"))] | length'
           )
-          next_deployment_number=$((pr_deployments + comment_deployments + 1))
+          # Since the number of $pr_deployments do not include the current deployment (yet),
+          # but $comment_deployments do, we need to increment the next deployment number by one if it is a pr deployment.
+          next_deployment_is_pr_deployment=${{ github.event_name == 'pull_request' && '1' || '0' }}
+          next_deployment_number=$((pr_deployments + comment_deployments + next_deployment_is_pr_deployment))
           echo "Next Deployment Number is $next_deployment_number"
           echo "next-deployment-number=$next_deployment_number" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,7 +113,7 @@ jobs:
           # but $comment_deployments do, we need to increment the next deployment number by one if it is a pr deployment.
           next_deployment_is_pr_deployment=${{ github.event_name == 'pull_request' && '1' || '0' }}
           next_deployment_number=$((pr_deployments + comment_deployments + next_deployment_is_pr_deployment))
-          echo "Next Deployment Number is $next_deployment_number"
+          echo "Next Deployment Number is $pr_deployments + $comment_deployments + $next_deployment_is_pr_deployment = $next_deployment_number"
           echo "next-deployment-number=$next_deployment_number" >> $GITHUB_OUTPUT
 
   redeploy-pre:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,11 +98,12 @@ jobs:
         # all the `!redeploy` comments, to get the next deployment number.
         # See https://docs.github.com/en/rest/deployments/deployments?apiVersion=2022-11-28#list-deployments
         run: |
+          # We --slurp the results because --paginate introduces potentially multiple array results
           pr_deployments=$(gh api \
-            -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" \
-            --paginate \
-            /repos/${{ github.repository }}/deployments \
-            --jq '[.[] | select(.ref == "${{ steps.pr.outputs.head }}")] | length'
+              -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" \
+              --paginate --slurp \
+              /repos/${{ github.repository }}/deployments \
+            | jq '[select(.[][].ref == "${{ steps.pr.outputs.head }}")] | length'
           )
           comment_deployments=$(gh pr view ${{ inputs.pr }} --repo ${{ github.repository }} \
             --json comments \
@@ -132,7 +133,7 @@ jobs:
         uses: access-nri/actions/.github/actions/commenter-permission-check@main
         with:
           # This means that commenters who use `!redeploy` must have at least `write` perms
-          # in the repository. `write` is probably the best fit. 
+          # in the repository. `write` is probably the best fit.
           minimum-permission: write
 
       - name: React to Comment


### PR DESCRIPTION
## Background

Due to `gh api --paginate` returning multiple arrays of pages of results for much-deployed-to repositories, we need a way to add the pages of deployments together to get correct results. 
First, we `--slurp` the results (put each 'page' into an array), then we call `jq` explicitly (since we can't use the `--jq` flag with `--slurp` for some reason), and then do a much-the-same filter (but one level deeper) to find the number of deployments to a given branch. 

Furthermore, we also do a quick fix to the way the deployment numbers are calculated. Because the number of `$pr_deployment` events only account for previous deployments (not the currently deploying one!) and the number of `$comment_deployments` account for all previous AND the current one, we only need to add one to the next deployment number if the next deployment is a traditional, pr-based one. Capiche?

In this PR:
* We fix the `$deployment_number` when the `gh api` results are paginated. 
* We also fix an issue with the deployment numbers incrementing incorrectly, see example: https://github.com/ACCESS-NRI/ACCESS-TEST/pull/10#issuecomment-2530528914

## Testing 

Done in https://github.com/ACCESS-NRI/ACCESS-TEST/pull/10 - note the multiple successful deployment numbers

Closes #187
