### PR TITLE
Move jobs around so they can be part of a single parallel workflow

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -35,6 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       root-sbd: ${{ steps.root-sbd.outputs.default }}
+      targets: ${{ steps.target.outputs.matrix }}
     steps:
       - name: root-sbd
         id: root-sbd
@@ -45,9 +46,27 @@ jobs:
             echo "default=${{ inputs.root-sbd }}" >> $GITHUB_OUTPUT
           fi
 
+      - name: Get deployment settings.json
+        uses: actions/checkout@v4
+        with:
+          repository: access-nri/build-cd
+          ref: main
+
+      - name: Generate Deployment Target Matrix
+        id: target
+        run: |
+          targets=$(jq --compact-output '.deployments' config/settings.json)
+          echo "$targets"
+          echo "targets=$targets" >> $GITHUB_OUTPUT
+
   verify-settings:
     name: Verify Deployment Settings
     runs-on: ubuntu-latest
+    needs:
+      - defaults
+    strategy:
+      matrix:
+        target: ${{ fromJson(needs.defaults.outputs.targets) }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -57,8 +76,7 @@ jobs:
       - uses: access-nri/build-cd/.github/actions/validate-deployment-settings@main
         with:
           settings-path: ./config/settings.json
-          # TODO: Turn this into a matrix job of targets
-          target: Gadi
+          target: ${{ matrix.target }}
           error-level: error
 
   push-tag:
@@ -103,11 +121,17 @@ jobs:
     needs:
       - defaults
       - push-tag
+    strategy:
+      matrix:
+        target: ${{ fromJson(needs.defaults.outputs.targets) }}
     uses: access-nri/build-cd/.github/workflows/deploy-1-setup.yml@main
     with:
-      ref: ${{ github.ref_name }}
-      version: ${{ needs.push-tag.outputs.name }}
-      root-sbd: ${{ needs.defaults.outputs.root-sbd }}
+      deployment-target: ${{ matrix.target }}
+      deployment-ref: ${{ github.ref_name }}
+      deployment-type: Release
+      deployment-version: ${{ needs.push-tag.outputs.name }}
+      spack-manifest-path: ./spack.yaml
+      spack-manifest-root-sbd: ${{ needs.defaults.outputs.root-sbd }}
     secrets: inherit
     permissions:
       contents: write

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Generate Deployment Target Matrix
         id: target
         run: |
-          targets=$(jq --compact-output '.deployments' config/settings.json)
+          targets=$(jq --compact-output --raw-output '.deployment | keys' config/settings.json)
           echo "$targets"
           echo "targets=$targets" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -319,6 +319,7 @@ jobs:
             echo "" >> $GITHUB_OUTPUT
             echo "If the above was not expected, please commit changes to \`config/versions.json\`." >> $GITHUB_OUTPUT
             echo "</details>" >> $GITHUB_OUTPUT
+            echo "" >> $GITHUB_OUTPUT
           done
 
           echo "EOF" >> $GITHUB_OUTPUT

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,201 +167,27 @@ jobs:
           context: ${{ steps.commit-status-args.outputs.context }}
           description: ${{ steps.commit-status-args.outputs.description }}
 
-  check-config:
-    name: Check Config Fields
+  deploy:
+    name: Deploy
     needs:
       - defaults
-    runs-on: ubuntu-latest
-    outputs:
-      spack-version: ${{ steps.spack.outputs.version }}
-      spack-packages-version: ${{ steps.spack-packages.outputs.version }}
-      spack-config-version:  ${{ steps.spack-config.outputs.version }}
-      config-settings-failures: ${{ steps.settings.outputs.failures }}
-    steps:
-      - name: Checkout ${{ github.repository }} Config
-        uses: actions/checkout@v4
-        with:
-          path: model
-          ref: ${{ needs.defaults.outputs.head-ref }}
-
-      - name: Validate ${{ github.repository }} config/versions.json
-        uses: access-nri/schema/.github/actions/validate-with-schema@main
-        with:
-          schema-version: ${{ vars.CONFIG_VERSIONS_SCHEMA_VERSION }}
-          schema-location: au.org.access-nri/model/deployment/config/versions
-          data-location: ./model/config/versions.json
-
-      - name: Validate spack-packages version
-        id: spack-packages
-        uses: access-nri/build-cd/.github/actions/validate-repo-version@main
-        with:
-          repo-to-check: spack-packages
-          pr: ${{ needs.defaults.outputs.head-ref }}
-
-      - name: Validate spack version
-        id: spack
-        uses: access-nri/build-cd/.github/actions/validate-repo-version@main
-        with:
-          repo-to-check: spack
-          pr: ${{ needs.defaults.outputs.head-ref }}
-
-      - name: Checkout build-cd Config
-        uses: actions/checkout@v4
-        with:
-          repository: ACCESS-NRI/build-cd
-          ref: main
-          path: cd
-
-      - name: Get spack-config version
-        id: spack-config
-        # TODO: For future targets, we need to know which target we are using by this point
-        run: |
-          version=$(jq --compact-output --raw-output \
-            --arg spack_version "${{ steps.spack.outputs.version }}" \
-            '.deployment.Gadi.Prerelease[$spack_version]."spack-config"' cd/config/settings.json
-          )
-          echo $version
-          echo "version=$version" >> $GITHUB_OUTPUT
-
-      - name: Validate build-cd config/settings.json
-        id: settings
-        uses: access-nri/build-cd/.github/actions/validate-deployment-settings@main
-        with:
-          settings-path: ./cd/config/settings.json
-          # TODO: Turn this into a matrix job of targets
-          target: Gadi
-
-  check-spack-yaml:
-    name: Check spack.yaml
-    runs-on: ubuntu-latest
-    needs:
-      - defaults
-    permissions:
-      pull-requests: write
-    outputs:
-      release: ${{ steps.version.outputs.release }}
-      prerelease: ${{ steps.version.outputs.prerelease }}
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          ref: ${{ needs.defaults.outputs.head-ref }}
-
-      - name: Validate ACCESS-NRI spack.yaml Restrictions
-        uses: access-nri/schema/.github/actions/validate-with-schema@main
-        with:
-          schema-version: ${{ vars.SPACK_YAML_SCHEMA_VERSION }}
-          schema-location: au.org.access-nri/model/spack/environment/deployment
-          data-location: ./spack.yaml
-
-      - name: Check Model Version Modified
-        # We don't want to fire off model deployment version checks if the PR is never going to be merged.
-        # We determine this by checking if either the pull request, or the pull request that a comment
-        # belongs to, is drafted.
-        # Yes, github.event.issue.draft refers to the pull request if the comment is made on a pull request!
-        if: >-
-          (github.event_name == 'pull_request' && !github.event.pull_request.draft) ||
-          (github.event_name == 'issue_comment' && !github.event.issue.draft)
-        id: version-modified
-        run: |
-          git checkout ${{ needs.defaults.outputs.base-ref }}
-
-          if [ ! -f spack.yaml ]; then
-            echo "::notice::There is no previous version of the spack.yaml to check at ${{ needs.defaults.outputs.base-ref }}, continuing..."
-            git checkout ${{ needs.defaults.outputs.head-ref }}
-            exit 0
-          fi
-
-          base_version=$(yq e '${{ env.SPACK_YAML_MODEL_YQ }}' spack.yaml)
-
-          git checkout ${{ needs.defaults.outputs.head-ref }}
-          current_version=$(yq e '${{ env.SPACK_YAML_MODEL_YQ }}' spack.yaml)
-          echo "current=${current_version}" >> $GITHUB_OUTPUT
-
-          if [[ "${base_version}" == "${current_version}" ]]; then
-            echo "::warning::The version string hasn't been modified in this PR, but needs to be before merging."
-            exit 1
-          fi
-
-      - name: Same Model Version Failure Notifier
-        if: failure() && steps.version-modified.outcome == 'failure'
-        uses: access-nri/actions/.github/actions/pr-comment@main
-        with:
-          pr: ${{ inputs.pr }}
-          comment: |
-            The model version in the `spack.yaml` has not been updated.
-            Either update it manually, or comment the following to have it updated and committed automatically:
-            * `!bump major` for feature releases
-            * `!bump minor` for bugfixes
-
-      - name: Projection Version Matches
-        # this step checks that the versions of the packages themselves match with the
-        #  names of the projections, if they're given.
-        # For example, access-om3@git.2023.12.12 matches with the
-        #  modulefile access-om3/2023.12.12 (specifically, the version strings match)
-        # TODO: Move this into the `scripts` directory - it's getting unweildly.
-        run: |
-          FAILED="false"
-
-          # Get all the defined projections (minus 'all') and make them suitable for a bash for loop
-          DEPS=$(yq '.spack.modules.default.tcl.projections | del(.all) | keys | join(" ")' spack.yaml)
-
-          # for each of the modules
-          for DEP in $DEPS; do
-            DEP_VER=''
-            if [[ "$DEP" == "${{ needs.defaults.outputs.root-sbd }}" ]]; then
-              # The model version is the bit after '@git.', before any later, space-separated, optional variants.
-              # For example, in 'MODEL@git.VERSION type=ACCESS ~debug' the version is 'VERSION'.
-              DEP_VER=$(yq '.spack.specs[0] | capture(".+@git\\.(?<version>[^ ]+).*") | .version' spack.yaml)
-            else
-              # Capture the section after '@git.' or '@' (if it's not a git-attributed version) and before a possible '=' for a given dependency.
-              # Ex. '@git.2024.02.11' -> '2024.02.11', '@access-esm1.5' -> 'access-esm1.5', '@git.2024.05.21=access-esm1.5' -> '2024.05.21'
-              DEP_VER=$(yq ".spack.packages.\"$DEP\".require[0] | match(\"^@(?:git.)?([^=]*)\").captures[0].string" spack.yaml)
-            fi
-
-            # Get the version from the module projection, for comparison with DEP_VER
-            # Projections are of the form '{name}/VERSION[-{hash:7}]', in which we only care about VERSION. For example, '{name}/2024.11.11', or '{name}/2024.11.11-{hash:7}'
-            MODULE_NAME=$(yq ".spack.modules.default.tcl.projections.\"$DEP\"" spack.yaml)
-            MODULE_VER="${MODULE_NAME#*/}"  # Strip '{name}/' from '{name}/VERSION' module, even if VERSION contains '/'
-            MODULE_VER="${MODULE_VER%%-\{hash:7\}}"  # Strip a potential '-{hash:7}' appendix from the VERSION, since we won't have that in the DEP_VER
-
-            if [[ "$DEP_VER" != "$MODULE_VER" ]]; then
-              echo "::error::$DEP: Version of dependency and projection do not match ($DEP_VER != $MODULE_VER)"
-              FAILED='true'
-            fi
-          done
-          if [[ "$FAILED" == "true" ]]; then
-            exit 1
-          fi
-
-      - name: Generate Versions
-        id: version
-        # This step generates the release and prerelease version numbers.
-        # The release is a general version number from the spack.yaml, looking the
-        # same as a regular release build, without optional variants. Ex. 'access-om2@git.2024.01.1 ~debug' -> '2024.01.1'
-        # The prerelease looks like: `pr<pull request number>-<number of deployments of pull request>`.
-        # Ex. Pull Request #12 with 2 deployments on branch -> `pr12-2`.
-        run: |
-          echo "release=$(yq '${{ env.SPACK_YAML_MODEL_YQ }} | capture("@git\.(?<version>[^ ~+]+)") | .version' spack.yaml)" >> $GITHUB_OUTPUT
-          echo "prerelease=pr${{ inputs.pr }}-${{ needs.defaults.outputs.next-deployment-number }}" >> $GITHUB_OUTPUT
-
-  # -----------------------------
-  # | PRERELEASE DEPLOYMENT JOB |
-  # -----------------------------
-  prerelease-deploy:
-    name: Deploy to Prerelease
-    # This will create a `spack` environment with the name `<model>-pr<pull request number>-<deployment number>`.
-    # For example, `access-om3-pr13-3` for the third deployment on the PR#13.
-    needs:
-      - defaults  # so we can access `inputs.root-sbd` that could have defaulted to `inputs.model`
-      - check-spack-yaml  # implies all the spack.yaml-related checks have passed, has appropriate version for the prerelease build
-      - check-config  # implies all the json-related checks have passed
+    strategy:
+      fail-fast: false
+      matrix:
+        # Example: ['Gadi', 'Setonix', ...]
+        target: ${{ fromJson(needs.defaults.outputs.targets) }}
     uses: access-nri/build-cd/.github/workflows/deploy-1-setup.yml@main
     with:
-      type: prerelease
-      ref: ${{ needs.defaults.outputs.head-ref }}
-      version: ${{ needs.check-spack-yaml.outputs.prerelease }}
-      root-sbd: ${{ needs.defaults.outputs.root-sbd }}
+      deployment-target: ${{ matrix.target }}
+      deployment-ref: ${{ needs.defaults.outputs.head-ref }}
+      deployment-type: Prerelease
+      # The prerelease looks like: `pr<pull request number>-<number of deployments of pull request>`.
+      # Ex. Pull Request #12 with 2 deployments on branch -> `pr12-2`.
+      # Note that for multi-target prereleases, they share the same deployment number.
+      deployment-version: ${{ needs.defaults.outputs.prerelease-version }}
+      prerelease-compare-ref: ${{ needs.defaults.outputs.base-ref }}
+      spack-manifest-path: ./spack.yaml
+      spack-manifest-root-sbd: ${{ needs.defaults.outputs.root-sbd }}
     secrets: inherit
 
   redeploy-post:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ on:
   #     - created
   #     - edited
 env:
-  SPACK_YAML_MODEL_YQ: .spack.specs[0]
+  RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
 jobs:
   defaults:
     name: Set Defaults
@@ -54,7 +54,9 @@ jobs:
       head-ref: ${{ steps.pr.outputs.head }}
       head-sha: ${{ steps.pr.outputs.sha }}
       base-ref: ${{ steps.pr.outputs.base }}
-      next-deployment-number: ${{ steps.branch.outputs.next-deployment-number }}
+      next-deployment-number: ${{ steps.prerelease.outputs.next-deployment-number }}
+      prerelease-version: ${{ steps.prerelease.outputs.version }}
+      targets: ${{ steps.target.outputs.targets }}
     steps:
       - name: root-sbd default
         id: root-sbd
@@ -93,7 +95,7 @@ jobs:
           echo "base=$base" >> $GITHUB_OUTPUT
 
       - name: Branch metadata
-        id: branch
+        id: prerelease
         # Essentially, count all the deployment entries that match the given branch, as well as
         # all the `!redeploy` comments, to get the next deployment number.
         # See https://docs.github.com/en/rest/deployments/deployments?apiVersion=2022-11-28#list-deployments
@@ -109,12 +111,32 @@ jobs:
             --json comments \
             --jq '[.comments[] | select(.body | startswith("!redeploy"))] | length'
           )
