### PR TITLE
Relax Root Spec Constraints

### DIFF
--- a/.github/actions/get-spack-root-spec/README.md
+++ b/.github/actions/get-spack-root-spec/README.md
@@ -1,0 +1,44 @@
+# Get Spack Manifest Information
+
+Action that returns information about a Spack manifest file.
+
+## Inputs
+
+> [!NOTE]
+> Action assumes that an appropriate repository is checked out prior to invocation
+
+| Name | Type | Description | Required | Default | Example |
+| ---- | ---- | ----------- | -------- | ------- | ------- |
+| `spack-manifest-path` | `string` | The path to the spack manifest file | `false` | `"./spack.yaml"` | `"./some/other.spack.yaml"` |
+
+## Outputs
+
+| Name | Type | Description | Example |
+| ---- | ---- | ----------- | ------- |
+| `root-spec` | `string` | The entirety of the root spec in the spack manifest file | `"access-om2@git.2025.01.01=access-om2 ~deterministic"` |
+| `root-spec-name` | `string` | The name of the root spec in the spack manifest file | `"access-om2"` |
+| `root-spec-ref` | `string` | The git ref from the root spec in the spack manifest file | `"2025.01.01"` |
+| `root-spec-yq` | `string` (`yq` filter) | The yq filter for the root spec of the spack manifest file | `(.spack.definitions[] \| select(."ROOT_PACKAGE") \| .[][]) // .spack.specs[0]` |
+
+## Example
+
+```yaml
+# ...
+jobs:
+  manifest:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - id: spec
+        uses: access-nri/build-cd/.github/actions/get-spack-root-spec@vX  # for some version `vX`
+        with:
+          spack-manifest-path: ./spack.yaml
+
+      - run: |
+          echo "Deploying ${{ steps.spec.outputs.root-spec-name }} at ${{ steps.spec.outputs.root-spec-version }}"
+
+          # You can tack on more filters on top of the `root-spec` one
+          variants=$(yq '${{ steps.spec.outputs.yq-root-spec }} | capture("[^~+- ]+(.+)") | .[0]' ./spack.yaml)
+          echo "Variants are $variants"
+```

--- a/.github/actions/get-spack-root-spec/README.md
+++ b/.github/actions/get-spack-root-spec/README.md
@@ -19,7 +19,7 @@ Action that returns information about a Spack manifest file.
 | `root-spec-name` | `string` | The name of the root spec in the spack manifest file | `"access-om2"` |
 | `root-spec-ref` | `string` | The git ref from the root spec in the spack manifest file | `"2025.01.01"` |
 | `root-spec-version` | `string` | The spack version from the root spec in the spack manifest file | `"release"` |
-| `root-spec-yq` | `string` (`yq` filter) | The yq filter for the root spec of the spack manifest file | `(.spack.definitions[] \| select(."ROOT_PACKAGE") \| .[][]) // .spack.specs[0]` |
+| `yq-root-spec` | `string` (`yq` filter) | The yq filter for obtaining the root spec for the spack manifest file - may change based on whether the root spec is in multi-target or single-target format | `.spack.specs[0]` |
 
 ## Example
 

--- a/.github/actions/get-spack-root-spec/README.md
+++ b/.github/actions/get-spack-root-spec/README.md
@@ -15,9 +15,10 @@ Action that returns information about a Spack manifest file.
 
 | Name | Type | Description | Example |
 | ---- | ---- | ----------- | ------- |
-| `root-spec` | `string` | The entirety of the root spec in the spack manifest file | `"access-om2@git.2025.01.01=access-om2 ~deterministic"` |
+| `root-spec` | `string` | The entirety of the root spec in the spack manifest file | `"access-om2@git.2025.01.01=release ~deterministic"` |
 | `root-spec-name` | `string` | The name of the root spec in the spack manifest file | `"access-om2"` |
 | `root-spec-ref` | `string` | The git ref from the root spec in the spack manifest file | `"2025.01.01"` |
+| `root-spec-version` | `string` | The spack version from the root spec in the spack manifest file | `"release"` |
 | `root-spec-yq` | `string` (`yq` filter) | The yq filter for the root spec of the spack manifest file | `(.spack.definitions[] \| select(."ROOT_PACKAGE") \| .[][]) // .spack.specs[0]` |
 
 ## Example

