### PR TITLE
Update Settings Matrix Generation to Adhere to `settings.schema.json`

### DIFF
--- a/.github/workflows/settings-1-update.yml
+++ b/.github/workflows/settings-1-update.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Generate Deployment Target Matrix
         id: target
         run: |
-          targets=$(jq --compact-output '.deployments' config/settings.json)
+          targets=$(jq --compact-output '.deployment | keys' config/settings.json)
           echo "$targets"
           echo "targets=$targets" >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
## Background

Fixes regression introduced in #218 in which we attempted to generate a matrix of targets without adhering to the `config/settings.schema.json`, leading to an empty (null) matrix and a failed workflow: see https://github.com/ACCESS-NRI/build-cd/actions/runs/13451909066/job/37587737547?pr=228
## The PR

In this PR:
- Update matrix generation to conform with existing schema - the key is `deployment` not `deployments`, and we only require the keys, not the entire object. 

## Testing

Tested `jq` locally - ran `jq -cr '.deployment | keys' config/settings.json` at a949ae057e07f7f9c07f58990ac1fb1e081a38ac and got expected `["Gadi"]`.

Tested matrix generated successfully in test workflow: https://github.com/codegat-test-org/test/actions/runs/13452297829
