### PR TITLE
config/settings.json: use Spack v0.22.3

### DIFF
--- a/config/settings.json
+++ b/config/settings.json
@@ -8,13 +8,13 @@
           "spack-config": "2024.03.22"
         },
         "0.22": {
-          "spack": "21da7d7e2b5e2680cd9d2e0a2fb4a7d13d8baa9d",
+          "spack": "54edfb12f97a7bab2754ee58a1efffcb9a031232",
           "spack-config": "2024.11.27"
         }
       },
       "Prerelease": {
         "0.22": {
-          "spack": "21da7d7e2b5e2680cd9d2e0a2fb4a7d13d8baa9d",
+          "spack": "54edfb12f97a7bab2754ee58a1efffcb9a031232",
           "spack-config": "2024.11.27"
         }
       }


### PR DESCRIPTION
Tested Spack v0.22.3 (minor update to v0.22.2) on Gadi, Setonix and Docker by doing an ACCESS-OM2 to build.