### PR TITLE
settings.json: Update Release 0.22 spack-config to 2024.11.27

### DIFF
--- a/config/settings.json
+++ b/config/settings.json
@@ -9,7 +9,7 @@
         },
         "0.22": {
           "spack": "21da7d7e2b5e2680cd9d2e0a2fb4a7d13d8baa9d",
-          "spack-config": "2024.07.05"
+          "spack-config": "2024.11.27"
         }
       },
       "Prerelease": {


### PR DESCRIPTION
In this PR:
* Update `Release 0.22 spack-config` to be the same as `Prerelease 0.22 spack-config` - `2024.11.27`. This is to update the `$SPACK_USER_CACHE_PATH` (including the environments folders to be at the root of the installation. 

References #195
