### PR TITLE
Upload build-db-pkgs.json as part of metadata artifact

### DIFF
--- a/.github/workflows/deploy-2-start.yml
+++ b/.github/workflows/deploy-2-start.yml
@@ -220,9 +220,11 @@ jobs:
         env:
           # TODO: Can we put both envs above in a $GITHUB_ENV file instead?
           SPACK_ENV_PATH: ${{ steps.path.outputs.spack }}/../environments/${{ inputs.env-name }}
+        # Copy both the spack.* files and the build-db-pkgs.json file to the artifact
         run: |
           rsync -e 'ssh -i ${{ steps.ssh.outputs.private-key-path }}' \
-            '${{ secrets.USER}}@${{ secrets.HOST_DATA }}:${{ env.SPACK_ENV_PATH }}/spack.*' \
+            '${{ secrets.USER }}@${{ secrets.HOST_DATA }}:${{ env.SPACK_ENV_PATH }}/spack.*' \
+            '${{ secrets.USER }}@${{ secrets.HOST_DATA }}:${{ env.SPACK_ENV_PATH }}/build-db-pkgs.json' \
             ./${{ env.ARTIFACT_NAME }}
 
           # Rename the files to include the deployment environment


### PR DESCRIPTION
Closes #245

## Background

The model-build database upload step was failing because it couldn't find `Gadi.build-db-pkgs.json` in the metadata artifact. This was due to `deploy-2-start.yaml` not actually uploading it as part of the metadata artifact, only uploading `spack.*` files. 

## The PR

In this PR:

* rsync across the `model-db-pkgs.json` into the metadata artifact, so it can be used by the `model-db-upload` job

## Testing

Locally rsynced across an equivalent file structure