--- a/.github/actions/get-spack-root-spec/action.yml
+++ b/.github/actions/get-spack-root-spec/action.yml
@@ -1,0 +1,53 @@
+name: Get Spack Manifest Information
+description: Action that returns information about a Spack manifest file
+author: Tommy Gatti
+inputs:
+  spack-manifest-path:
+    type: string
+    required: false
+    default: ./spack.yaml
+    description: The path to the spack manifest file
+outputs:
+  root-spec:
+    description: |
+      The entirety of the root spec in the spack manifest file.
+      For example: 'access-om2@git.2025.01.01=access-om2 ~deterministic'.
+    value: ${{ steps.spec.outputs.full }}
+  root-spec-name:
+    description: |
+      The name of the root spec in the spack manifest file.
+      For example: 'access-om2'.
+    value: ${{ steps.spec.outputs.name }}
+  root-spec-ref:
+    description: |
+      The git ref from the root spec in the spack manifest file.
+      For example: '2025.01.01'.
+    value: ${{ steps.spec.outputs.ref }}
+  yq-root-spec:
+    description: |
+      The yq filter for the root spec of the spack manifest file.
+    value: ${{ steps.yq.outputs.filter }}
+runs:
+  using: composite
+  steps:
+    - name: Set yq filter for root spec
+      id: yq
+      shell: bash
+      # This attempts to get the spack.yaml model first via the multi-target
+      # .spack.definitions.root_package method, then the traditional '.spack.specs[0]'.
+      run: echo "filter=(.spack.definitions[] | select(."ROOT_PACKAGE") | .[][]) // .spack.specs[0]" >> $GITHUB_OUTPUT
+
+    - name: Get spec info from spack manifest
+      id: spec
+      shell: bash
+      run: |
+        full=$(yq '${{ steps.yq.outputs.filter }}' ${{ inputs.spack-manifest-path }})
+        groups=$(yq '${{ steps.yq.outputs.filter }} | capture("(?<name>.+)@git\\.(?<ref>[^= ]+).*")' ${{ inputs.spack-manifest-path }})
+        name=$(yq '.name' <<< "$groups")
+        ref=$(yq '.ref' <<< "$groups")
+
+        echo "Split '$full' into name: '$name' and ref: '$ref'"
+
+        echo "full=$full" >> $GITHUB_OUTPUT
+        echo "name=$name" >> $GITHUB_OUTPUT
+        echo "ref=$ref" >> $GITHUB_OUTPUT

--- a/.github/actions/get-spack-root-spec/action.yml
+++ b/.github/actions/get-spack-root-spec/action.yml
@@ -40,7 +40,21 @@ runs:
       shell: bash
       # This attempts to get the spack.yaml model first via the multi-target
       # .spack.definitions.root_package[0] method, then the traditional '.spack.specs[0]'.
-      run: echo "filter=(.spack.definitions[] | select(."ROOT_PACKAGE") | .[][0]) // .spack.specs[0]" >> $GITHUB_OUTPUT
+      env:
+        MULTI_TARGET_ROOT_SPEC_YQ_FILTER: (.spack.definitions[] | select(."ROOT_PACKAGE") | .[][0])
+        SINGLE_TARGET_ROOT_SPEC_YQ_FILTER: .spack.specs[0]
+      run: |
+        if [[ -n "$(yq '${{ env.MULTI_TARGET_ROOT_SPEC_YQ_FILTER }}' ${{ inputs.spack-manifest-path }})" ]]; then
+          filter="${{ env.MULTI_TARGET_ROOT_SPEC_YQ_FILTER }}"
+        elif [[ -n "$(yq '${{ env.SINGLE_TARGET_ROOT_SPEC_YQ_FILTER }}' ${{ inputs.spack-manifest-path }})" ]]; then
+          filter="${{ env.SINGLE_TARGET_ROOT_SPEC_YQ_FILTER }}"
+        else
+          echo "We can't find the root spec!"
+          exit 1
+        fi
+
+        echo "Based on the root spec, we are using '$filter'"
+        echo "filter=$filter" >> $GITHUB_OUTPUT
 
     - name: Get spec info from spack manifest
       id: spec
@@ -60,7 +74,7 @@ runs:
         ref=$(yq '.ref' <<< "$groups")
         version=$(yq '.version' <<< "$groups")
 
-        echo "Split '$full' into name: '$name', ref: '$ref', version: $version"
+        echo "Split '$full' into name: '$name', ref: '$ref', version: '$version'"
 
         echo "full=$full" >> $GITHUB_OUTPUT
         echo "name=$name" >> $GITHUB_OUTPUT

