### PR TITLE
Undeploy: Export DEPLOYMENT_TARGET before removing environments

### DIFF
--- a/.github/workflows/undeploy-1-start.yml
+++ b/.github/workflows/undeploy-1-start.yml
@@ -68,6 +68,11 @@ jobs:
         id: undeploy
         run: |
           ssh ${{ secrets.USER}}@${{ secrets.HOST }} -i ${{ steps.ssh.outputs.private-key-path }} /bin/bash <<'EOT'
+
+          # Export vars.DEPLOYMENT_TARGET
+          export DEPLOYMENT_TARGET="${{ vars.DEPLOYMENT_TARGET }}"
+          echo "DEPLOYMENT_TARGET exported as $DEPLOYMENT_TARGET"
+
           . ${{ steps.path.outputs.spack-config }}/spack-enable.bash
           envs=$(find ${{ steps.path.outputs.spack }}/../environments -type d -name '${{ inputs.version-pattern }}' -printf '%f ')
 


### PR DESCRIPTION
Closes #242

## Background

A curious regression introduced in #218, is that now that we can (and have, in `ACCESS-TEST` Prereleases) use the set-at-install-time environment variable `DEPLOYMENT_TARGET` in our `spack.yaml`s, `spack` expects it to be set. Interestingly, `spack` now errors out when it can't find it, since it loads config from all existing environments `spack.yaml` while uninstalling some environments, including ones that require `DEPLOYMENT_TARGET`. 

## The PR

In this PR:
* export `DEPLOYMENT_TARGET` before undeploying environments 

## Testing

Tested uninstallation of a dummy enviroment in Prerelease without exporting `DEPLOYMENT_TARGET` which fails as expected.
Exported `DEPLOYMENT_TARGET` and then attempted uninstallation, which succeeded. 
