### PR TITLE
Draft PRs disable schema and package projection checks

### DIFF
--- a/.github/workflows/deploy-1-setup.yml
+++ b/.github/workflows/deploy-1-setup.yml
@@ -173,6 +173,9 @@ jobs:
           ref: ${{ inputs.deployment-ref }}
 
       - name: Validate ACCESS-NRI spack.yaml Restrictions
+        if: >-
+          (github.event_name == 'pull_request' && !github.event.pull_request.draft) ||
+          (github.event_name == 'issue_comment' && !github.event.issue.draft)
         uses: access-nri/schema/.github/actions/validate-with-schema@main
         with:
           schema-version: ${{ vars.SPACK_YAML_SCHEMA_VERSION }}
@@ -185,7 +188,7 @@ jobs:
 
       - name: Check '@latest' version usage
         if: >-
-          (github.event_name == 'pull_request' && !github.event.pull_request.draft) || 
+          (github.event_name == 'pull_request' && !github.event.pull_request.draft) ||
           (github.event_name == 'issue_comment' && !github.event.issue.draft)
         run: |
           if [[ "${{ steps.current.outputs.root-spec-ref }}" == "latest" ]]; then
@@ -236,40 +239,47 @@ jobs:
               * `!bump major` for feature releases
               * `!bump minor` for bugfixes
 
-      - name: Projection Version Matches
-        # this step checks that the versions of the packages themselves match with the
-        #  names of the projections, if they're given.
-        # For example, access-om3@git.2023.12.12 matches with the
-        #  modulefile access-om3/2023.12.12 (specifically, the version strings match)
-        # TODO: Move this into the `scripts` directory - it's getting unweildly.
+      - name: Check Projections - Specs
+        # This step checks that the root spec has an appropriate projection in the spack.yaml file.
         run: |
           git checkout ${{ inputs.deployment-ref }}
 
+          current_projection=$(yq '.spack.modules.default.tcl.projections.${{ steps.current.outputs.root-spec-name }}' ${{ inputs.spack-manifest-path }})
+          expected_projection_prefix='{name}/${{ steps.current.outputs.root-spec-ref }}'
+
+          if [[ "$current_projection" == "$expected_projection_prefix"* ]]; then
+              echo "Current root spec projection ($current_projection) and expected projection prefix ($expected_projection_prefix) match."
+          else
+              echo "::error::Current root spec projection ($current_projection) and expected projection prefix ($expected_projection_prefix) don't match."
+              exit 1
+          fi
+
+      - name: Check Projections - Packages
+        # This step checks that the defined projections have the same versions as the referenced packages in the spack.yaml file.
+        # For example, mom5@git.2023.12.12 matches with the
+        #  modulefile mom5/2023.12.12 (specifically, the version strings match)
+        if: >-
+          (github.event_name == 'pull_request' && !github.event.pull_request.draft) ||
+          (github.event_name == 'issue_comment' && !github.event.issue.draft)
+        run: |
           FAILED="false"
-          # Get all the defined projections (minus 'all') and make them suitable for a bash for loop
-          DEPS=$(yq '.spack.modules.default.tcl.projections | del(.all) | keys | join(" ")' spack.yaml)
+          # Get all the defined projections (minus 'all' and the root spec) and make them suitable for a bash for loop
+          DEPS=$(yq '.spack.modules.default.tcl.projections | del(.all) | del(.${{ steps.current.outputs.root-spec-name }}) | keys | join(" ")' spack.yaml)
 
-          # for each of the modules
+          # for each of the module names
           for DEP in $DEPS; do