--- a/.github/actions/get-spack-root-spec/action.yml
+++ b/.github/actions/get-spack-root-spec/action.yml
@@ -23,6 +23,11 @@ outputs:
       The git ref from the root spec in the spack manifest file.
       For example: '2025.01.01'.
     value: ${{ steps.spec.outputs.ref }}
+  root-spec-version:
+    description: |
+      The spack version from the root spec in the spack manifest file.
+      For example, 'release'.
+    value: ${{ steps.spec.outputs.version }}
   yq-root-spec:
     description: |
       The yq filter for the root spec of the spack manifest file.
@@ -41,13 +46,23 @@ runs:
       id: spec
       shell: bash
       run: |
+        # Example: access-om2@git.2025.01.0=release ~variant
         full=$(yq '${{ steps.yq.outputs.filter }}' ${{ inputs.spack-manifest-path }})
-        groups=$(yq '${{ steps.yq.outputs.filter }} | capture("(?<name>.+)@git\\.(?<ref>[^= ]+).*")' ${{ inputs.spack-manifest-path }})
+
+        # Example of groups from the above:
+        # name: anything before `@git.`. Ex: access-om2
+        # ref: anything after `@git.` but before an `=` (for =VERSION syntax) or before a space, `+` or `~` (for variants). Ex: 2025.01.0
+        # version: anything after a `=`, but before a space, `+` or `~` (for variants). Ex: release
+        groups=$(yq '${{ steps.yq.outputs.filter }} | capture("(?<name>.+)@git\\.(?<ref>[^=+~ ]+)(?:=(?<version>[^~+ ]+))?.*")' ${{ inputs.spack-manifest-path }})
+
+        # Pull values from groups above
         name=$(yq '.name' <<< "$groups")
         ref=$(yq '.ref' <<< "$groups")
+        version=$(yq '.version' <<< "$groups")
 
-        echo "Split '$full' into name: '$name' and ref: '$ref'"
+        echo "Split '$full' into name: '$name', ref: '$ref', version: $version"
 
         echo "full=$full" >> $GITHUB_OUTPUT
         echo "name=$name" >> $GITHUB_OUTPUT
         echo "ref=$ref" >> $GITHUB_OUTPUT
+        echo "version=$version" >> $GITHUB_OUTPUT

--- a/.github/actions/get-spack-root-spec/action.yml
+++ b/.github/actions/get-spack-root-spec/action.yml
@@ -34,8 +34,8 @@ runs:
       id: yq
       shell: bash
       # This attempts to get the spack.yaml model first via the multi-target
-      # .spack.definitions.root_package method, then the traditional '.spack.specs[0]'.
-      run: echo "filter=(.spack.definitions[] | select(."ROOT_PACKAGE") | .[][]) // .spack.specs[0]" >> $GITHUB_OUTPUT
+      # .spack.definitions.root_package[0] method, then the traditional '.spack.specs[0]'.
+      run: echo "filter=(.spack.definitions[] | select(."ROOT_PACKAGE") | .[][0]) // .spack.specs[0]" >> $GITHUB_OUTPUT
 
     - name: Get spec info from spack manifest
       id: spec

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -27,9 +27,6 @@ on:
   #     - spack.yaml
 
 env:
-  # This attempts to get the spack.yaml model first via the multi-target
-  # .spack.definitions.root_package method, then the traditional '.spack.specs[0]'.
-  SPACK_YAML_MODEL_YQ: (.spack.definitions[] | select(."ROOT_PACKAGE") | .[][]) // .spack.specs[0]
   METADATA_PATH: /opt/metadata
   OUTPUTS_PATH: /opt/outputs
 jobs:
@@ -83,15 +80,13 @@ jobs:
     permissions:
       contents: write
     outputs:
-      name: ${{ steps.tag.outputs.name }}
+      name: ${{ steps.tag.outputs.root-spec-ref }}
     steps:
       - uses: actions/checkout@v4
 
-      - name: Generate Tag
+      - name: Get root spec ref
         id: tag
-        # Get the tag name from the `spack.yaml` that was merged into main, which
-        # is of the form `<model>@git.<version>`.
-        run: echo "name=$(yq '${{ env.SPACK_YAML_MODEL_YQ }} | split("@git.") | .[1]' spack.yaml)" >> $GITHUB_OUTPUT
+        uses: access-nri/build-cd/.github/actions/get-spack-root-spec@v4
 
       - name: Import Commit-Signing Key
         uses: crazy-max/ghaction-import-gpg@01dd5d3ca463c7f10f7f4f7b4f177225ac661ee4  # v6.1.0
