### PR TITLE
Multi-Target GitHub Releases

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -141,6 +141,7 @@ jobs:
   release:
     name: Create Release
     needs:
+      - defaults
       - push-tag
       - deploy-release
     runs-on: ubuntu-latest
@@ -148,8 +149,6 @@ jobs:
       url: ${{ steps.release.outputs.url }}
       created-at: ${{ steps.metadata.outputs.created-at }}
     steps:
-      - uses: actions/checkout@v4
-
       - name: Download Metadata Artifacts
         uses: actions/download-artifact@v4
         with:
@@ -164,6 +163,36 @@ jobs:
           path: ${{ env.OUTPUTS_PATH}}
           merge-multiple: true
 
+      - name: Generate Release Notes
+        id: release-body
+        run: |
+          echo "body<<EOF" >> $GITHUB_OUTPUT
+
+          echo "This is an official release of \`${{ inputs.model }}\` \`${{ needs.push-tag.outputs.name }}\`. " >> $GITHUB_OUTPUT
+          echo "## Deployment Information" >> $GITHUB_OUTPUT
+
+          for file in ${{ env.OUTPUTS_PATH }}/*; do
+            # Setting all the variables that would be needed for the release body creation...
+            filename=$(basename -- "$file")
+            target="${filename##*.}"
+
+            # For brevity, '-cr' is '--compact-output --raw-output'
+            spack_version=$(jq -cr '.spack_version' "$file")
+            spack_config_version=$(jq -cr '.spack_config_version' "$file")
+            spack_packages_version=$(jq -cr '.spack_packages_version' "$file")
+            deployment_modules_location=$(jq -cr '.deployment_modules_location' "$file")
+
+            echo "### \`$target\`" >> $GITHUB_OUTPUT
+            echo "Deployed using [spack $spack_version](https://github.com/ACCESS-NRI/spack/tree/releases/$spack_version), [spack-packages $spack_packages_version](https://github.com/ACCESS-NRI/spack-packages/releases/tag/$spack_packages_version) and [spack-config $spack_config_version](https://github.com/ACCESS-NRI/spack-config/releases/tag/$spack_config_version)." >> $GITHUB_OUTPUT
+            echo "Deployed as module accessible using:" >> $GITHUB_OUTPUT
+            echo "\`\`\`bash" >> $GITHUB_OUTPUT
+            echo "module use $deployment_modules_location" >> $GITHUB_OUTPUT
+            echo "module load ${{ needs.defaults.outputs.root-sbd }}/${{ needs.push-tag.outputs.name }}" >> $GITHUB_OUTPUT
+            echo "\`\`\`" >> $GITHUB_OUTPUT
+            echo "" >> $GITHUB_OUTPUT
+          done
+          echo "EOF" >> $GITHUB_OUTPUT
+
       - name: Create Release
         id: release
         uses: softprops/action-gh-release@69320dbe05506a9a39fc8ae11030b214ec2d1f87  # v2.0.5
@@ -171,7 +200,7 @@ jobs:
           tag_name: ${{ needs.push-tag.outputs.name }}
           name: ${{ inputs.model}} ${{ needs.push-tag.outputs.name }}
           body: |
-            This release of ${{ inputs.model }} ${{ needs.push-tag.outputs.name }} uses [spack-packages ${{ needs.deploy-to-environment.outputs.packages-version }}](https://github.com/ACCESS-NRI/spack-packages/releases/tag/${{ needs.deploy-to-environment.outputs.packages-version }}) and [spack-config ${{ needs.deploy-to-environment.outputs.config-version }}](https://github.com/ACCESS-NRI/spack-config/releases/tag/${{ needs.deploy-to-environment.outputs.config-version }}).
+            ${{ steps.release-body.outputs.body }}
           generate_release_notes: true
           fail_on_unmatched_files: true
           files: |
@@ -184,7 +213,7 @@ jobs:
         id: metadata
         env:
           GH_TOKEN: ${{ github.token }}
-        run: echo "created-at=$(gh release view --json createdAt --jq '.createdAt')" >> $GITHUB_OUTPUT
+        run: echo "created-at=$(gh release view --json createdAt --jq '.createdAt' --repo ${{ github.repository }})" >> $GITHUB_OUTPUT
 
   # FIXME: This won't work until ACCESS-NRI/build-cd#201 is resolved
   build-db:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -28,6 +28,8 @@ on:
 
 env:
   SPACK_YAML_MODEL_YQ: .spack.specs[0]
+  METADATA_PATH: /opt/metadata
+  OUTPUTS_PATH: /opt/outputs
 jobs:
   defaults:
     name: Set Defaults
@@ -124,7 +126,7 @@ jobs:
     strategy:
       matrix:
         target: ${{ fromJson(needs.defaults.outputs.targets) }}
-    uses: access-nri/build-cd/.github/workflows/deploy-1-setup.yml@main
+    uses: access-nri/build-cd/.github/workflows/deploy-1-setup.yml@v3
     with:
       deployment-target: ${{ matrix.target }}
       deployment-ref: ${{ github.ref_name }}
@@ -135,3 +137,89 @@ jobs:
     secrets: inherit
     permissions:
       contents: write
+
+  release:
+    name: Create Release
+    needs:
+      - push-tag
+      - deploy-release
+    runs-on: ubuntu-latest
+    outputs:
+      url: ${{ steps.release.outputs.url }}
+      created-at: ${{ steps.metadata.outputs.created-at }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download Metadata Artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: ${{ needs.deploy-release.outputs.general-metadata-artifact-glob }}
+          path: ${{ env.METADATA_PATH }}
+          merge-multiple: true
+
+      - name: Download Outputs Artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: ${{ needs.deploy-release.outputs.general-outputs-artifact-glob }}
+          path: ${{ env.OUTPUTS_PATH}}
+          merge-multiple: true
+
+      - name: Create Release
+        id: release
+        uses: softprops/action-gh-release@69320dbe05506a9a39fc8ae11030b214ec2d1f87  # v2.0.5
+        with:
+          tag_name: ${{ needs.push-tag.outputs.name }}
+          name: ${{ inputs.model}} ${{ needs.push-tag.outputs.name }}
+          body: |
+            This release of ${{ inputs.model }} ${{ needs.push-tag.outputs.name }} uses [spack-packages ${{ needs.deploy-to-environment.outputs.packages-version }}](https://github.com/ACCESS-NRI/spack-packages/releases/tag/${{ needs.deploy-to-environment.outputs.packages-version }}) and [spack-config ${{ needs.deploy-to-environment.outputs.config-version }}](https://github.com/ACCESS-NRI/spack-config/releases/tag/${{ needs.deploy-to-environment.outputs.config-version }}).
+          generate_release_notes: true
+          fail_on_unmatched_files: true
+          files: |
+            ${{ env.METADATA_PATH }}/spack.yaml
+            ${{ env.METADATA_PATH }}/spack.lock
+            ${{ env.METADATA_PATH }}/spack.location
+            ${{ env.METADATA_PATH }}/spack.location.json
+
+      - name: Release Metadata
+        id: metadata
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: echo "created-at=$(gh release view --json createdAt --jq '.createdAt')" >> $GITHUB_OUTPUT
+
+  # FIXME: This won't work until ACCESS-NRI/build-cd#201 is resolved
+  build-db:
+    name: Build DB Metadata Upload
+    needs:
+      - deploy-release
+      - release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download Metadata Artifact
+        uses: actions/download-artifact@v4
+        with:
+          pattern: ${{ needs.deploy-release.outputs.general-metadata-artifact-glob }}
+          path: ${{ env.METADATA_PATH }}
+
+      - name: Checkout Upload Script
+        uses: actions/checkout@v4
+        with:
+          repository: access-nri/build-cd
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ vars.PYTHON_VERSION }}
+          cache: pip
+
+      - name: Install Build Metadata Script Requirements
+        run: pip install -r tools/release_provenance/requirements.txt
+
+      - name: Upload Build Metadata
+        env:
+          BUILD_DB_CONNECTION_STR: ${{ secrets.BUILD_DB_CONNECTION_STR }}
+          OUTPUT_PATH: ./metadata_output
+        run: |
+          ./scripts/generate-build-metadata.bash ${{ needs.release.outputs.url }} ${{ needs.release.outputs.created-at }} ${{ needs.deploy-to-environment.outputs.packages-version }} ${{ needs.deploy-to-environment.outputs.config-version }} ${{ env.METADATA_PATH }} ${{ env.OUTPUT_PATH }} ${{ inputs.root-sbd }} ${{ vars.BUILD_DB_PACKAGES }}
+
+          echo "Attempting upload of build_metadata.json"
+          python ./tools/release_provenance/save_release.py "${{ env.OUTPUT_PATH }}/build_metadata.json"

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -175,10 +175,10 @@ jobs:
           generate_release_notes: true
           fail_on_unmatched_files: true
           files: |
-            ${{ env.METADATA_PATH }}/spack.yaml
-            ${{ env.METADATA_PATH }}/spack.lock
-            ${{ env.METADATA_PATH }}/spack.location
-            ${{ env.METADATA_PATH }}/spack.location.json
+            ${{ env.METADATA_PATH }}/*.spack.yaml
+            ${{ env.METADATA_PATH }}/*.spack.lock
+            ${{ env.METADATA_PATH }}/*.spack.location
+            ${{ env.METADATA_PATH }}/*.spack.location.json
 
       - name: Release Metadata
         id: metadata

--- a/.github/workflows/deploy-1-setup.yml
+++ b/.github/workflows/deploy-1-setup.yml
@@ -46,10 +46,15 @@ on:
           Within the spack manifest, the overarching spack bundle that contains all other packages.
           Usually the first entry in the .spack.specs section of the manifest.
     outputs:
+      general-metadata-artifact-glob:
+        value: ${{ jobs.deployment.outputs.general-metadata-artifact-glob }}
+        description: |
+          General pattern for the artifact that contains the deployment metadata files for this invocation of the job.
+          These files are of the form deploy-metadata.{{inputs.deployment-target}}
       general-outputs-artifact-glob:
         value: ${{ jobs.outputs-upload.outputs.general-artifact-name }}
         description: |
-          General pattern for the artifact that contains the outputs for this invocation of the job.
+          General pattern for the artifact that contains the text outputs for this invocation of the job.
           Output files are of the form deploy-outputs.{{inputs.deployment-target}}
     # TODO: This is a workaround for matrixed dynamic job outputs. See https://github.com/orgs/community/discussions/17245
     # The outputs in the file are below:
@@ -273,7 +278,7 @@ jobs:
     needs:
       - check-config  # Verify configuration information is correct
       - check-spack-yaml  # Verify spack manifest information is correct
-    uses: access-nri/build-cd/.github/workflows/deploy-2-start.yml@main
+    uses: access-nri/build-cd/.github/workflows/deploy-2-start.yml@v3
     with:
       type: ${{ inputs.deployment-type }}
       model: ${{ inputs.spack-manifest-root-sbd }}

--- a/.github/workflows/deploy-2-start.yml
+++ b/.github/workflows/deploy-2-start.yml
@@ -208,6 +208,13 @@ jobs:
             '${{ secrets.USER}}@${{ secrets.HOST_DATA }}:${{ env.SPACK_ENV_PATH }}/spack.*' \
             ./${{ env.ARTIFACT_NAME }}
 
+          # Rename the files to include the deployment environment
+          cd ./${{ env.ARTIFACT_NAME }}
+          for file in *; do
+            mv "$file" "${{ inputs.deployment-environment }}.$file"
+          done
+          cd -
+
       - name: Upload Metadata Artifact
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/deploy-2-start.yml
+++ b/.github/workflows/deploy-2-start.yml
@@ -38,10 +38,16 @@ on:
       spack-location:
         value: ${{ jobs.deploy-to-environment.outputs.spack-location }}
         description: The location of the spack directory on the deployment environment
+      general-metadata-artifact-glob:
+        value: ${{ jobs.deploy-to-environment.outputs.metadata-artifact-name }}
+        description: |
+          General pattern for the artifact that contains the deployment metadata files for this invocation of the job.
+          These files are of the form deploy-metadata.{{inputs.deployment-target}}
 env:
   SPACK_YAML_SPEC_YQ: .spack.specs[0]
   SPACK_YAML_MODULEFILE_PROJECTION_YQ: .spack.modules.default.tcl.projections.${{ inputs.root-sbd }}
   METADATA_PATH: /opt/metadata
+  ARTIFACT_NAME: deploy-metadata.${{ inputs.deployment-environment }}
 jobs:
   deploy-to-environment:
     name: Deploy to ${{ inputs.deployment-environment }}
@@ -52,6 +58,7 @@ jobs:
       config-version: ${{ steps.versions.outputs.config }}
       spack-location: ${{ steps.location.outputs.spack }}
       modules-location: ${{ steps.location.outputs.modules }}
+      metadata-artifact-name: ${{ env.ARTIFACT_NAME }}
     steps:
       # Deployment
       - uses: actions/checkout@v4
@@ -199,89 +206,10 @@ jobs:
         run: |
           rsync -e 'ssh -i ${{ steps.ssh.outputs.private-key-path }}' \
             '${{ secrets.USER}}@${{ secrets.HOST_DATA }}:${{ env.SPACK_ENV_PATH }}/spack.*' \
-            ./${{ inputs.env-name }}
+            ./${{ env.ARTIFACT_NAME }}
 
       - name: Upload Metadata Artifact
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ inputs.env-name }}
-          path: ./${{ inputs.env-name }}/*
-          overwrite: true
-
-  release:
-    name: Create Release
-    if: inputs.type == 'Release'
-    needs:
-      - deploy-to-environment
-    runs-on: ubuntu-latest
-    outputs:
-      url: ${{ steps.release.outputs.url }}
-      created-at: ${{ steps.metadata.outputs.created-at }}
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Download Metadata Artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: ${{ inputs.env-name }}
-          path: ${{ env.METADATA_PATH }}
-
-      - name: Create Release
-        id: release
-        uses: softprops/action-gh-release@69320dbe05506a9a39fc8ae11030b214ec2d1f87  # v2.0.5
-        with:
-          tag_name: ${{ inputs.version }}
-          name: ${{ inputs.model}} ${{ inputs.version }}
-          body: |
-            This release of ${{ inputs.model }} ${{ inputs.version }} uses [spack-packages ${{ needs.deploy-to-environment.outputs.packages-version }}](https://github.com/ACCESS-NRI/spack-packages/releases/tag/${{ needs.deploy-to-environment.outputs.packages-version }}) and [spack-config ${{ needs.deploy-to-environment.outputs.config-version }}](https://github.com/ACCESS-NRI/spack-config/releases/tag/${{ needs.deploy-to-environment.outputs.config-version }}).
-          generate_release_notes: true
-          fail_on_unmatched_files: true
-          files: |
-            ${{ env.METADATA_PATH }}/spack.yaml
-            ${{ env.METADATA_PATH }}/spack.lock
-            ${{ env.METADATA_PATH }}/spack.location
-            ${{ env.METADATA_PATH }}/spack.location.json
-
-      - name: Release Metadata
-        id: metadata
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: echo "created-at=$(gh release view --json createdAt --jq '.createdAt')" >> $GITHUB_OUTPUT
-
-  build-db:
-    name: Build DB Metadata Upload
-    if: inputs.type == 'Release'
-    needs:
-      - deploy-to-environment
-      - release
-    runs-on: ubuntu-latest
-    steps:
-      - name: Download Metadata Artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: ${{ inputs.env-name }}
-          path: ${{ env.METADATA_PATH }}
-
-      - name: Checkout Upload Script
-        uses: actions/checkout@v4
-        with:
-          repository: access-nri/build-cd
-
-      - name: Setup Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ vars.PYTHON_VERSION }}
-          cache: pip
-
-      - name: Install Build Metadata Script Requirements
-        run: pip install -r tools/release_provenance/requirements.txt
-
-      - name: Upload Build Metadata
-        env:
-          BUILD_DB_CONNECTION_STR: ${{ secrets.BUILD_DB_CONNECTION_STR }}
-          OUTPUT_PATH: ./metadata_output
-        run: |
-          ./scripts/generate-build-metadata.bash ${{ needs.release.outputs.url }} ${{ needs.release.outputs.created-at }} ${{ needs.deploy-to-environment.outputs.packages-version }} ${{ needs.deploy-to-environment.outputs.config-version }} ${{ env.METADATA_PATH }} ${{ env.OUTPUT_PATH }} ${{ inputs.root-sbd }} ${{ vars.BUILD_DB_PACKAGES }}
-
-          echo "Attempting upload of build_metadata.json"
-          python ./tools/release_provenance/save_release.py "${{ env.OUTPUT_PATH }}/build_metadata.json"
+          name: ${{ env.ARTIFACT_NAME }}
+          path: ./${{ env.ARTIFACT_NAME }}/*


### PR DESCRIPTION
References #200

## Background

This PR updates our release pipeline to do a single, post-multi-target-deployment GitHub Release, of the form https://github.com/ACCESS-NRI/build-cd/issues/200#issuecomment-2574326112 - instead of a release per deployment target. See image for a rough idea of the changes:

![release-changes](https://github.com/user-attachments/assets/4192a8b0-de42-470d-9d3e-530f94a65ae7)

In this PR:
- Move `release` and `build-db` jobs out of matrixed `deploy-2-start.yml` job, into `cd.yml`, so it can fire once all deployments are complete
- Update metadata artifact (which contains `spack.yaml`, `spack.lock`...) to instead be prepended with deployment target (eg. `deploy-metadata.Gadi`, `deploy-metadata.Setonix`...)
- Output a metadata artifact glob from `deploy-2-start.yml`, similar to the `deploy-outputs.*` glob from matrixed `deploy-1-setup.yml` (eg. `deploy-metadata.*`). Used to add deployment metadata files to the release.
- Generate the non-autogenerated release notes based on deployment environments

## Testing

Testing of the new release comment generation was done in my own test org so we don't create any actual release deployments of `ACCESS-TEST`. [This workflow run](https://github.com/codegat-test-org/test/actions/runs/12645405597) created https://github.com/codegat-test-org/test/releases/tag/v1.0.0 using [this workflow file](https://github.com/codegat-test-org/test/blob/27914c1cb3b92a585842b1982530e2e62529ac65/.github/workflows/test_updated_release.yml).
