### PR TITLE
`!bump` comment command fix

### DIFF
--- a/.github/workflows/ci-comment.yml
+++ b/.github/workflows/ci-comment.yml
@@ -2,6 +2,7 @@ name: Comment Command
 run-name: ${{ inputs.model }} Comment Command
 # NOTE: This workflow requires:
 # permissions.contents:write
+# permissions.pull-requests:write
 on:
   workflow_call:
     inputs:
@@ -12,7 +13,7 @@ on:
       root-sbd:
         type: string
         required: false
-        default: ${{ inputs.model }}
+        # default: ${{ inputs.model }}
         description: |
           The name of the root Spack Bundle Definition, if it is different from the model name.
           This is often a package named similarly in ACCESS-NRI/spack-packages.
@@ -26,12 +27,31 @@ env:
   SPACK_YAML_MODEL_YQ: .spack.specs[0]
   SPACK_YAML_MODEL_PROJECTION_YQ: .spack.modules.default.tcl.projections.${{ inputs.root-sbd }}
 jobs:
+  defaults:
+    name: Set Defaults
+    # Unfortunately, you can't set a dynamic default value based on `inputs` yet.
+    runs-on: ubuntu-latest
+    outputs:
+      root-sbd: ${{ steps.root-sbd.outputs.default }}
+    steps:
+      - name: root-sbd default
+        id: root-sbd
+        run: |
+          if [[ "${{ inputs.root-sbd }}" == "" ]]; then
+            echo "default=${{ inputs.model }}" >> $GITHUB_OUTPUT
+          else
+            echo "default=${{ inputs.root-sbd }}" >> $GITHUB_OUTPUT
+          fi
+
   bump-version:
     name: Bump spack.yaml
     if: github.event.issue.pull_request && startsWith(github.event.comment.body, '!bump')
+    needs:
+      - defaults
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
+      contents: write
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
@@ -48,7 +68,7 @@ jobs:
         #   version: The version that will be bumped (could be latest tag instead of original-version)
         #   bump: The bump type (major, minor or current as specified in the bump-version action)
         run: |
-          # Get the version of ${{ inputs.root-sbd }} from the spack.yaml in the PR the comment was written in
+          # Get the version of ${{ needs.defaults.outputs.root-sbd }} from the spack.yaml in the PR the comment was written in
           gh pr checkout ${{ github.event.issue.number }}
           original_version=$(yq e '${{ env.SPACK_YAML_MODEL_YQ }} | split("@git.") | .[1]' spack.yaml)
           echo "original-version=${original_version}" >> $GITHUB_OUTPUT
@@ -105,10 +125,10 @@ jobs:
 
       - name: Update, Commit and Push the Bump
         run: |
-          yq -i '${{ env.SPACK_YAML_MODEL_YQ }} = "${{ inputs.root-sbd }}@git.${{ steps.bump.outputs.after }}"' spack.yaml
+          yq -i '${{ env.SPACK_YAML_MODEL_YQ }} = "${{ needs.defaults.outputs.root-sbd }}@git.${{ steps.bump.outputs.after }}"' spack.yaml
           yq -i '${{ env.SPACK_YAML_MODEL_PROJECTION_YQ }} = "{name}/${{ steps.bump.outputs.after }}"' spack.yaml
           git add spack.yaml
-          git commit -m "spack.yaml: Updated ${{ inputs.root-sbd }} package version from ${{ steps.setup.outputs.original-version }} to ${{ steps.bump.outputs.after }}"
+          git commit -m "spack.yaml: Updated ${{ needs.defaults.outputs.root-sbd }} package version from ${{ steps.setup.outputs.original-version }} to ${{ steps.bump.outputs.after }}"
           git push
 
       - name: Success Notifier

--- a/.github/workflows/ci-comment.yml
+++ b/.github/workflows/ci-comment.yml
@@ -13,6 +13,7 @@ on:
       root-sbd:
         type: string
         required: false
+        # The equivalent default is set in the defaults job below. 
         # default: ${{ inputs.model }}
         description: |
           The name of the root Spack Bundle Definition, if it is different from the model name.

--- a/.github/workflows/ci-comment.yml
+++ b/.github/workflows/ci-comment.yml
@@ -24,8 +24,6 @@ on:
   #     - edited
 env:
   RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-  SPACK_YAML_MODEL_YQ: .spack.specs[0]
-  SPACK_YAML_MODEL_PROJECTION_YQ: .spack.modules.default.tcl.projections.${{ inputs.root-sbd }}
 jobs:
   defaults:
     name: Set Defaults
@@ -54,6 +52,8 @@ jobs:
       contents: write
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      SPACK_YAML_MODEL_YQ: .spack.specs[0]
+      SPACK_YAML_MODEL_PROJECTION_YQ: .spack.modules.default.tcl.projections.${{ needs.defaults.outputs.root-sbd }}
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## Background
> [!IMPORTANT]
> This is a major-level change to `build-cd`, as it requires changes to Model Deployment Repositories CI/CD. This means that this PR must be merged into a new `v3` branch, and `v3` will become the new default branch. 

The majority of this issue comes down to a token mismatch (which isn't visible in this PR), and the fact that I'd missed a place where I'd set `root-sbd.default: inputs.model`, which is invalid in GitHub Actions. 

Furthermore, I'd failed to do `secrets.inherit` in the calling workflows, which is why this is a major update. 

## Testing

Testing took place in https://github.com/ACCESS-NRI/ACCESS-TEST/pull/11 - note the successful bump, as well as the deployment created after the bump!

In this PR:
- **ci-comment.yml: Set default root-sbd, update permissions**
- **ci-comment.yml: Made env vars set after defaults job completes**

References #109