@@ -107,7 +102,7 @@ jobs:
 
       - name: Push Tag
         env:
-          TAG: ${{ steps.tag.outputs.name }}
+          TAG: ${{ steps.tag.outputs.root-spec-ref }}
         run: |
           git tag ${{ env.TAG }} -m "Deployment of ${{ inputs.model }} ${{ env.TAG }} via build-cd 'cd.yml' workflow"
           git push --tags

--- a/.github/workflows/ci-comment.yml
+++ b/.github/workflows/ci-comment.yml
@@ -53,30 +53,25 @@ jobs:
       contents: write
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      # This attempts to get the spack.yaml model first via the multi-target
-      # .spack.definitions.root_package method, then the traditional '.spack.specs[0]'.
-      SPACK_YAML_MODEL_YQ: (.spack.definitions[] | select(."ROOT_PACKAGE") | .[][]) // .spack.specs[0]
       SPACK_YAML_MODEL_PROJECTION_YQ: .spack.modules.default.tcl.projections.${{ needs.defaults.outputs.root-sbd }}
     steps:
       - uses: actions/checkout@v4
         with:
+          ref: refs/pull/${{ github.event.issue.number }}/head
           fetch-depth: 0
           fetch-tags: true
           token: ${{ secrets.GH_COMMIT_CHECK_TOKEN }}
 
+      - name: Original version
+        id: original
+        uses: access-nri/build-cd/.github/actions/get-spack-root-spec@v4
+
       - name: Setup
         id: setup
         # outputs:
-        #   original-version: The version contained within the spack.yaml
         #   version: The version that will be bumped (could be latest tag instead of original-version)
         #   bump: The bump type (major, minor or current as specified in the bump-version action)
         run: |
-          # Get the version of ${{ needs.defaults.outputs.root-sbd }} from the spack.yaml in the PR the comment was written in
-          gh pr checkout ${{ github.event.issue.number }}
-          original_version=$(yq e '${{ env.SPACK_YAML_MODEL_YQ }} | split("@git.") | .[1]' spack.yaml)
-          echo "original-version=${original_version}" >> $GITHUB_OUTPUT
-
-          # Validate the comment
           if [[ "${{ contains(github.event.comment.body, 'major') }}" == "true" ]]; then
             # Compare the current date (year-month) with the latest git tag (year-month)
             # to determine the next valid tag. We do this because especially feature-rich
@@ -95,11 +90,11 @@ jobs:
               echo "version=${tag_date}" >> $GITHUB_OUTPUT
               echo "bump=major" >> $GITHUB_OUTPUT
             else
-              echo "version=${original_version}" >> $GITHUB_OUTPUT
+              echo "version=${{ steps.original.outputs.root-spec-ref }}" >> $GITHUB_OUTPUT
               echo "bump=current" >> $GITHUB_OUTPUT
             fi
           elif [[ "${{ contains(github.event.comment.body, 'minor')}}" == "true" ]]; then
-            echo "version=${original_version}" >> $GITHUB_OUTPUT
+            echo "version=${{ steps.original.outputs.root-spec-ref }}" >> $GITHUB_OUTPUT
             echo "bump=minor" >> $GITHUB_OUTPUT
           else
             echo "::warning::Usage: `!bump [major|minor]`, got `${{ github.event.comment.body }}`"
@@ -128,10 +123,10 @@ jobs:
 
       - name: Update, Commit and Push the Bump
         run: |
-          yq -i '${{ env.SPACK_YAML_MODEL_YQ }} = "${{ needs.defaults.outputs.root-sbd }}@git.${{ steps.bump.outputs.after }}"' spack.yaml
+          yq -i '${{ steps.original.outputs.yq-root-spec }} = "${{ needs.defaults.outputs.root-sbd }}@git.${{ steps.bump.outputs.after }}"' spack.yaml
           yq -i '${{ env.SPACK_YAML_MODEL_PROJECTION_YQ }} = "{name}/${{ steps.bump.outputs.after }}"' spack.yaml
           git add spack.yaml
