### PR TITLE
Only do Deployment Version Checks if PR is not a Draft

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -255,6 +255,13 @@ jobs:
           data-location: ./spack.yaml
 
       - name: Check Model Version Modified
+        # We don't want to fire off model deployment version checks if the PR is never going to be merged.
+        # We determine this by checking if either the pull request, or the pull request that a comment
+        # belongs to, is drafted.
+        # Yes, github.event.issue.draft refers to the pull request if the comment is made on a pull request!
+        if: >-
+          (github.event_name == 'pull_request' && !github.event.pull_request.draft) ||
+          (github.event_name == 'issue_comment' && !github.event.issue.draft)
         id: version-modified
         run: |
           git checkout ${{ needs.defaults.outputs.base-ref }}


### PR DESCRIPTION
In this PR:
* Add a fairly basic condition that we should only bother with checking that the overall model version is bumped if it is not a draft. 

Note that there is a small hole with this approach - if a PR is drafted, but undrafted after the final commit before a merge, the model version check will not have fired, and the PR could be erroneously merged with the same version. Luckily, the Release CD will pick up on this and fail, which means one just has to reopen the PR, and reset the `main` branch. If a better solution is sought, I can create an issue. 

Closes #190 
