### PR TITLE
Update trigger: on push to default branch, and always on pull request

### DIFF
--- a/.github/workflows/settings-1-update.yml
+++ b/.github/workflows/settings-1-update.yml
@@ -1,13 +1,13 @@
 name: Config Settings Update
 on:
   push:
-    branches:
-      - main
+    # Below condition is enforced by the `if` condition in 
+    # the `setup-settings-update` job:
+    # branches:
+    #   - $default_branch
     paths:
       - config/settings.*
   pull_request:
-    branches:
-      - main
     paths:
       - config/settings.*
 env:
@@ -68,7 +68,7 @@ jobs:
 
   setup-settings-update:
     name: Setup Update of Deployment Settings
-    if: github.event_name == 'push'
+    if: github.event_name == 'push' && github.ref_name == github.event.repository.default_branch
     needs:
       - settings-validation
     runs-on: ubuntu-latest


### PR DESCRIPTION
Closes #229

## Background

Since we are moving from a `main` default branch to a `vX` branch (where `X` is the latest major version of `build-cd`), we are updating the trigger for this job to:

* The default branch `on.push`
* Any branch `on.pull_request`

Provided it updates the `config/settings.json` file. 

## The PR

In this PR:

* Update trigger condition for running settings checks and deployments. 