-            DEP_VER=''
-            if [[ "$DEP" == "${{ inputs.spack-manifest-root-sbd }}" ]]; then
-              # The model version is the bit after '@git.', before any later, space-separated, optional variants.
-              # For example, in 'MODEL@git.VERSION type=ACCESS ~debug' the version is 'VERSION'.
-              DEP_VER=${{ steps.current.outputs.root-spec-ref }}
+            # Capture the section after '@git.' or '@' (if it's not a git-attributed version) and before a possible '=' for a given dependency.
+            # Ex. '@git.2024.02.11' -> '2024.02.11', '@access-esm1.5' -> 'access-esm1.5', '@git.2024.05.21=access-esm1.5' -> '2024.05.21'
+            package_ver=$(yq ".spack.packages.\"$DEP\".require[0] | match(\"^@(?:git.)?([^=]*)\").captures[0].string" spack.yaml)
+            expected_projection_prefix="{name}/$package_ver"
+
+            # Projections must start with '{name}/VERSION'. For example, '{name}/2024.11.11', or '{name}/2024.11.11-{hash:7}'
+            current_projection=$(yq ".spack.modules.default.tcl.projections.\"$DEP\"" spack.yaml)
+
+            if [[ "$current_projection" == "$expected_projection_prefix"* ]]; then
+              echo "$DEP: Current projection ($current_projection) and expected projection prefix ($expected_projection_prefix) match."
             else
-              # Capture the section after '@git.' or '@' (if it's not a git-attributed version) and before a possible '=' for a given dependency.
-              # Ex. '@git.2024.02.11' -> '2024.02.11', '@access-esm1.5' -> 'access-esm1.5', '@git.2024.05.21=access-esm1.5' -> '2024.05.21'
-              DEP_VER=$(yq ".spack.packages.\"$DEP\".require[0] | match(\"^@(?:git.)?([^=]*)\").captures[0].string" spack.yaml)
-            fi
-
-            # Get the version from the module projection, for comparison with DEP_VER
-            # Projections are of the form '{name}/VERSION[-{hash:7}]', in which we only care about VERSION. For example, '{name}/2024.11.11', or '{name}/2024.11.11-{hash:7}'
-            MODULE_NAME=$(yq ".spack.modules.default.tcl.projections.\"$DEP\"" spack.yaml)
-            MODULE_VER="${MODULE_NAME#*/}"  # Strip '{name}/' from '{name}/VERSION' module, even if VERSION contains '/'
-            MODULE_VER="${MODULE_VER%%-\{hash:7\}}"  # Strip a potential '-{hash:7}' appendix from the VERSION, since we won't have that in the DEP_VER
-
-            if [[ "$DEP_VER" != "$MODULE_VER" ]]; then
-              echo "::error::$DEP: Version of dependency and projection do not match ($DEP_VER != $MODULE_VER)"
+              echo "::error::$DEP: Current projection ($current_projection) and expected projection prefix ($expected_projection_prefix) don't match."
               FAILED='true'
             fi
           done


### PR DESCRIPTION
Closes #237

## Background

Prereleases have evolved - sometimes they are used not to create a Release, but to have a sharable location to test out various builds. This means that the schema (and some of the checks) are unnessecarily restrictive. This PR removes schema checks and package projection checks for Draft PRs in Model Deployment Repositories. 

## Open Questions

Wouldn't mind @aidanheerdegen and @harshula s opinions on these questions:

* Say we have an environment that installs `mom5@development` with spack package hash `abcdefg`. If we create another environment that reuses this package and therefore it's hash, will we have a modulefile clash even with a modulefile name `{name}/development-{hash:7` (resolves to `mom5/development-abcdefg`)?
  * And is this actually a problem? The packages are identical - it's not like the earlier case where we had `{name}/development` clashing the other, non-identical builds of `mom5@development`. 

## Testing

Using `ACCESS-TEST` with branch `237-skip-check-spack-yaml-check-on-draft_TEST` (which is the PR branch with all access-nri workflow refs replaced with the above branch). Did this with `sed -E 's|uses: access-nri/build-cd/(.+)@v4|uses: access-nri/build-cd/$1@237-skip-check-spack-yaml-check-on-draft_TEST|g' -i .github/workflows/*`

See https://github.com/ACCESS-NRI/ACCESS-TEST/pull/31 - this contains a run of tests that validate:

* Commit-invoked Draft PRs skip schema and package projection checks :heavy_check_mark: 
* `!redeploy`-invoked Draft PRs skip schema and package projection checks :heavy_check_mark: 
* Commit-invoked Non Draft PRs do NOT skip schema and package projection checks (and `!bump` continues to work) :heavy_check_mark: 
* `!redeploy`-invoked Non Draft PRs do NOT skip schema and package projection checks :heavy_check_mark: 

This verifies that this PR is working as expected. 