-          git commit -m "spack.yaml: Updated ${{ needs.defaults.outputs.root-sbd }} package version from ${{ steps.setup.outputs.original-version }} to ${{ steps.bump.outputs.after }}"
+          git commit -m "spack.yaml: Updated ${{ needs.defaults.outputs.root-sbd }} package version from ${{ steps.original.outputs.root-spec-ref }} to ${{ steps.bump.outputs.after }}"
           git push
 
       - name: Success Notifier

--- a/.github/workflows/ci-comment.yml
+++ b/.github/workflows/ci-comment.yml
@@ -55,9 +55,14 @@ jobs:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       SPACK_YAML_MODEL_PROJECTION_YQ: .spack.modules.default.tcl.projections.${{ needs.defaults.outputs.root-sbd }}
     steps:
+      - name: Get branch from issue
+        id: issue
+        # We have to do a bit more interrogation of the issue number to get the branch name to check out
+        run: echo "branch=$(gh pr view ${{ github.event.issue.number }} --repo ${{ github.repository }} --json headRefName --jq .headRefName)" >> $GITHUB_OUTPUT
+
       - uses: actions/checkout@v4
         with:
-          ref: refs/pull/${{ github.event.issue.number }}/head
+          ref: ${{ steps.issue.outputs.branch }}
           fetch-depth: 0
           fetch-tags: true
           token: ${{ secrets.GH_COMMIT_CHECK_TOKEN }}

--- a/.github/workflows/ci-comment.yml
+++ b/.github/workflows/ci-comment.yml
@@ -127,8 +127,12 @@ jobs:
           git_tag_gpgsign: true
 
       - name: Update, Commit and Push the Bump
+        env:
+          # If the root spec contained an '=VERSION' segment, we want to add that back to the updated root spec, too
+          OPTIONAL_VERSION: ${{ steps.original.outputs.root-spec-version != '' && format('={0}', steps.original.outputs.root-spec-version) || '' }}
         run: |
-          yq -i '${{ steps.original.outputs.yq-root-spec }} = "${{ needs.defaults.outputs.root-sbd }}@git.${{ steps.bump.outputs.after }}"' spack.yaml
+          updated_spec="${{ needs.defaults.outputs.root-sbd }}@git.${{ steps.bump.outputs.after }}${{ env.OPTIONAL_VERSION }}"
+          yq -i "${{ steps.original.outputs.yq-root-spec }} = \"$updated_spec\"" spack.yaml
           yq -i '${{ env.SPACK_YAML_MODEL_PROJECTION_YQ }} = "{name}/${{ steps.bump.outputs.after }}"' spack.yaml
           git add spack.yaml
           git commit -m "spack.yaml: Updated ${{ needs.defaults.outputs.root-sbd }} package version from ${{ steps.original.outputs.root-spec-ref }} to ${{ steps.bump.outputs.after }}"
@@ -138,7 +142,7 @@ jobs:
         uses: access-nri/actions/.github/actions/pr-comment@main
         with:
           comment: |
-            :white_check_mark: Version bumped from `${{ steps.setup.outputs.original-version }}` to `${{ steps.bump.outputs.after }}` :white_check_mark:
+            :white_check_mark: Version bumped from `${{ steps.original.outputs.root-spec-ref }}` to `${{ steps.bump.outputs.after }}` :white_check_mark:
 
       - name: Failure Notifier
         if: failure()

--- a/.github/workflows/deploy-1-setup.yml
+++ b/.github/workflows/deploy-1-setup.yml
@@ -161,13 +161,9 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
-    env:
-      # This attempts to get the spack.yaml model first via the multi-target
-      # .spack.definitions.root_package method, then the traditional '.spack.specs[0]'.
-      SPACK_YAML_MODEL_YQ: (.spack.definitions[] | select(."ROOT_PACKAGE") | .[][]) // .spack.specs[0]
     outputs:
       # Release version of the deployment. Inferred if not given in inputs.deployment-version
-      release: ${{ steps.version.outputs.release }}
+      release: ${{ steps.yq.outputs.root-spec-ref }}
       # Spack env name in form <model>-<version>
       spack-env-name: ${{ steps.get-env-name.outputs.env-name }}
     steps:
@@ -182,6 +178,10 @@ jobs:
           schema-version: ${{ vars.SPACK_YAML_SCHEMA_VERSION }}
           schema-location: au.org.access-nri/model/spack/environment/deployment
           data-location: ${{ inputs.spack-manifest-path }}