+
           # Since the number of $pr_deployments do not include the current deployment (yet),
           # but $comment_deployments do, we need to increment the next deployment number by one if it is a pr deployment.
           next_deployment_is_pr_deployment=${{ github.event_name == 'pull_request' && '1' || '0' }}
           next_deployment_number=$((pr_deployments + comment_deployments + next_deployment_is_pr_deployment))
           echo "Next Deployment Number is $pr_deployments + $comment_deployments + $next_deployment_is_pr_deployment = $next_deployment_number"
           echo "next-deployment-number=$next_deployment_number" >> $GITHUB_OUTPUT
+
+          version="pr${{ inputs.pr }}-$next_deployment_number"
+          echo "Prerelease version will be $version"
+          echo "version=$version" >> $GITHUB_OUTPUT
+
+      - name: Get deployment settings.json
+        uses: actions/checkout@v4
+        with:
+          repository: access-nri/build-cd
+          ref: main
+
+      - name: Generate Deployment Target Matrix
+        id: target
+        # These are used in the deploy job to determine the targets to deploy to - irrespective of the type of deployment.
+        run: |
+          targets=$(jq --raw-output --compact-output '.deployment | keys' config/settings.json)
+          echo "$targets"
+          echo "targets=$targets" >> $GITHUB_OUTPUT
+
 
   redeploy-pre:
     name: '!redeploy Pending'
