### PR TITLE
Allow `@latest`

### DIFF
--- a/.github/actions/get-spack-root-spec/action.yml
+++ b/.github/actions/get-spack-root-spec/action.yml
@@ -65,9 +65,9 @@ runs:
 
         # Example of groups from the above:
         # name: anything before `@git.`. Ex: access-om2
-        # ref: anything after `@git.` but before an `=` (for =VERSION syntax) or before a space, `+` or `~` (for variants). Ex: 2025.01.0
+        # ref: anything after `@` or `@git.`; but before `=` (for =VERSION syntax) or ` `/`+`/`~` (for variants). Ex: 2025.01.0
         # version: anything after a `=`, but before a space, `+` or `~` (for variants). Ex: release
-        groups=$(yq '${{ steps.yq.outputs.filter }} | capture("(?<name>.+)@git\\.(?<ref>[^=+~ ]+)(?:=(?<version>[^~+ ]+))?.*")' ${{ inputs.spack-manifest-path }})
+        groups=$(yq '${{ steps.yq.outputs.filter }} | capture("(?<name>.+)@(?:git\\.)?(?<ref>[^=+~ ]+)(?:=(?<version>[^~+ ]+))?.*")' ${{ inputs.spack-manifest-path }})
 
         # Pull values from groups above
         name=$(yq '.name' <<< "$groups")

--- a/.github/actions/get-spack-root-spec/action.yml
+++ b/.github/actions/get-spack-root-spec/action.yml
@@ -68,9 +68,9 @@ runs:
         # ref: anything after `@` or `@git.`; but before `=` (for =VERSION syntax) or ` `/`+`/`~` (for variants). Ex: 2025.01.0
         # version: anything after a `=`, but before ` `/`+`/`~` (for variants). Ex: release
         
-        groups_regex="${{ steps.yq.outputs.filter }} | capture(\"(?<name>.+)@(?:git\\.)?(?<ref>[^=+~ ]+)(?:=(?<version>[^~+ ]+))?.*\")"
+        groups_regex='(?<name>.+)@(?:git\\.)?(?<ref>[^=+~ ]+)(?:=(?<version>[^~+ ]+))?.*'
 
-        groups=$(yq "$groups_regex" ${{ inputs.spack-manifest-path }})
+        groups=$(yq '${{ steps.yq.outputs.filter }} | capture("'"$groups_regex"'")' ${{ inputs.spack-manifest-path }})
 
         # Pull values from groups above
         name=$(yq '.name' <<< "$groups")

--- a/.github/actions/get-spack-root-spec/action.yml
+++ b/.github/actions/get-spack-root-spec/action.yml
@@ -63,11 +63,14 @@ runs:
         # Example: access-om2@git.2025.01.0=release ~variant
         full=$(yq '${{ steps.yq.outputs.filter }}' ${{ inputs.spack-manifest-path }})
 
-        # Example of groups from the above:
-        # name: anything before `@git.`. Ex: access-om2
+        # Example of captured groups from the above:
+        # name: anything before `@`. Ex: access-om2
         # ref: anything after `@` or `@git.`; but before `=` (for =VERSION syntax) or ` `/`+`/`~` (for variants). Ex: 2025.01.0
-        # version: anything after a `=`, but before a space, `+` or `~` (for variants). Ex: release
-        groups=$(yq '${{ steps.yq.outputs.filter }} | capture("(?<name>.+)@(?:git\\.)?(?<ref>[^=+~ ]+)(?:=(?<version>[^~+ ]+))?.*")' ${{ inputs.spack-manifest-path }})
+        # version: anything after a `=`, but before ` `/`+`/`~` (for variants). Ex: release
+        
+        groups_regex="${{ steps.yq.outputs.filter }} | capture(\"(?<name>.+)@(?:git\\.)?(?<ref>[^=+~ ]+)(?:=(?<version>[^~+ ]+))?.*\")"
+
+        groups=$(yq "$groups_regex" ${{ inputs.spack-manifest-path }})
 
         # Pull values from groups above
         name=$(yq '.name' <<< "$groups")

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -104,6 +104,11 @@ jobs:
         env:
           TAG: ${{ steps.tag.outputs.root-spec-ref }}
         run: |
+          if [[ "${{ env.TAG }}" == "latest" ]]; then
+            echo "::error::The version 'latest' is reserved for a spack package that moves often and cannot be used as a release tag. Reset the 'main' or 'backport' branch, reopen the merged PR, and update the version."
+            exit 1
+          fi
+
           git tag ${{ env.TAG }} -m "Deployment of ${{ inputs.model }} ${{ env.TAG }} via build-cd 'cd.yml' workflow"
           git push --tags
 

--- a/.github/workflows/deploy-1-setup.yml
+++ b/.github/workflows/deploy-1-setup.yml
@@ -183,6 +183,16 @@ jobs:
         id: current
         uses: access-nri/build-cd/.github/actions/get-spack-root-spec@v4
 
+      - name: Check '@latest' version usage
+        if: >-
+          (github.event_name == 'pull_request' && !github.event.pull_request.draft) || 
+          (github.event_name == 'issue_comment' && !github.event.issue.draft)
+        run: |
+          if [[ "${{ steps.current.outputs.root-spec-ref }}" == "latest" ]]; then
+              echo "::error::The '@latest' version string is not allowed in non-draft PRs. It is reserved for a spack package that moves often and cannot be used as a future release tag"
+              exit 1
+          fi
+
       - name: Checkout base (${{ inputs.prerelease-compare-ref }}) spack manifest
         if: inputs.deployment-type != 'Release'
         continue-on-error: true


### PR DESCRIPTION
References #234

## Background

Local `spack` builds using a `spack.yaml` need to use `@latest` because they can't reference a not-yet-existing `@git.TAG` like prerelease builds can. To allow continuity between these types, allow `@latest` in the schema. 

## The PR

In this PR:

- **get-spack-root-spec action: Allow `@latest` as ref**
- **cd.yml: Add a check so that a `@latest` version is not deployed as a Release**

## Testing

Tested locally via `yq` on a `spack.yaml` of the form:

```yaml
spack:
  specs:
    - access-om2@latest
```

by running:

```bash
docker run -i --rm mikefarah/yq '.spack.specs[0] | capture("(?<name>.+)@(?:git\\.)?(?<ref>[^=+~ ]+)(?:=(?<version>[^~+ ]+))?.*")' < spack.yaml
```
