### PR TITLE
Replace `env.SPACK_YAML_MODEL_YQ` to accomodate for multi-target-format `spack.yaml`

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -27,7 +27,9 @@ on:
   #     - spack.yaml
 
 env:
-  SPACK_YAML_MODEL_YQ: .spack.specs[0]
+  # This attempts to get the spack.yaml model first via the multi-target
+  # .spack.definitions.root_package method, then the traditional '.spack.specs[0]'.
+  SPACK_YAML_MODEL_YQ: (.spack.definitions[] | select(."root_package") | .[][]) // .spack.specs[0]
   METADATA_PATH: /opt/metadata
   OUTPUTS_PATH: /opt/outputs
 jobs:

--- a/.github/workflows/ci-comment.yml
+++ b/.github/workflows/ci-comment.yml
@@ -13,7 +13,7 @@ on:
       root-sbd:
         type: string
         required: false
-        # The equivalent default is set in the defaults job below. 
+        # The equivalent default is set in the defaults job below.
         # default: ${{ inputs.model }}
         description: |
           The name of the root Spack Bundle Definition, if it is different from the model name.
@@ -53,7 +53,9 @@ jobs:
       contents: write
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      SPACK_YAML_MODEL_YQ: .spack.specs[0]
+      # This attempts to get the spack.yaml model first via the multi-target
+      # .spack.definitions.root_package method, then the traditional '.spack.specs[0]'.
+      SPACK_YAML_MODEL_YQ: (.spack.definitions[] | select(."root_package") | .[][]) // .spack.specs[0]
       SPACK_YAML_MODEL_PROJECTION_YQ: .spack.modules.default.tcl.projections.${{ needs.defaults.outputs.root-sbd }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/deploy-1-setup.yml
+++ b/.github/workflows/deploy-1-setup.yml
@@ -162,7 +162,9 @@ jobs:
     permissions:
       pull-requests: write
     env:
-      SPACK_YAML_MODEL_YQ: .spack.specs[0]
+      # This attempts to get the spack.yaml model first via the multi-target
+      # .spack.definitions.root_package method, then the traditional '.spack.specs[0]'.
+      SPACK_YAML_MODEL_YQ: (.spack.definitions[] | select(."root_package") | .[][]) // .spack.specs[0]
     outputs:
       # Release version of the deployment. Inferred if not given in inputs.deployment-version
       release: ${{ steps.version.outputs.release }}

--- a/.github/workflows/deploy-2-start.yml
+++ b/.github/workflows/deploy-2-start.yml
@@ -44,7 +44,9 @@ on:
           General pattern for the artifact that contains the deployment metadata files for this invocation of the job.
           These files are of the form deploy-metadata.{{inputs.deployment-target}}
 env:
-  SPACK_YAML_SPEC_YQ: .spack.specs[0]
+  # This attempts to get the spack.yaml model first via the multi-target
+  # .spack.definitions.root_package method, then the traditional '.spack.specs[0]'.
+  SPACK_YAML_MODEL_YQ: (.spack.definitions[] | select(."root_package") | .[][]) // .spack.specs[0]
   SPACK_YAML_MODULEFILE_PROJECTION_YQ: .spack.modules.default.tcl.projections.${{ inputs.root-sbd }}
   METADATA_PATH: /opt/metadata
   ARTIFACT_NAME: deploy-metadata.${{ inputs.deployment-environment }}


### PR DESCRIPTION
Closes #208

## Background

Since we are (pre-emptively) going with the multi-target-compliant `spack.yaml` referenced in https://github.com/ACCESS-NRI/model-deployment-template/issues/15#issuecomment-2574265200 (https://github.com/ACCESS-NRI/model-deployment-template/issues/15), we'll need to update the `yq` filter to accomodate for root packages that are stored in `.spack.definitions[].root_package[]` rather than `.spack.specs[0]`. 


In this PR:
* Update `env.SPACK_YAML_MODEL_YQ` across the pipeline to first check for the new multi-target-compliant type of definition, and if that's `null`, go back to the traditional `.spack.specs[0]`. 

## Testing

Tested `yq` filter locally using https://github.com/ACCESS-NRI/ACCESS-OM2/blob/d907f3314a9956875baaaaf2b4d7b6be6fa81926/spack.yaml and https://github.com/ACCESS-NRI/ACCESS-OM2/blob/69168932f1b3414a5c5850a8c62063d0c7b48628/spack.yaml