@@ -148,7 +170,7 @@ jobs:
       - name: Exit if no write permissions
         if: steps.commenter.outputs.has-permission == 'false'
         run: |
-          echo "User ${{ github.event.comment.user.login }} doesn't have 'write' permission on ${{ github.repository }}, not allowing deployment"
+          echo "::error::User ${{ github.event.comment.user.login }} doesn't have 'write' permission on ${{ github.repository }}, not allowing deployment"
           exit 1
 
       - name: Set Commit Status Args
@@ -191,7 +213,7 @@ jobs:
     secrets: inherit
 
   redeploy-post:
-    name: '!redeploy Status ${{ needs.prerelease-deploy.result }}'
+    name: '!redeploy Status ${{ needs.deploy.result }}'
     # Always set the commit status after the redeploy job - don't want an always pending status!
     # successful redeploy = successful commit status
     # failed, skipped, cancelled redeploy = failure commit status
@@ -199,7 +221,7 @@ jobs:
     needs:
       - defaults  # to get access to the head-sha
       - redeploy-pre  # to get the initial commit status context and description
-      - prerelease-deploy  # to get the overall status of this workflow
+      - deploy  # to get the overall status of this workflow
     runs-on: ubuntu-latest
     permissions:
       statuses: write  # so we can set the commit status!
@@ -209,61 +231,120 @@ jobs:
         uses: access-nri/actions/.github/actions/react-to-comment@main
         with:
           token: ${{ github.token }}
-          reaction: ${{ needs.prerelease-deploy.result == 'success' && '+1' || '-1' }}
+          reaction: ${{ needs.deploy.result == 'success' && '+1' || '-1' }}
 
-      - name: Set commit status from workflow ${{ needs.prerelease-deploy.result }}
+      - name: Set commit status from workflow ${{ needs.deploy.result }}
         uses: myrotvorets/set-commit-status-action@3730c0a348a2ace3c110851bed53331bc6406e9f  # v2.0.1
         with:
-          status: ${{ needs.prerelease-deploy.result == 'success' && 'success' || 'failure' }}
+          status: ${{ needs.deploy.result == 'success' && 'success' || 'failure' }}
           sha: ${{ needs.defaults.outputs.head-sha }}
           context: ${{ needs.redeploy-pre.outputs.commit-status-context }}
           description: ${{ needs.redeploy-pre.outputs.commit-status-description }}
 
-  notifier:
-    name: Notifier
+  post-deploy-notifier:
+    name: Post-Deploy Notifier
+    if: always()
     needs:
       - defaults  # so we can access `inputs.root-sbd` that could have defaulted to `inputs.model`
-      - check-spack-yaml  # implies all the spack.yaml-related checks have passed, has appropriate version for the prerelease build
-      - check-config  # so we can access potential failures from config/settings.json validation
+      - deploy  # so we can access deployment information such as versions used, status of deployments, etc.
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
+    env:
+      OUTPUT_ARTIFACT_PATH: ./merged_outputs
     steps:
+      - name: Download matrix deployment outputs
+        uses: actions/download-artifact@v4
+        with:
+          pattern: ${{ needs.deploy.outputs.general-outputs-artifact-glob }}
+          path: ${{ env.OUTPUT_ARTIFACT_PATH }}
+          merge-multiple: true
+
+      - name: Create deployment message
+        id: matrix-output-parser
+        # Outputs defined in deploy-1-setup.yml under the outputs-upload job
+        # Creates a comment of the form: https://github.com/ACCESS-NRI/ACCESS-TEST/pull/15#issuecomment-2558675980
+        run: |
+          echo "deployments-message<<EOF" >> $GITHUB_OUTPUT
+
+          for file in ${{ env.OUTPUT_ARTIFACT_PATH }}/*; do
+            # Setting all the variables that would be needed for the PR comment creation...
+            filename=$(basename -- "$file")
+            target="${filename##*.}"
+
+            # For brevity, '-cr' is '--compact-output --raw-output'
+            spack_version=$(jq -cr '.spack_version' "$file")
+            spack_config_version=$(jq -cr '.spack_config_version' "$file")
+            spack_packages_version=$(jq -cr '.spack_packages_version' "$file")
+            release_deployment_version=$(jq -cr '.release_deployment_version' "$file")
+            spack_environment_name=$(jq -cr '.spack_environment_name' "$file")
+            deployment_result=$(jq -cr '.deployment_result' "$file")
+            deployment_modules_location=$(jq -cr '.deployment_modules_location' "$file")
+            deployment_spack_location=$(jq -cr '.deployment_spack_location' "$file")
+
+            # Create the message for the deployment
+            # Header
+            if [[ "$deployment_result" == "success" ]]; then
+              echo "### :white_check_mark: :desktop_computer: \`$target\` Deployment" >> $GITHUB_OUTPUT
+            else
+              echo "### :x: :desktop_computer: \`$target\` Deployment" >> $GITHUB_OUTPUT
+              continue
+            fi
+
+            # Deployment Details
+            echo "<details>" >> $GITHUB_OUTPUT
+            echo "<summary>Usage Instructions</summary>" >> $GITHUB_OUTPUT
+            echo "" >> $GITHUB_OUTPUT
+            echo "Deployed as: " >> $GITHUB_OUTPUT
+            echo "* \`$release_deployment_version\` as a Release (when merged)." >> $GITHUB_OUTPUT
+            echo "* \`${{ needs.defaults.outputs.prerelease-version }}\` as a Prerelease (during this PR)." >> $GITHUB_OUTPUT
+            echo "" >> $GITHUB_OUTPUT
+            echo "This Prerelease is accessible on \`$target\` using:" >> $GITHUB_OUTPUT
+            echo "\`\`\`bash" >> $GITHUB_OUTPUT
+            echo "module use $deployment_modules_location" >> $GITHUB_OUTPUT
+            echo "module load ${{ needs.defaults.outputs.root-sbd }}/${{ needs.defaults.outputs.prerelease-version }}" >> $GITHUB_OUTPUT
+            echo "\`\`\`" >> $GITHUB_OUTPUT
+            echo "where the binaries shall be on your \`PATH\`." >> $GITHUB_OUTPUT
+            echo "For advanced users, this Prerelease is also accessible on \`$target\` via \`$deployment_spack_location\` in the \`${{ needs.defaults.outputs.root-sbd }}-${{ needs.defaults.outputs.prerelease-version }}\` environment." >> $GITHUB_OUTPUT
+            echo "</details>" >> $GITHUB_OUTPUT
+
+            # Configuration Details
+            echo "<details>" >> $GITHUB_OUTPUT
+            echo "<summary>Configuration Details</summary>" >> $GITHUB_OUTPUT
+            echo "" >> $GITHUB_OUTPUT
+            echo "This Prelease was deployed using:" >> $GITHUB_OUTPUT
+            echo "* \`access-nri/spack\` on branch [$spack_version](https://github.com/ACCESS-NRI/spack/tree/releases/v${spack_version})" >> $GITHUB_OUTPUT
+            echo "* \`access-nri/spack-packages\` version [$spack_packages_version](https://github.com/ACCESS-NRI/spack-packages/releases/tag/${spack_packages_version})" >> $GITHUB_OUTPUT
+            echo "* \`access-nri/spack-config\` version [$spack_config_version](https://github.com/ACCESS-NRI/spack-config/releases/tag/${spack_config_version})" >> $GITHUB_OUTPUT
+            echo "" >> $GITHUB_OUTPUT
+            echo "If the above was not expected, please commit changes to \`config/versions.json\`." >> $GITHUB_OUTPUT
+            echo "</details>" >> $GITHUB_OUTPUT
+          done
+
+          echo "EOF" >> $GITHUB_OUTPUT
+
+      - name: Config status roll up
+        id: config-rollup
+        # Roll up the config status booleans from each of the files, and return the overall result
+        run: |
+          echo "errors=$(jq --slurp 'map(.ci_configuration_check_failure | any)' ${{ env.OUTPUT_ARTIFACT_PATH }}/*)" >> $GITHUB_OUTPUT
+
+      - name: Deployment status roll up
+        id: deployment-rollup
+        # Roll up the deployment status from each of the files, and return the overall result
+        # In other words, if any of the deployments are not a success (AKA, failure/skipped/cancelled), then the overall status is failure
+        run: |
+          echo "errors=$(jq --slurp 'map(.deployment_result == "success") | all | not' ${{ env.OUTPUT_ARTIFACT_PATH }}/*)" >> $GITHUB_OUTPUT
+
       - name: PR Comment Notifier
         id: comment
         uses: access-nri/actions/.github/actions/pr-comment@main
         with:
-          pr: ${{ inputs.pr }}
           comment: |
-            :rocket: Deploying ${{ inputs.model }} `${{ needs.check-spack-yaml.outputs.release }}` as prerelease `${{ needs.check-spack-yaml.outputs.prerelease }}` with commit ${{ needs.defaults.outputs.head-sha }}
-            ${{ needs.check-config.outputs.config-settings-failures != '' && ':warning:There are issues with the `build-cd` deployment configuration. If this is unexpected, let @ACCESS-NRI/model-release know.' || '' }}
-            <details>
-            <summary>Details and usage instructions</summary>
+            :rocket: [${{ steps.deployment-rollup.outputs.errors == 'true' && 'Attempted to deploy' || 'Deployed' }}](${{ env.RUN_URL }}) `${{ inputs.model }}` as prerelease `${{ needs.defaults.outputs.root-sbd }}/${{ needs.defaults.outputs.prerelease-version }}` with commit ${{ needs.defaults.outputs.head-sha }}
+            ${{ steps.config-rollup.outputs.errors == 'true' && ':warning:There are issues with the `build-cd` deployment configuration. If this is unexpected, let @ACCESS-NRI/model-release know.' || '' }}
 
-            This `${{ inputs.model }}` model will be deployed as:
-            * `${{ needs.check-spack-yaml.outputs.release }}` as a Release (when merged).
-            * `${{ needs.check-spack-yaml.outputs.prerelease }}` as a Prerelease (during this PR).
-
-            This Prerelease is accessible on Gadi using:
-            ```bash
-            module use /g/data/vk83/prerelease/modules
-            module load ${{ needs.defaults.outputs.root-sbd }}/${{ needs.check-spack-yaml.outputs.prerelease }}
-            ```
-            where the binaries shall be on your `$PATH`.
-            This Prerelease is also accessible on Gadi via `/g/data/vk83/prerelease/apps/spack/${{ needs.check-config.outputs.spack-version }}/spack` in the `${{ needs.defaults.outputs.root-sbd }}-${{ needs.check-spack-yaml.outputs.prerelease }}` environment.
-            </details>
-
-            :hammer_and_wrench: Using: spack `${{ needs.check-config.outputs.spack-version }}`, spack-packages `${{ needs.check-config.outputs.spack-packages-version}}`, spack-config `${{ needs.check-config.outputs.spack-config-version }}`
-            <details>
-            <summary>Details</summary>
-
-            It will be deployed using:
-            * `access-nri/spack` on branch [`${{ needs.check-config.outputs.spack-version }}`](https://github.com/ACCESS-NRI/spack/tree/releases/v${{ needs.check-config.outputs.spack-version }})
-            * `access-nri/spack-packages` version [`${{ needs.check-config.outputs.spack-packages-version }}`](https://github.com/ACCESS-NRI/spack-packages/releases/tag/${{ needs.check-config.outputs.spack-packages-version }})
-            * `access-nri/spack-config` version [`${{ needs.check-config.outputs.spack-config-version }}`](https://github.com/ACCESS-NRI/spack-config/releases/tag/${{ needs.check-config.outputs.spack-config-version }})
-
-            If this is not what was expected, commit changes to `config/versions.json`.
-            </details>
+            ${{ steps.matrix-output-parser.outputs.deployments-message }}
 
       - name: PR Description Notifier
         env:
@@ -271,7 +352,7 @@ jobs:
           PR_BODY_PATH: ./body.txt
           PR_BODY_PATH_UPDATED: ./updated.body.txt
           PRERELEASE_SECTION_REGEX: "^:rocket: .* :rocket:$"
-          PRERELEASE_SECTION: ":rocket: The latest prerelease `${{ needs.defaults.outputs.root-sbd }}/${{ needs.check-spack-yaml.outputs.prerelease }}` at ${{ needs.defaults.outputs.head-sha }} is here: ${{ steps.comment.outputs.comment-link }} :rocket:"
+          PRERELEASE_SECTION: ":rocket: The latest prerelease `${{ needs.defaults.outputs.root-sbd }}/${{ needs.defaults.outputs.prerelease-version }}` at ${{ needs.defaults.outputs.head-sha }} is here: ${{ steps.comment.outputs.comment-url }} :rocket:"
         run: |
           gh pr view ${{ inputs.pr }} --repo ${{ github.repository }} --json body --jq .body > ${{ env.PR_BODY_PATH }}
 

--- a/.github/workflows/deploy-1-setup.yml
+++ b/.github/workflows/deploy-1-setup.yml
@@ -91,50 +91,182 @@ on:
     #     description: |
     #       Directory containing the spack instance of the deployed model on the inputs.deployment-target
 jobs:
-  setup-spack-env:
-    name: Setup Spack Environment
+  check-config:
+    name: Check Config
     runs-on: ubuntu-latest
     outputs:
-      # Model name inferred from repository name
-      model: ${{ steps.get-model.outputs.model }}
-      # Spack env name in form <model>-<version>
-      env-name: ${{ steps.get-env-name.outputs.env-name }}
+      spack-version: ${{ steps.spack.outputs.version }}
+      spack-packages-version: ${{ steps.spack-packages.outputs.version }}
+      spack-config-version:  ${{ steps.spack-config.outputs.version }}
+      config-settings-failures: ${{ steps.settings.outputs.failures }}
     steps:
-      - name: Get Model
-        id: get-model
-        # for the cases where the repo name is in uppercase but the package name is lowercase (eg. access-nri/MOM5)
-        # and also the cases where there is a '.' in the repo name, which isn't spack-compliant (eg. access-nri/ACCESS-ESM1.5)
-        run: echo "model=$(echo ${{ github.event.repository.name }} | tr [:upper:] [:lower:] | tr '.' 'p')" >> $GITHUB_OUTPUT
+      - name: Checkout ${{ github.repository }} Config
+        uses: actions/checkout@v4
+        with:
+          path: model
+          ref: ${{ inputs.deployment-ref }}
+
+      - name: Validate ${{ github.repository }} config/versions.json
+        uses: access-nri/schema/.github/actions/validate-with-schema@main
+        with:
+          schema-version: ${{ vars.CONFIG_VERSIONS_SCHEMA_VERSION }}
+          schema-location: au.org.access-nri/model/deployment/config/versions
+          data-location: ./model/config/versions.json
+
+      - name: Validate spack-packages version
+        id: spack-packages
+        uses: access-nri/build-cd/.github/actions/validate-repo-version@main
+        with:
+          repo-to-check: spack-packages
+          pr: ${{ inputs.deployment-ref }}
+
+      - name: Validate spack version
+        id: spack
+        uses: access-nri/build-cd/.github/actions/validate-repo-version@main
+        with:
+          repo-to-check: spack
+          pr: ${{ inputs.deployment-ref }}
+
+      - name: Checkout build-cd Config
+        uses: actions/checkout@v4
+        with:
+          repository: ACCESS-NRI/build-cd
+          ref: main
+          path: cd
+
+      - name: Get spack-config version
+        id: spack-config
+        run: |
+          version=$(jq --compact-output --raw-output \
+              --arg spack_version "${{ steps.spack.outputs.version }}" \
+              '.deployment.${{ inputs.deployment-target }}.${{ inputs.deployment-type }}[$spack_version]."spack-config"' cd/config/settings.json
+          )
+          echo $version
+          echo "version=$version" >> $GITHUB_OUTPUT
+
+      - name: Validate build-cd config/settings.json
+        id: settings
+        uses: access-nri/build-cd/.github/actions/validate-deployment-settings@main
+        with:
+          settings-path: ./cd/config/settings.json
+          target: ${{ inputs.deployment-target }}
+
+  check-spack-yaml:
+    name: Check Spack Manifest
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    env:
+      SPACK_YAML_MODEL_YQ: .spack.specs[0]
+    outputs:
+      # Release version of the deployment. Inferred if not given in inputs.deployment-version
+      release: ${{ steps.version.outputs.release }}
+      # Spack env name in form <model>-<version>
+      spack-env-name: ${{ steps.get-env-name.outputs.env-name }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ inputs.deployment-ref }}
+
+      - name: Validate ACCESS-NRI spack.yaml Restrictions
+        uses: access-nri/schema/.github/actions/validate-with-schema@main
+        with:
+          schema-version: ${{ vars.SPACK_YAML_SCHEMA_VERSION }}
+          schema-location: au.org.access-nri/model/spack/environment/deployment
+          data-location: ${{ inputs.spack-manifest-path }}
+
+      - name: Check Model Version Modified
+        # We don't want to fire off model deployment version checks if the PR is never going to be merged.
+        # We determine this by checking if either the pull request, or the pull request that a comment
+        # belongs to, is drafted.
+        # Yes, github.event.issue.draft refers to the pull request if the comment is made on a pull request!
+        if: >-
+          inputs.deployment-type != 'Release' &&
+          (github.event_name == 'pull_request' && !github.event.pull_request.draft) ||
+          (github.event_name == 'issue_comment' && !github.event.issue.draft)
+        id: version-modified
+        run: |
+          git checkout ${{ inputs.prerelease-compare-ref }}
+
+          if [ ! -f spack.yaml ]; then
+              echo "::notice::There is no previous version of the spack.yaml to check at ${{ inputs.prerelease-compare-ref }}, continuing..."
+              git checkout ${{ inputs.deployment-ref }}
+              exit 0
+          fi
+
+          base_version=$(yq e '${{ env.SPACK_YAML_MODEL_YQ }}' spack.yaml)
+
+          git checkout ${{ inputs.deployment-ref }}
+          current_version=$(yq e '${{ env.SPACK_YAML_MODEL_YQ }}' spack.yaml)
+          echo "current=${current_version}" >> $GITHUB_OUTPUT
+
+          if [[ "${base_version}" == "${current_version}" ]]; then
+              echo "::warning::The version string hasn't been modified in this PR, but needs to be before merging."
+              exit 1
+          fi
+
+      - name: Same Model Version Failure Notifier
+        if: failure() && steps.version-modified.outcome == 'failure'
+        uses: access-nri/actions/.github/actions/pr-comment@main
+        with:
+          comment: |
+              The model version in the `${{ inputs.spack-manifest-path }}` has not been updated.
+              Either update it manually, or comment the following to have it updated and committed automatically:
+              * `!bump major` for feature releases
+              * `!bump minor` for bugfixes
+
+      - name: Projection Version Matches
+        # this step checks that the versions of the packages themselves match with the
+        #  names of the projections, if they're given.
+        # For example, access-om3@git.2023.12.12 matches with the
+        #  modulefile access-om3/2023.12.12 (specifically, the version strings match)
+        # TODO: Move this into the `scripts` directory - it's getting unweildly.
+        run: |
+          FAILED="false"
+
+          # Get all the defined projections (minus 'all') and make them suitable for a bash for loop
+          DEPS=$(yq '.spack.modules.default.tcl.projections | del(.all) | keys | join(" ")' spack.yaml)
+
+          # for each of the modules
+          for DEP in $DEPS; do
+            DEP_VER=''
+            if [[ "$DEP" == "${{ inputs.spack-manifest-root-sbd }}" ]]; then
+              # The model version is the bit after '@git.', before any later, space-separated, optional variants.
+              # For example, in 'MODEL@git.VERSION type=ACCESS ~debug' the version is 'VERSION'.
+              DEP_VER=$(yq '.spack.specs[0] | capture(".+@git\\.(?<version>[^ ]+).*") | .version' spack.yaml)
+            else
+              # Capture the section after '@git.' or '@' (if it's not a git-attributed version) and before a possible '=' for a given dependency.
+              # Ex. '@git.2024.02.11' -> '2024.02.11', '@access-esm1.5' -> 'access-esm1.5', '@git.2024.05.21=access-esm1.5' -> '2024.05.21'
+              DEP_VER=$(yq ".spack.packages.\"$DEP\".require[0] | match(\"^@(?:git.)?([^=]*)\").captures[0].string" spack.yaml)
+            fi
+
+            # Get the version from the module projection, for comparison with DEP_VER
+            # Projections are of the form '{name}/VERSION[-{hash:7}]', in which we only care about VERSION. For example, '{name}/2024.11.11', or '{name}/2024.11.11-{hash:7}'
+            MODULE_NAME=$(yq ".spack.modules.default.tcl.projections.\"$DEP\"" spack.yaml)
+            MODULE_VER="${MODULE_NAME#*/}"  # Strip '{name}/' from '{name}/VERSION' module, even if VERSION contains '/'
+            MODULE_VER="${MODULE_VER%%-\{hash:7\}}"  # Strip a potential '-{hash:7}' appendix from the VERSION, since we won't have that in the DEP_VER
+
+            if [[ "$DEP_VER" != "$MODULE_VER" ]]; then
+              echo "::error::$DEP: Version of dependency and projection do not match ($DEP_VER != $MODULE_VER)"
+              FAILED='true'
+            fi
+          done
+          if [[ "$FAILED" == "true" ]]; then
+            exit 1
+          fi
+
+      - name: Generate Versions
+        id: version
+        # This step generates the release version number, if it wasn't already given.
+        # The release is a general version number from the spack.yaml, looking the
+        # same as a regular release build, without optional variants. Ex. 'access-om2@git.2024.01.1 ~debug' -> '2024.01.1'
+        run: echo "release=$(yq '${{ env.SPACK_YAML_MODEL_YQ }} | capture("@git\.(?<version>[^ ~+]+)") | .version' spack.yaml)" >> $GITHUB_OUTPUT
 
       - name: Set Spack Env Name String
         id: get-env-name
         # replace occurences of '.' with '_' in environment name as spack doesn't support '.'. Ex: 'access-om2-v1.0.0' -> 'access-om2-v1_0_0'.