+
+      - name: Get root spec yq
+        id: yq
+        uses: access-nri/build-cd/.github/actions/get-spack-root-spec@v4
 
       - name: Check Model Version Modified
         # We don't want to fire off model deployment version checks if the PR is never going to be merged.
@@ -202,10 +202,10 @@ jobs:
               exit 0
           fi
 
-          base_version=$(yq e '${{ env.SPACK_YAML_MODEL_YQ }}' spack.yaml)
+          base_version=$(yq e '${{ steps.yq.outputs.yq-root-spec }}' spack.yaml)
 
           git checkout ${{ inputs.deployment-ref }}
-          current_version=$(yq e '${{ env.SPACK_YAML_MODEL_YQ }}' spack.yaml)
+          current_version=$(yq e '${{ steps.yq.outputs.yq-root-spec }}' spack.yaml)
           echo "current=${current_version}" >> $GITHUB_OUTPUT
 
           if [[ "${base_version}" == "${current_version}" ]]; then
@@ -241,11 +241,11 @@ jobs:
             if [[ "$DEP" == "${{ inputs.spack-manifest-root-sbd }}" ]]; then
               # The model version is the bit after '@git.', before any later, space-separated, optional variants.
               # For example, in 'MODEL@git.VERSION type=ACCESS ~debug' the version is 'VERSION'.
-              DEP_VER=$(yq '${{ env.SPACK_YAML_MODEL_YQ }} | capture(".+@git\\.(?<version>[^ ]+).*") | .version' spack.yaml)
+              DEP_VER=${{ steps.yq.outputs.root-spec-ref }}
             else
               # Capture the section after '@git.' or '@' (if it's not a git-attributed version) and before a possible '=' for a given dependency.
               # Ex. '@git.2024.02.11' -> '2024.02.11', '@access-esm1.5' -> 'access-esm1.5', '@git.2024.05.21=access-esm1.5' -> '2024.05.21'
-              DEP_VER=$(yq ".spack.packages.\"$DEP\".require[0] | match(\"^@(?:git.)?([^=]*)\").captures[0].string" spack.yaml)
+              DEP_VER=$(yq ".spack.packages.\"$DEP\".require[0] | match(\"^@(?:git.)?([^=]*)\").captures[0].string" ${{ inputs.spack-manifest-path}})
             fi
 
             # Get the version from the module projection, for comparison with DEP_VER
@@ -262,13 +262,6 @@ jobs:
           if [[ "$FAILED" == "true" ]]; then
             exit 1
           fi
-
-      - name: Generate Versions
-        id: version
-        # This step generates the release version number, if it wasn't already given.
-        # The release is a general version number from the spack.yaml, looking the
-        # same as a regular release build, without optional variants. Ex. 'access-om2@git.2024.01.1 ~debug' -> '2024.01.1'
-        run: echo "release=$(yq '${{ env.SPACK_YAML_MODEL_YQ }} | capture("@git\.(?<version>[^ ~+]+)") | .version' spack.yaml)" >> $GITHUB_OUTPUT
 
       - name: Set Spack Env Name String
         id: get-env-name

--- a/.github/workflows/deploy-1-setup.yml
+++ b/.github/workflows/deploy-1-setup.yml
@@ -192,7 +192,6 @@ jobs:
 
           if [ ! -f spack.yaml ]; then
               echo "::notice::There is no previous version of the spack.yaml to check at ${{ inputs.prerelease-compare-ref }}, continuing..."
-              git checkout ${{ inputs.deployment-ref }}
               exit 1
           fi
 
@@ -234,8 +233,9 @@ jobs:
         #  modulefile access-om3/2023.12.12 (specifically, the version strings match)
         # TODO: Move this into the `scripts` directory - it's getting unweildly.
         run: |
-          FAILED="false"
+          git checkout ${{ inputs.deployment-ref }}
 
+          FAILED="false"
           # Get all the defined projections (minus 'all') and make them suitable for a bash for loop
           DEPS=$(yq '.spack.modules.default.tcl.projections | del(.all) | keys | join(" ")' spack.yaml)
 

--- a/.github/workflows/deploy-1-setup.yml
+++ b/.github/workflows/deploy-1-setup.yml
@@ -163,7 +163,7 @@ jobs:
       pull-requests: write
     outputs:
       # Release version of the deployment. Inferred if not given in inputs.deployment-version
-      release: ${{ steps.yq.outputs.root-spec-ref }}
+      release: ${{ steps.current.outputs.root-spec-ref }}
       # Spack env name in form <model>-<version>
       spack-env-name: ${{ steps.get-env-name.outputs.env-name }}
     steps:
@@ -179,8 +179,26 @@ jobs:
           schema-location: au.org.access-nri/model/spack/environment/deployment
           data-location: ${{ inputs.spack-manifest-path }}
 
-      - name: Get root spec yq
-        id: yq
+      - name: Get current (${{ inputs.deployment-ref }}) root spec version
+        id: current
+        uses: access-nri/build-cd/.github/actions/get-spack-root-spec@v4
+
+      - name: Checkout base (${{ inputs.prerelease-compare-ref }}) spack manifest
+        if: inputs.deployment-type != 'Release'
+        continue-on-error: true
+        id: checkout-base-spack
+        run: |
+          git checkout ${{ inputs.prerelease-compare-ref }}
+
+          if [ ! -f spack.yaml ]; then
+              echo "::notice::There is no previous version of the spack.yaml to check at ${{ inputs.prerelease-compare-ref }}, continuing..."
+              git checkout ${{ inputs.deployment-ref }}
+              exit 1
+          fi
+
+      - name: Get base root spec version
+        id: base
+        if: inputs.deployment-type != 'Release' && steps.checkout-base-spack.outcome != 'failure'
         uses: access-nri/build-cd/.github/actions/get-spack-root-spec@v4
 
       - name: Check Model Version Modified
@@ -189,26 +207,12 @@ jobs:
         # belongs to, is drafted.
         # Yes, github.event.issue.draft refers to the pull request if the comment is made on a pull request!
         if: >-
-          inputs.deployment-type != 'Release' &&
+          inputs.deployment-type != 'Release' && steps.checkout-base-spack.outcome != 'failure' &&
           (github.event_name == 'pull_request' && !github.event.pull_request.draft) ||
           (github.event_name == 'issue_comment' && !github.event.issue.draft)
         id: version-modified
         run: |
-          git checkout ${{ inputs.prerelease-compare-ref }}
-
-          if [ ! -f spack.yaml ]; then
-              echo "::notice::There is no previous version of the spack.yaml to check at ${{ inputs.prerelease-compare-ref }}, continuing..."
-              git checkout ${{ inputs.deployment-ref }}
-              exit 0
-          fi
-
-          base_version=$(yq e '${{ steps.yq.outputs.yq-root-spec }}' spack.yaml)
-
-          git checkout ${{ inputs.deployment-ref }}
-          current_version=$(yq e '${{ steps.yq.outputs.yq-root-spec }}' spack.yaml)
-          echo "current=${current_version}" >> $GITHUB_OUTPUT
-
-          if [[ "${base_version}" == "${current_version}" ]]; then
+          if [[ "${{ steps.base.outputs.root-spec-ref }}" == "${{ steps.current.outputs.root-spec-ref }}" ]]; then
               echo "::warning::The version string hasn't been modified in this PR, but needs to be before merging."
               exit 1
           fi
@@ -241,11 +245,11 @@ jobs:
             if [[ "$DEP" == "${{ inputs.spack-manifest-root-sbd }}" ]]; then
               # The model version is the bit after '@git.', before any later, space-separated, optional variants.
               # For example, in 'MODEL@git.VERSION type=ACCESS ~debug' the version is 'VERSION'.
-              DEP_VER=${{ steps.yq.outputs.root-spec-ref }}
+              DEP_VER=${{ steps.current.outputs.root-spec-ref }}
             else
               # Capture the section after '@git.' or '@' (if it's not a git-attributed version) and before a possible '=' for a given dependency.
               # Ex. '@git.2024.02.11' -> '2024.02.11', '@access-esm1.5' -> 'access-esm1.5', '@git.2024.05.21=access-esm1.5' -> '2024.05.21'
-              DEP_VER=$(yq ".spack.packages.\"$DEP\".require[0] | match(\"^@(?:git.)?([^=]*)\").captures[0].string" ${{ inputs.spack-manifest-path}})
+              DEP_VER=$(yq ".spack.packages.\"$DEP\".require[0] | match(\"^@(?:git.)?([^=]*)\").captures[0].string" spack.yaml)
             fi
 
             # Get the version from the module projection, for comparison with DEP_VER

--- a/.github/workflows/deploy-2-start.yml
+++ b/.github/workflows/deploy-2-start.yml
@@ -49,9 +49,6 @@ on:
           General pattern for the artifact that contains the deployment metadata files for this invocation of the job.
           These files are of the form deploy-metadata.{{inputs.deployment-target}}
 env:
