### PR TITLE
Tools for Mass Model Deployment Repository Operations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ venv
 # Testing files
 *.pyc
 __pycache__
+# Environment Files
+.secrets.env
+.vars.env

--- a/tools/mdr-change/README.md
+++ b/tools/mdr-change/README.md
@@ -48,7 +48,6 @@ Pull requests are annoying to create sometimes. But they're even more annoying w
 
 #### Prerequisites
 
-- You have updated the `--title` arg in the script.
 - Optionally, you have added other changes to files needed in the script.
 - You have updated/created a new PR body based on `templates/general.pull-request.md`.
 
@@ -74,8 +73,6 @@ Draft pull requests in all MDRs.
 ### Mass-Create/Update GitHub Environment Variables/Secrets in ALL MDRs - `mass-repo-env-change.bash`
 
 Sometimes `vars/secrets` needs to be updated in a given environment across all MDRs. This can be a bit annoying to do, so there is a script to do it.
-
-Note that this cannot handle multiline values (such as SSH keys).
 
 > [!NOTE]
 > For info on what variables should be set, see [ACCESS-NRI/model-deployment-template](https://github.com/ACCESS-NRI/model-deployment-template).

--- a/tools/mdr-change/README.md
+++ b/tools/mdr-change/README.md
@@ -55,15 +55,16 @@ Pull requests are annoying to create sometimes. But they're even more annoying w
 #### Inputs
 
 ```bash
-# Usage: ./mass-create-prs.bash <version> <body_file> <repos_dir>`
+# Usage: ./mass-create-prs.bash <version> '<pr_title>' <pr_body_file> <repos_dir>`
 # Example:
-./mass-create-prs.bash v5 ./templates/general.pull-request.md ../../..
+./mass-create-prs.bash v5 'Infrastructure Update: v5: New Feature' ./templates/general.pull-request.md ../../..
 ```
 
 Where:
 
 - `version` is the version of the `build-cd` infrastructure will be used in entrypoint workflows to `build-cd` in MDRs.
-- `body-file` is a path to a file containing a PR description suitable for use for all MDRs, based on `templates/general.pull-request.md`.
+- `pr_title` is a string that will be the title for all created PRs.
+- `pr_body_file` is a path to a file containing a PR description suitable for use for all MDRs, based on `templates/general.pull-request.md`.
 - `repos_dir` is a local directory that is the parent of all model deployment repositories referenced in the script. This is so we can make the changes needed for a PR to be opened.
 
 #### Outputs

--- a/tools/mdr-change/README.md
+++ b/tools/mdr-change/README.md
@@ -106,8 +106,6 @@ An updated variable/secret in the given environment across all MDRs.
 
 Sometimes repo-level `vars/secrets` (rather than environment-level, see [this section](#mass-createupdate-github-environment-variablessecrets-in-all-mdrs---mass-repo-env-changebash)) needs to be updated across all MDRs. This can be a bit annoying to do too, so there is a script to do it.
 
-Note that this cannot handle multiline values (such as SSH keys).
-
 > [!NOTE]
 > For info on what variables should be set, see [ACCESS-NRI/model-deployment-template](https://github.com/ACCESS-NRI/model-deployment-template).
 

--- a/tools/mdr-change/README.md
+++ b/tools/mdr-change/README.md
@@ -1,0 +1,137 @@
+# Model Deployment Repository Change Scripts
+
+This folder contains scripts for mass changes to Model Deployment Repositories (MDRs) - focussed especially around the PR creation process or environment variable updates.
+
+## Scripts
+
+Don't forget to check the inputs, as well as if any of the script needs to be modified before running. This extends to templates used or `.env` files it expects.
+
+> [!NOTE]
+> All of these scripts require `admin` permissions, except for `mass-create-pr.bash`, which requires `write`.
+
+### Create New MDR-Style GitHub Environment in a Repository - `create-env.bash`
+
+Creating environments via the web interface is annoying. Especially when you're essentially creating the same thing every time, as is common in MDRs.
+
+This script creates a MDR-style GitHub Environment informed by local, **NOT** version controlled `.env` files. It sets @aidanheerdegen and @CodeGat as Environment Approvers.
+
+> [!NOTE]
+> For info on what variables should be in the `.env` files, see [ACCESS-NRI/model-deployment-template](https://github.com/ACCESS-NRI/model-deployment-template).
+
+#### Inputs
+
+```bash
+# Usage: ./create-env.bash <repo> <target> <type> <secrets_file> <vars_file> <ssh_key_file>`
+# Example:
+./create-env.bash access-nri/access-test Gadi Release ../.secrets.env ../.vars.env ~/.ssh/key
+```
+
+Where:
+
+- `repo` is a repository in `OWNER/REPO` format.
+- `target` is the name of the HPC system, no spaces allowed.
+- `type` is the type of environment. Currently one of `Release`/`Prerelease`.
+- `secrets_file` is a path to a local `dotenv`-style file that contains all the secret names and values for import, minus the `secrets.SSH_KEY` secret.
+- `vars_file` is a path to a local `dotenv`-style file that contains all the variable names and values for import.
+- `ssh_key_file` is a file that contains an SSH private key that is used in the `secrets.SSH_KEY` variable.
+
+#### Outputs
+
+A GitHub environment ready to use for deployments, at a given repository.
+
+### Mass-Create Infrastructure-Updating PRs in ALL MDRs - `mass-create-pr.bash`
+
+Pull requests are annoying to create sometimes. But they're even more annoying when you have to do the same PR for every model deployment repository. This script automates PR creation to all model deployment repositories for a given version of `build-cd` infrastructure.
+
+> [!IMPORTANT]
+> This is a mass operation. Make sure you've got the inputs and prerequisites right before running this script!
+
+#### Prerequisites
+
+- You have updated the `--title` arg in the script.
+- Optionally, you have added other changes to files needed in the script.
+- You have updated/created a new PR body based on `templates/general.pull-request.md`.
+
+#### Inputs
+
+```bash
+# Usage: ./mass-create-prs.bash <version> <body_file> <repos_dir>`
+# Example:
+./mass-create-prs.bash v5 ./templates/general.pull-request.md ../../..
+```
+
+Where:
+
+- `version` is the version of the `build-cd` infrastructure will be used in entrypoint workflows to `build-cd` in MDRs.
+- `body-file` is a path to a file containing a PR description suitable for use for all MDRs, based on `templates/general.pull-request.md`.
+- `repos_dir` is a local directory that is the parent of all model deployment repositories referenced in the script. This is so we can make the changes needed for a PR to be opened.
+
+#### Outputs
+
+Draft pull requests in all MDRs.
+
+### Mass-Create/Update GitHub Environment Variables/Secrets in ALL MDRs - `mass-repo-env-change.bash`
+
+Sometimes `vars/secrets` needs to be updated in a given environment across all MDRs. This can be a bit annoying to do, so there is a script to do it.
+
+Note that this cannot handle multiline values (such as SSH keys).
+
+> [!NOTE]
+> For info on what variables should be set, see [ACCESS-NRI/model-deployment-template](https://github.com/ACCESS-NRI/model-deployment-template).
+
+Also,
+
+> [!IMPORTANT]
+> This is a mass operation. Make sure you've got the inputs and prerequisites right before running this script!
+
+#### Inputs
+
+```bash
+# Usage: ./mass-repo-env-change.bash <env_target> <env_type> <var_type> <var_name> <value>`
+# Example:
+./mass-repo-env-change.bash Gadi Release variable DEPLOYMENT_TARGET gadi
+```
+
+Where:
+
+- `env_target` is the name of the HPC system, no spaces allowed.
+- `env_type` is the type of environment. Currently one of `Release`/`Prerelease`.
+- `var_type` is the type of data being stored. Either `secret` or `variable`.
+- `var_name` is the name of the data stored.
+- `value` is the value of the data stored.
+
+#### Outputs
+
+An updated variable/secret in the given environment across all MDRs.
+
+### Mass-Create/Update Repo Variables/Secrets in ALL MDRs - `mass-repo-change.bash`
+
+Sometimes repo-level `vars/secrets` (rather than environment-level, see [this section](#mass-createupdate-github-environment-variablessecrets-in-all-mdrs---mass-repo-env-changebash)) needs to be updated across all MDRs. This can be a bit annoying to do too, so there is a script to do it.
+
+Note that this cannot handle multiline values (such as SSH keys).
+
+> [!NOTE]
+> For info on what variables should be set, see [ACCESS-NRI/model-deployment-template](https://github.com/ACCESS-NRI/model-deployment-template).
+
+Also,
+
+> [!IMPORTANT]
+> This is a mass operation. Make sure you've got the inputs and prerequisites right before running this script!
+
+#### Inputs
+
+```bash
+# Usage: ./mass-repo-env-change.bash <var_type> <var_name> <value>`
+# Example:
+./mass-repo-env-change.bash variable SPACK_YAML_SCHEMA_VERSION 1-0-4
+```
+
+Where:
+
+- `var_type` is the type of data being stored. Either `secret` or `variable`.
+- `var_name` is the name of the data stored.
+- `value` is the value of the data stored.
+
+#### Outputs
+
+An updated repo-level variable/secret across all MDRs.

--- a/tools/mdr-change/create-env.bash
+++ b/tools/mdr-change/create-env.bash
@@ -26,11 +26,11 @@ if [ ! -f "$secrets_env_file" ]; then
     exit 1
 fi
 if [ ! -f "$vars_env_file" ]; then
-    echo "Secrets Environment file not found: $vars_env_file"
+    echo "Variable Environment file not found: $vars_env_file"
     exit 1
 fi
 if [ ! -f "$ssh_key_file" ]; then
-    echo "Secrets Environment file not found: $ssh_key_file"
+    echo "SSH Key file not found: $ssh_key_file"
     exit 1
 fi
 

--- a/tools/mdr-change/create-env.bash
+++ b/tools/mdr-change/create-env.bash
@@ -1,0 +1,81 @@
+#!/bin/bash
+# Script that creates an environment for a given repository
+
+### Variables
+
+repo=$1
+
+environment_target=$2
+environment_type=$3
+environment_name="${environment_target} ${environment_type}"
+
+
+secrets_env_file=$4
+vars_env_file=$5
+
+ssh_key_file=$6
+
+### Input checking
+if [ -z "$repo" ] || [ -z "$environment_target" ] || [ -z "$environment_type" ] || [ -z "$secrets_env_file" ] || [ -z "$vars_env_file" ] || [ -z "$ssh_key_file" ]; then
+    echo "Usage: $0 <repo> <target> <type> <secrets_file> <vars_file> <ssh_key_file>"
+    exit 1
+fi
+
+if [ ! -f "$secrets_env_file" ]; then
+    echo "Secrets Environment file not found: $secrets_env_file"
+    exit 1
+fi
+if [ ! -f "$vars_env_file" ]; then
+    echo "Secrets Environment file not found: $vars_env_file"
+    exit 1
+fi
+if [ ! -f "$ssh_key_file" ]; then
+    echo "Secrets Environment file not found: $ssh_key_file"
+    exit 1
+fi
+
+
+### Environment
+# Create environment
+# Reviewers are CodeGat and aidanheerdegen
+if [[ "$environment_type" == "Release" ]]; then
+  # Set branch protections
+  gh api \
+    --method PUT \
+    -H "Accept: application/vnd.github+json" \
+    -H "X-GitHub-Api-Version: 2022-11-28" \
+    "/repos/$repo/environments/$environment_name" \
+    -F "prevent_self_review=false" \
+    -F "reviewers[][type]=User" \
+    -F "reviewers[][id]=45781416" \
+    -F "reviewers[][type]=User" \
+    -F "reviewers[][id]=6063709" \
+    -F "deployment_branch_policy[protected_branches]=false" \
+    -F "deployment_branch_policy[custom_branch_policies]=true"
+
+  # Set custom branch policies
+  gh api \
+    --method POST \
+    -H "Accept: application/vnd.github+json" \
+    -H "X-GitHub-Api-Version: 2022-11-28" \
+    "/repos/$repo/environments/$environment_name/deployment-branch-policies" \
+    -f "name=main" -f "type=branch"
+
+  gh api \
+    --method POST \
+    -H "Accept: application/vnd.github+json" \
+    -H "X-GitHub-Api-Version: 2022-11-28" \
+    "/repos/$repo/environments/$environment_name/deployment-branch-policies" \
+    -f "name=backport/*.*" -f "type=branch"
+
+else
+  gh api \
+    --method PUT \
+    -H "Accept: application/vnd.github+json" \
+    -H "X-GitHub-Api-Version: 2022-11-28" \
+    "/repos/$repo/environments/$environment_name"
+fi
+
+# Set secrets/vars via env files
+gh secret set --repo "$repo" --env "$environment_name" -f "$secrets_env_file"
+gh variable set --repo "$repo" --env "$environment_name" -f "$vars_env_file"

--- a/tools/mdr-change/create-env.bash
+++ b/tools/mdr-change/create-env.bash
@@ -78,4 +78,5 @@ fi
 
 # Set secrets/vars via env files
 gh secret set --repo "$repo" --env "$environment_name" -f "$secrets_env_file"
+gh secret set SSH_KEY --repo "$repo" --env "$environment_name" < "$ssh_key_file"
 gh variable set --repo "$repo" --env "$environment_name" -f "$vars_env_file"

--- a/tools/mdr-change/create-env.bash
+++ b/tools/mdr-change/create-env.bash
@@ -40,6 +40,7 @@ fi
 # Reviewers are CodeGat and aidanheerdegen
 if [[ "$environment_type" == "Release" ]]; then
   # Set branch protections
+  # https://docs.github.com/en/rest/deployments/environments?apiVersion=2022-11-28#create-or-update-an-environment
   gh api \
     --method PUT \
     -H "Accept: application/vnd.github+json" \
@@ -54,6 +55,7 @@ if [[ "$environment_type" == "Release" ]]; then
     -F "deployment_branch_policy[custom_branch_policies]=true"
 
   # Set custom branch policies
+  # https://docs.github.com/en/rest/deployments/branch-policies?apiVersion=2022-11-28#create-a-deployment-branch-policy
   gh api \
     --method POST \
     -H "Accept: application/vnd.github+json" \

--- a/tools/mdr-change/mass-create-pr.bash
+++ b/tools/mdr-change/mass-create-pr.bash
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+### Variables
+version=$1
+body_file=$2
+repos_dir=$3
+
+if [ -z "$version" ] || [ -z "$body_file" ] || [ -z "$repos_dir" ]; then
+    echo "Usage: $0 <version> <body_file> <repos_dir>"
+    exit 1
+fi
+
+### Creation of changes and PR
+
+deployment_repos=$(gh search repos --owner access-nri \
+  --json name \
+  --jq '[.[].name] | join(" ")' \
+  -- topic:deployment -topic:template
+)
+branch="infra-update-$version"
+
+echo "MAKE SURE YOU HAVE UPDATED THE BODY FILE + PR TITLE IN SCRIPT"
+echo "Going to change the following repos in 10s: $deployment_repos"
+sleep 10
+
+for repo in $deployment_repos; do
+  cd "$repos_dir/$repo" || exit
+  # Getting repos in a state to create PR
+  git checkout main
+  git pull
+  git checkout -b "$branch"
+
+  # Editing of files - be careful!
+  # Basic update of entrypoints to $version
+  sed -i -E "s/@v.+/@$version/g" .github/workflows/c*.yml
+  # Other changes here...
+
+  # git operations
+  git add .
+  git commit -m "infra: Update to $version"
+  git push
+
+  # PR creation
+  cd - || exit
+  gh pr create \
+    --repo "access-nri/$repo" \
+    --assignee @me \
+    --title "Deployment Infrastructure $version: CHANGES" \
+    --body-file "$body_file" \
+    --base main \
+    --head "$branch" \
+    --label type:infra \
+    --draft
+
+  sleep 3
+done

--- a/tools/mdr-change/mass-create-pr.bash
+++ b/tools/mdr-change/mass-create-pr.bash
@@ -2,11 +2,12 @@
 
 ### Variables
 version=$1
-body_file=$2
-repos_dir=$3
+pr_title=$2
+pr_body_file=$3
+repos_dir=$4
 
-if [ -z "$version" ] || [ -z "$body_file" ] || [ -z "$repos_dir" ]; then
-    echo "Usage: $0 <version> <body_file> <repos_dir>"
+if [ -z "$version" ] || [ -z "$pr_title" ] || [ -z "$pr_body_file" ] || [ -z "$repos_dir" ]; then
+    echo "Usage: $0 <version> '<title>' <pr_body_file> <repos_dir>"
     exit 1
 fi
 
@@ -25,6 +26,14 @@ sleep 10
 
 for repo in $deployment_repos; do
   cd "$repos_dir/$repo" || exit
+
+  # Check if there are uncommitted changes and exit if so - we don't want to commit something automatically
+  uncommitted_changes=$(git ls-files --others --directory --deleted --modified --exclude-standard)
+  if [ -n "$uncommitted_changes" ]; then
+    echo "Uncommitted changes in $repo: $uncommitted_changes. Exiting..."
+    exit 1
+  fi
+
   # Getting repos in a state to create PR
   git checkout main
   git pull
@@ -32,7 +41,7 @@ for repo in $deployment_repos; do
 
   # Editing of files - be careful!
   # Basic update of entrypoints to $version
-  sed -i -E "s/@v.+/@$version/g" .github/workflows/c*.yml
+  sed -i -E "s|(access-nri/build-cd/.+)@v.+|\1@$version|g" .github/workflows/c*.yml
   # Other changes here...
 
   # git operations
@@ -45,8 +54,8 @@ for repo in $deployment_repos; do
   gh pr create \
     --repo "access-nri/$repo" \
     --assignee @me \
-    --title "Deployment Infrastructure $version: CHANGES" \
-    --body-file "$body_file" \
+    --title "$pr_title" \
+    --body-file "$pr_body_file" \
     --base main \
     --head "$branch" \
     --label type:infra \

--- a/tools/mdr-change/mass-env-change.bash
+++ b/tools/mdr-change/mass-env-change.bash
@@ -1,0 +1,32 @@
+#!/bin/bash
+# Script that updates environment variables for a given environment in all deployment repositories
+
+### Variables
+
+environment_target=$1
+environment_type=$2
+environment_name="${environment_target} ${environment_type}"
+
+var_type=$3
+var_name=$4
+value=$5
+
+### Input checking
+if [ -z "$environment_target" ] || [ -z "$environment_type" ] || [ -z "$var_type" ] || [ -z "$var_name" ] || [ -z "$value" ]; then
+    echo "Usage: $0 <env_target> <env_type> <var_type> <var_name> <value>"
+    exit 1
+fi
+
+deployment_repos=$(gh search repos --owner access-nri \
+  --json name \
+  --jq '[.[].name] | join(" ")' \
+  -- topic:deployment -topic:template
+)
+
+for repo in $deployment_repos; do
+  if [[ "$var_type" == "secret" ]]; then
+    gh secret set "$var_name" --repo "access-nri/$repo" --env "$environment_name" --body "$value"
+  elif [[ "$var_type" == "variable" ]]; then
+    gh variable set "$var_name" --repo "access-nri/$repo" --env "$environment_name" --body "$value"
+  fi
+done

--- a/tools/mdr-change/mass-repo-change.bash
+++ b/tools/mdr-change/mass-repo-change.bash
@@ -1,0 +1,27 @@
+#!/bin/bash
+# Script that updates repo variables in all deployment repositories
+
+### Variables
+var_type=$1
+var_name=$2
+value=$3
+
+### Input checking
+if [ -z "$var_type" ] || [ -z "$var_name" ] || [ -z "$value" ]; then
+    echo "Usage: $0 <var_type> <var_name> <value>"
+    exit 1
+fi
+
+deployment_repos=$(gh search repos --owner access-nri \
+  --json name \
+  --jq '[.[].name] | join(" ")' \
+  -- topic:deployment -topic:template
+)
+
+for repo in $deployment_repos; do
+  if [[ "$var_type" == "secret" ]]; then
+    gh secret set "$var_name" --repo "access-nri/$repo" --body "$value"
+  elif [[ "$var_type" == "variable" ]]; then
+    gh variable set "$var_name" --repo "access-nri/$repo" --body "$value"
+  fi
+done

--- a/tools/mdr-change/mass-repo-env-change.bash
+++ b/tools/mdr-change/mass-repo-env-change.bash
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Script that updates environment variables for a given environment in all deployment repositories
+# Script that updates repo variables for a given environment in all deployment repositories
 
 ### Variables
 

--- a/tools/mdr-change/templates/general.pull-request.md
+++ b/tools/mdr-change/templates/general.pull-request.md
@@ -1,0 +1,18 @@
+References issue ACCESS-NRI/build-cd#<NUM> and PR ACCESS-NRI/build-cd#<NUM>
+
+> [!IMPORTANT]
+> This PR is a major update to the deployment infrastructure. See below for the prerequisites for this repository to be able to merge this PR.
+
+## Background
+
+<Short statement on the infrastructure update>
+
+The main new features include:
+
+* **Feature 1**: Something
+
+* **Feature 2**: Something else
+
+## Prerequisites for Merging
+
+- [ ] Update `build-cd` entrypoints (this PR!)


### PR DESCRIPTION
This PR adds scripts to simplify mass operations over Model Deployment Repositories, or other operations that are annoying to do over the web interface. 

Specifically, it adds scripts for:

- Mass creation of PRs to model deployment repositories when there is an infrastructure update
- Mass updates of a `var/secret` across model deployment repositories at either the environment or repo level
- Creation of an environment suitable to use in model deployment repositories (either `Release` or `Prerelease`) through the use of local `.env` files