-        run: echo "env-name=$(echo '${{ steps.get-model.outputs.model }}-${{ inputs.version }}' | tr '.' '_')" >> $GITHUB_OUTPUT
-
-  setup-deployment-env:
-    name: Setup Deployment Environment
-    runs-on: ubuntu-latest
-    outputs:
-      deployment-environments: ${{ steps.get-deployment-environment.outputs.deployment-environments }}
-    steps:
-      - name: Checkout Config
-        uses: actions/checkout@v4
-        with:
-          repository: access-nri/build-cd
-
-      - name: Get Environments
-        id: get-deployment-environment
-        run: |
-          if [[ "${{ inputs.type }}" == "release" ]]; then
-            # Convention is to just have the name by itself for release (eg. 'Gadi')
-            echo "deployment-environments=$(jq --compact-output '.deployment | keys' ${{ env.CONFIG_SETTINGS_PATH }})" >> $GITHUB_OUTPUT
-          elif [[ "${{ inputs.type }}" == "prerelease" ]]; then
-            # Convention is to have the name + Prerelease (eg. 'Gadi Prerelease')
-            echo "deployment-environments=$(jq --compact-output '[.deployment | keys | "\(.[]) Prerelease"]' ${{ env.CONFIG_SETTINGS_PATH }})" >> $GITHUB_OUTPUT
-          else
-            echo "::error::The 'type' input was invalid. Check the inputs documentation."
-            exit 1
-          fi
+        run: echo "env-name=$(echo '${{ inputs.spack-manifest-root-sbd }}-${{ inputs.deployment-version }}' | tr '.' '_')" >> $GITHUB_OUTPUT
 
   deployment:
     name: Deployment