-  # This attempts to get the spack.yaml model first via the multi-target
-  # .spack.definitions.root_package method, then the traditional '.spack.specs[0]'.
-  SPACK_YAML_MODEL_YQ: (.spack.definitions[] | select(."ROOT_PACKAGE") | .[][]) // .spack.specs[0]
   SPACK_YAML_MODULEFILE_PROJECTION_YQ: .spack.modules.default.tcl.projections.${{ inputs.root-sbd }}
   METADATA_PATH: /opt/metadata
   ARTIFACT_NAME: deploy-metadata.${{ inputs.deployment-target }}
@@ -86,6 +83,11 @@ jobs:
           spack-version: ${{ steps.versions.outputs.spack }}
           deployment-environment: ${{ inputs.deployment-target }} ${{ inputs.deployment-type }}
 
+      - name: Get yq filters
+        id: yq
+        # FIXME: We should pass through inputs.spack-manifest-path here (and below raw spack.yaml) - see ACCESS-NRI/build-cd#225
+        uses: access-nri/build-cd/.github/actions/get-spack-root-spec@v4
+
       - name: Setup SSH
         id: ssh
         uses: access-nri/actions/.github/actions/setup-ssh@main
@@ -102,7 +104,7 @@ jobs:
         # Also removes the `@git.VERSION` specifier for Prereleases so
         # we don't have to shift tags around.
         run: |
-          yq -i '${{ env.SPACK_YAML_MODEL_YQ }} = (${{ env.SPACK_YAML_MODEL_YQ }} | split("@").[0])' spack.yaml
+          yq -i '${{ steps.yq.outputs.yq-root-spec }} = "${{ inputs.root-sbd }}"' spack.yaml
           yq -i '${{ env.SPACK_YAML_MODULEFILE_PROJECTION_YQ }} = "{name}/${{ inputs.version }}"' spack.yaml
           echo '::notice::Prerelease accessible as module `${{ inputs.model}}/${{ inputs.version }}`'
 


### PR DESCRIPTION
References #223

## Background

Since we now allow `=VERSION` in our `@git.REF=VERSION` constraints, we need to update the infrastructure to expect this possibility when parsing the root spec - especially when getting the `ref`. This avoids the possibility of the deployment version/deployment tag being something like `2025.01.0=access-om2`. 

## PR

In this PR:
* Create a new internal action for returning important root spec information from the spack manifest - `get-spack-root-spec`. This means that we only have to update the YQ filters in a single place, now. That means we can...
* Remove all references to the original `env.SPACK_YAML_MODEL_YQ` and replace them with calls to outputs of `get-spack-root-spec`. This says nothing about the `env.SPACK_YAML_MODULE_PROJECTION_YQ`, which should be done in #227 

## Testing

All tests were conducted on the (ephemeral) branch based on this PR branch called [`223-relax-specs_TEST`](https://github.com/ACCESS-NRI/build-cd/compare/223-relax-specs...223-relax-specs_TEST). This was done to update the entrypoints within `build-cd` to point to the PR branch (rather than the un-updated `v4` base branch).

The tests were done on the PR https://github.com/ACCESS-NRI/ACCESS-TEST/pull/25

### Test `spack.specs[0]` with `=VERSION` (Single-Target Style)

Succeeded, see [comment containing run and commit data](https://github.com/ACCESS-NRI/ACCESS-TEST/pull/25#issuecomment-2649821224).

### Test `!bump` command with `=VERSION`

Succeeded, see [invocation](https://github.com/ACCESS-NRI/ACCESS-TEST/pull/25#issuecomment-2652591223), [bump commit](https://github.com/ACCESS-NRI/ACCESS-TEST/pull/25/commits/911b6b0869f4144962ff6a98b2a84acf62ef1095).

### Test `spack.definitions[].ROOT_PACKAGE[0]` with `=VERSION` (Multi-Target Style)

Succeeded, see [comment containing run and commit data](https://github.com/ACCESS-NRI/ACCESS-TEST/pull/25#issuecomment-2652622501). 

### Test `spack.definitions[].ROOT_PACKAGE[0]` without `=VERSION` (Multi-Target Style)

Succeeded, see [comment containing run and commit data](https://github.com/ACCESS-NRI/ACCESS-TEST/pull/25#issuecomment-2652679687).
