### PR TITLE
Update Acceptable Environments to the form `SUPERCOMPUTER TYPE`

### DIFF
--- a/.github/workflows/deploy-1-setup.yml
+++ b/.github/workflows/deploy-1-setup.yml
@@ -8,7 +8,7 @@ on:
         required: true
         description: |
           The target machine for the model being deployed.
-          Equivalent to the name of the GitHub Environment, minus a potential Prerelease Type.
+          Equivalent to the name of the GitHub Environment, minus a Release/Prerelease Type.
       deployment-type:
         type: string
         required: true
@@ -282,7 +282,6 @@ jobs:
       - check-spack-yaml  # Verify spack manifest information is correct
     uses: access-nri/build-cd/.github/workflows/deploy-2-start.yml@v4
     with:
-      type: ${{ inputs.deployment-type }}
       model: ${{ inputs.spack-manifest-root-sbd }}
       ref: ${{ inputs.deployment-ref }}
       version: ${{ inputs.deployment-version }}

--- a/.github/workflows/deploy-2-start.yml
+++ b/.github/workflows/deploy-2-start.yml
@@ -3,10 +3,6 @@ concurrency: ${{ inputs.deployment-target }} ${{ inputs.deployment-type }}
 on:
   workflow_call:
     inputs:
-      type:
-        type: string
-        required: true
-        description: The type of deployment - either 'Release' or 'Prerelease'
       model:
         type: string
         required: true
@@ -27,7 +23,7 @@ on:
         type: string
         required: true
         description: |
-          The GitHub Environment, minus a potential Type.
+          The GitHub Environment, minus a Type.
           Combined with inputs.deployment-type to create the GitHub Environment name.
       deployment-type:
         type: string
@@ -35,7 +31,7 @@ on:
         description: |
           The type of deployment.
           Can be one of: Release, Prerelease.
-          Combined with inputs.deployment-type to create the GitHub Environment name.
+          Combined with inputs.deployment-target to create the GitHub Environment name.
       root-sbd:
         type: string
         required: true
@@ -63,7 +59,7 @@ jobs:
   deploy-to-environment:
     name: Deploy to ${{ inputs.deployment-target }} ${{ inputs.deployment-type }}
     runs-on: ubuntu-latest
-    environment: ${{ inputs.deployment-target }} ${{ inputs.deployment-type != 'Release' && inputs.deployment-type || '' }}
+    environment: ${{ inputs.deployment-target }} ${{ inputs.deployment-type }}
     outputs:
       packages-version: ${{ steps.versions.outputs.packages }}
       config-version: ${{ steps.versions.outputs.config }}
@@ -100,7 +96,7 @@ jobs:
             ${{ secrets.HOST_DATA }}
 
       - name: Prerelease spack.yaml Modifications
-        if: inputs.type == 'Prerelease'
+        if: inputs.deployment-type == 'Prerelease'
         # Modifies the name of the prerelease modulefile to the
         # `pr<number>-<commit>` style. For example, `access-om3/pr12-2`.
         # Also removes the `@git.VERSION` specifier for Prereleases so

--- a/.github/workflows/undeploy-1-start.yml
+++ b/.github/workflows/undeploy-1-start.yml
@@ -38,7 +38,7 @@ jobs:
     name: Undeploy ${{ inputs.version-pattern }} from ${{ inputs.target }} ${{ inputs.type }}
     needs: validate-inputs
     runs-on: ubuntu-latest
-    environment: ${{ inputs.target }} ${{ inputs.type != 'Release' && inputs.type }}
+    environment: ${{ inputs.target }} ${{ inputs.type }}
     steps:
       - uses: actions/checkout@v4
 
@@ -52,7 +52,7 @@ jobs:
         with:
           spack-installs-root-path: ${{ vars.SPACK_INSTALLS_ROOT_LOCATION }}
           spack-version: ${{ steps.versions.outputs.spack }}
-          deployment-environment: ${{ inputs.target }} ${{ inputs.type != 'Release' && inputs.type }}
+          deployment-environment: ${{ inputs.target }} ${{ inputs.type }}
 
       - name: Setup SSH
         id: ssh


### PR DESCRIPTION
Closes #220

## Background

It's a bit strange to have release environments of the form `SUPERCOMPUTER`, when Prereleases are of the form `SUPERCOMPUTER Prerelease`. Since we're already doing a bunch of major-level updates in #121, we'll add this to the pile.

Requires GitHub Environments for `Release` to be of the form `SUPERCOMPUTER Release`. 

## Testing

Used the `ACCESS-NRI/ACCESS-TEST` repository to test that the changes had no ill effects to both Prereleases and Releases. Used branch `dev-121-multi-target-workflows_TEST` into `main` with PR https://github.com/ACCESS-NRI/ACCESS-TEST/pull/22 and Release deployment run https://github.com/ACCESS-NRI/ACCESS-TEST/actions/runs/13106902743/job/36563191633. 

Nothing problematic happened - although note the failure of the ModelDB upload - this was because I'd hard-coded in a reference to `GadiTest` rather than `Gadi` (just for the `_TEST` branch), but I'd created a `Gadi Release` Environment rather than a `GadiTest Release` one. Whoops!

The created Release is at https://github.com/ACCESS-NRI/ACCESS-TEST/releases/tag/2025.01.1