--- a/.github/workflows/deploy-1-setup.yml
+++ b/.github/workflows/deploy-1-setup.yml
@@ -269,21 +269,17 @@ jobs:
         run: echo "env-name=$(echo '${{ inputs.spack-manifest-root-sbd }}-${{ inputs.deployment-version }}' | tr '.' '_')" >> $GITHUB_OUTPUT
 
   deployment:
-    name: Deployment
+    name: ${{ inputs.deployment-target }}
     needs:
-      - setup-spack-env
-      - setup-deployment-env
-    strategy:
-      fail-fast: false
-      matrix:
-        deployment-environment: ${{ fromJson(needs.setup-deployment-env.outputs.deployment-environments) }}
+      - check-config  # Verify configuration information is correct
+      - check-spack-yaml  # Verify spack manifest information is correct
     uses: access-nri/build-cd/.github/workflows/deploy-2-start.yml@main
     with:
-      type: ${{ inputs.type }}
-      model: ${{ needs.setup-spack-env.outputs.model }}
-      ref: ${{ inputs.ref }}
-      version: ${{ inputs.version }}
-      env-name: ${{ needs.setup-spack-env.outputs.env-name }}
-      deployment-environment: ${{ matrix.deployment-environment }}
-      root-sbd: ${{ inputs.root-sbd }}
+      type: ${{ inputs.deployment-type }}
+      model: ${{ inputs.spack-manifest-root-sbd }}
+      ref: ${{ inputs.deployment-ref }}
+      version: ${{ inputs.deployment-version }}
+      env-name: ${{ needs.check-spack-yaml.outputs.spack-env-name }}
+      deployment-environment: ${{ inputs.deployment-type == 'Prerelease' && format('{0} Prerelease', inputs.deployment-target) || inputs.deployment-target }}
+      root-sbd: ${{ inputs.spack-manifest-root-sbd }}
     secrets: inherit

--- a/.github/workflows/deploy-1-setup.yml
+++ b/.github/workflows/deploy-1-setup.yml
@@ -1,26 +1,95 @@
-name: Deployment Setup
+name: Deploy
 on:
   workflow_call:
     inputs:
