### PR TITLE
config/settings.json: use Spack v0.22.5

### DIFF
--- a/config/settings.json
+++ b/config/settings.json
@@ -8,13 +8,13 @@
           "spack-config": "2024.03.22"
         },
         "0.22": {
-          "spack": "9653dbe2e20814d0b97393dce80af73c63d97300",
+          "spack": "f32c2593340d854b69494afe32cbef0b764933fe",
           "spack-config": "2025.02.1"
         }
       },
       "Prerelease": {
         "0.22": {
-          "spack": "9653dbe2e20814d0b97393dce80af73c63d97300",
+          "spack": "f32c2593340d854b69494afe32cbef0b764933fe",
           "spack-config": "2025.02.1"
         }
       }


### PR DESCRIPTION
* Upstream had problem with the v0.22.4 release process.
* v0.22.5 has no functional changes compared to v0.22.4.