-      type:
+      deployment-target:
+        type: string
+        required: true
+        description: |
+          The target machine for the model being deployed.
+          Equivalent to the name of the GitHub Environment, minus a potential Prerelease Type.
+      deployment-type:
+        type: string
+        required: true
+        description: |
+          The type of model being deployed.
+          Can be one of: Release, Prerelease.
+      deployment-version:
+        type: string
+        required: true
+        description: |
+          The version of the model being deployed.
+          Usually takes the form of either a git tag (2024.12.0), or a Prerelease version (pr12-2)
+      deployment-ref:
+        type: string
+        required: true
+        description: |
+          The git ref where the spack manifest that will be deployed is located.
+          In Prereleases, this is the HEAD of the source branch of the PR.
+      prerelease-compare-ref:
         type: string
         required: false
-        default: release
-        description: The type of deployment - either 'release' or 'prerelease'
-      ref:
+        description: |
+          Optional git ref to compare against the current inputs.deployment-ref
+          Useful for checking that files have been modified appropriately.
+      spack-manifest-path:
         type: string
         required: true
-        description: The git commit-ish ref where the `spack.yaml` is located
-      version:
+        default: spack.yaml
+        description: |
+          Relative path in the Model Deployment Repository that contains the spack manifest file.
+          Usually a spack.yaml file.
+      spack-manifest-root-sbd:
         type: string
         required: true
-        description: The version for the model being deployed
-      root-sbd:
-        type: string
-        required: true
-        description: The root SBD that is being used as the modulefile name
-env:
-  CONFIG_SETTINGS_PATH: ./config/settings.json
+        description: |
+          Within the spack manifest, the overarching spack bundle that contains all other packages.
+          Usually the first entry in the .spack.specs section of the manifest.
+    outputs:
+      general-outputs-artifact-glob:
+        value: ${{ jobs.outputs-upload.outputs.general-artifact-name }}
+        description: |
+          General pattern for the artifact that contains the outputs for this invocation of the job.
+          Output files are of the form deploy-outputs.{{inputs.deployment-target}}
+    # TODO: This is a workaround for matrixed dynamic job outputs. See https://github.com/orgs/community/discussions/17245
+    # The outputs in the file are below:
+    #   spack-version:
+    #     value: ${{ jobs.check-config.outputs.spack-version }}
+    #     description: |
+    #       Branch of 'access-nri/spack' that is used to deploy the model.
+    #       The VERSION part of the 'releases/VERSION' branch.
+    #   spack-config-version:
+    #     value: ${{ jobs.check-config.outputs.spack-config-version }}
+    #     description: |
+    #       Git ref of 'access-nri/spack-config' that is used to configure spack.
+    #   spack-packages-version:
+    #     value: ${{ jobs.check-config.outputs.spack-packages-version }}
+    #     description: |
+    #       Git ref of 'access-nri/spack-packages' that is used to reference custom packages in spack.
+    #   release-deployment-version:
+    #     value: ${{ jobs.check-spack-yaml.outputs.release }}
+    #     description: |
+    #       Version of the model being deployed as if it were a release version.
+    #   ci-configuration-check-failure:
+    #     value: ${{ jobs.check-config.outputs.config-settings-failures }}
+    #     description: |
+    #       Boolean true/false for whether the configuration check failed for inputs.deployment-target
+    #   spack-environment-name:
+    #     value: ${{ jobs.check-spack-yaml.outputs.spack-env-name }}
+    #     description: |
+    #       Name for the spack environment that contains the deployed model
+    #   deployment-result:
+    #    value: ${{ jobs.deployment.result }}
+    #    description: |
+    #      Result of the deployment - skipped/cancelled/success/failure
+    #   deployment-modules-location:
+    #     value: ${{ jobs.deployment.outputs.module-location }}
+    #     description: |
+    #       Directory containing the modules of the deployed model on the inputs.deployment-target
+    #   deployment-spack-location:
+    #     value: ${{ jobs.deployment.outputs.spack-location }}
+    #     description: |
+    #       Directory containing the spack instance of the deployed model on the inputs.deployment-target
 jobs:
   setup-spack-env:
     name: Setup Spack Environment

--- a/.github/workflows/deploy-1-setup.yml
+++ b/.github/workflows/deploy-1-setup.yml
@@ -92,7 +92,7 @@ on:
     #       Directory containing the spack instance of the deployed model on the inputs.deployment-target
 jobs:
   check-config:
-    name: Check Config
+    name: '${{ inputs.deployment-target }}: Check Config'
     runs-on: ubuntu-latest
     outputs:
       spack-version: ${{ steps.spack.outputs.version }}
@@ -152,7 +152,7 @@ jobs:
           target: ${{ inputs.deployment-target }}
 
   check-spack-yaml:
-    name: Check Spack Manifest
+    name: '${{ inputs.deployment-target }}: Check Spack Manifest'
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
@@ -285,7 +285,7 @@ jobs:
     secrets: inherit
 
   outputs-upload:
-    name: Outputs Upload
+    name: '${{ inputs.deployment-target }}:Outputs Upload'
     # Creates a JSON artifact with information on the deployment created during this run.
     # In workflows that call this as a matrix, one must do a deep merge with all files generated from the matrix,
     # using the outputs.general-outputs-artifact-name artifact as part of the workflow run.

--- a/.github/workflows/deploy-1-setup.yml
+++ b/.github/workflows/deploy-1-setup.yml
@@ -283,3 +283,42 @@ jobs:
       deployment-environment: ${{ inputs.deployment-type == 'Prerelease' && format('{0} Prerelease', inputs.deployment-target) || inputs.deployment-target }}
       root-sbd: ${{ inputs.spack-manifest-root-sbd }}
     secrets: inherit
+
+  outputs-upload:
+    name: Outputs Upload
+    # Creates a JSON artifact with information on the deployment created during this run.
+    # In workflows that call this as a matrix, one must do a deep merge with all files generated from the matrix,
+    # using the outputs.general-outputs-artifact-name artifact as part of the workflow run.
+    if: always()
+    # always, because we might want to interrogate some of the information even in a failed deployment.
+    needs:
+      - check-config
+      - check-spack-yaml
+      - deployment
+    runs-on: ubuntu-latest
+    env:
+      UPLOAD_FILE_NAME: deploy-outputs.${{ inputs.deployment-target }}
+    outputs:
+      general-artifact-name: deploy-outputs.*
+    steps:
+      - name: Create outputs file
+        # See the on.workflow_call.outputs section for details on the info created.
+        run: |
+          jq --null-input '{
+            spack_version: "${{ needs.check-config.outputs.spack-version }}",
+            spack_config_version: "${{ needs.check-config.outputs.spack-config-version }}",
+            spack_packages_version: "${{ needs.check-config.outputs.spack-packages-version }}",
+            ci_configuration_check_failure: ${{ needs.check-config.outputs.config-settings-failures != '' }},
+            release_deployment_version: "${{ needs.check-spack-yaml.outputs.release }}",
+            spack_environment_name: "${{ needs.check-spack-yaml.outputs.spack-env-name }}",
+            deployment_result: "${{ needs.deployment.result }}",
+            deployment_modules_location: "${{ needs.deployment.outputs.modules-location }}",
+            deployment_spack_location: "${{ needs.deployment.outputs.spack-location }}"
+          }' > ./${{ env.UPLOAD_FILE_NAME }}
+
+      - name: Upload
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.UPLOAD_FILE_NAME }}
+          path: ./${{ env.UPLOAD_FILE_NAME }}
+          if-no-files-found: error

--- a/.github/workflows/deploy-2-start.yml
+++ b/.github/workflows/deploy-2-start.yml
@@ -31,6 +31,13 @@ on:
         type: string
         required: true
         description: The root SBD that is being used as the modulefile name
+    outputs:
+      modules-location:
+        value: ${{ jobs.deploy-to-environment.outputs.modules-location }}
+        description: The location of the modules directory on the deployment environment
+      spack-location:
+        value: ${{ jobs.deploy-to-environment.outputs.spack-location }}
+        description: The location of the spack directory on the deployment environment
 env:
   SPACK_YAML_SPEC_YQ: .spack.specs[0]
   SPACK_YAML_MODULEFILE_PROJECTION_YQ: .spack.modules.default.tcl.projections.${{ inputs.root-sbd }}
@@ -43,6 +50,8 @@ jobs:
     outputs:
       packages-version: ${{ steps.versions.outputs.packages }}
       config-version: ${{ steps.versions.outputs.config }}
+      spack-location: ${{ steps.location.outputs.spack }}
+      modules-location: ${{ steps.location.outputs.modules }}
     steps:
       # Deployment
       - uses: actions/checkout@v4

--- a/.github/workflows/deploy-2-start.yml
+++ b/.github/workflows/deploy-2-start.yml
@@ -6,7 +6,7 @@ on:
       type:
         type: string
         required: true
-        description: The type of deployment - either 'release' or 'prerelease'
+        description: The type of deployment - either 'Release' or 'Prerelease'
       model:
         type: string
         required: true
@@ -82,7 +82,7 @@ jobs:
             ${{ secrets.HOST_DATA }}
 
       - name: Prerelease spack.yaml Modifications
-        if: inputs.type == 'prerelease'
+        if: inputs.type == 'Prerelease'
         # Modifies the name of the prerelease modulefile to the
         # `pr<number>-<commit>` style. For example, `access-om3/pr12-2`.
         # Also removes the `@git.VERSION` specifier for Prereleases so
@@ -140,6 +140,12 @@ jobs:
           spack --debug install --fresh ${{ vars.SPACK_INSTALL_PARALLEL_JOBS }} || exit $?
           spack module tcl refresh -y
           EOT
+
+      - name: Export deployment target locations
+        id: location
+        run: |
+          echo "spack=${{ steps.path.outputs.spack }}" >> $GITHUB_OUTPUT
+          echo "modules=${{ vars.DEPLOYED_MODULES_DIR }}" >> $GITHUB_OUTPUT
 
       - name: Get metadata from ${{ inputs.deployment-environment }}
         env:
@@ -204,7 +210,7 @@ jobs:
 
   release:
     name: Create Release
-    if: inputs.type == 'release'
+    if: inputs.type == 'Release'
     needs:
       - deploy-to-environment
     runs-on: ubuntu-latest
@@ -244,7 +250,7 @@ jobs:
 
   build-db:
     name: Build DB Metadata Upload
-    if: inputs.type == 'release'
+    if: inputs.type == 'Release'
     needs:
       - deploy-to-environment
       - release

--- a/.github/workflows/settings-1-update.yml
+++ b/.github/workflows/settings-1-update.yml
@@ -14,8 +14,32 @@ env:
   CONFIG_SETTINGS_PATH: ./config/settings.json
   CONFIG_SETTINGS_SCHEMA_PATH: ./config/settings.schema.json
 jobs:
+  setup-settings-validation:
+    name: Setup Validate Deployment Settings
+    runs-on: ubuntu-latest
+    outputs:
+      targets: ${{ steps.target.outputs.matrix }}
+    steps:
+      - name: Get deployment settings.json
+        uses: actions/checkout@v4
+        with:
+          repository: access-nri/build-cd
+          ref: main
+
+      - name: Generate Deployment Target Matrix
+        id: target
+        run: |
+          targets=$(jq --compact-output '.deployments' config/settings.json)
+          echo "$targets"
+          echo "targets=$targets" >> $GITHUB_OUTPUT
+
   settings-validation:
     name: Validate Deployment Settings
+    needs:
+      - setup-settings-validation
+    strategy:
+      matrix:
+        target: ${{ fromJson(needs.setup-settings-validation.outputs.targets) }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout settings.json
@@ -33,15 +57,14 @@ jobs:
         uses: access-nri/build-cd/.github/actions/validate-deployment-settings@main
         with:
           settings-path: ${{ env.CONFIG_SETTINGS_PATH }}
-          # TODO: Turn this into a matrix job of targets
-          target: Gadi
+          target: ${{ matrix.target }}
 
       - name: Comment Validation Issues
         if: steps.validate.outputs.failures != '' && github.event_name == 'pull_request'
         uses: access-nri/actions/.github/actions/pr-comment@main
         with:
           comment: |
-            :warning: `${{ env.CONFIG_SETTINGS_PATH }}`: Inconsistencies detected with the configuration. See below. :warning:
+            :warning: `${{ env.CONFIG_SETTINGS_PATH }}`: Inconsistencies detected with the `${{ matrix.target }}` configuration. See below. :warning:
             ${{ steps.validate.outputs.failures }}
 
   setup-settings-update:


### PR DESCRIPTION
## Background
Although preliminary work had been done on allowing multiple HPC targets (notably by [creating a config file](https://github.com/ACCESS-NRI/build-cd/blob/main/config/settings.json) that allows for multiple HPCs, using GitHub Environments that correspond to multiple HPCs, and having inputs to existing workflows take a variable GitHub Environment), we aren't fully there yet. 

The major change is that we start the matrixing(?) of the overall pipeline much, much earlier. Each matrix job contains the `check-spack-yaml`, `check-config` and `deploy` jobs, and the rest of the pre- and post- matrix jobs are relatively unchanged. Although, the deployment comment that is generated is now no longer relatively static, but must be generated on the fly depending on how many deployment targets there are. Yuck. 

### Annoying Workaround Diversion...

One major annoyance is that GitHub does not allow dynamic outputs from matrix jobs to be consolidated easily. For example, say we have a matrix job (with `id` `get-location`) where each instance of the job returns an output (called `location`). If a later job `needs` `get-location`, the `needs.get-location.outputs.location` will be the value of the _last completed successful_ instance of the matrix job (since the output `location` is continuously overwritten), which is both not what we want, AND nondeterministic. 

In order to get all the outputs of the matrix job we need to do a workaround in which we write the "outputs" as an artifact of an instance of the matrix job, and then read those artifacts in later jobs. See https://github.com/ACCESS-NRI/build-cd/pull/203/files#diff-5e593466d0b143a180dbe89a953c8d5b832f52f3610e393f4f7542d5e7f4fbf9R54

## How It Works, Visually

Chicken-scratches on how the workflow looked after and before are below:

![jobs_moved](https://github.com/user-attachments/assets/cbeea9d3-506a-46ae-a066-73deee4c0ec4)

## Testing

Testing was done primarily in https://github.com/ACCESS-NRI/ACCESS-TEST/pull/15 (starts working after [this event](https://github.com/ACCESS-NRI/ACCESS-TEST/pull/15#event-15742531759)). Note that we only deploy to `Gadi`, but it should work just as well with multiple targets. 

References #199 
