### PR TITLE
Only Do Some Prerelease Modifications if the Root Spec is as expected

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -200,7 +200,7 @@ jobs:
       deployment-version: ${{ needs.defaults.outputs.prerelease-version }}
       prerelease-compare-ref: ${{ needs.defaults.outputs.base-ref }}
       spack-manifest-path: ./spack.yaml
-      spack-manifest-root-sbd: ${{ needs.defaults.outputs.root-sbd }}
+      expected-root-spec-name: ${{ needs.defaults.outputs.root-sbd }}
     secrets: inherit
 
   redeploy-post:

--- a/.github/workflows/deploy-1-setup.yml
+++ b/.github/workflows/deploy-1-setup.yml
@@ -40,12 +40,12 @@ on:
         description: |
           Relative path in the Model Deployment Repository that contains the spack manifest file.
           Usually a spack.yaml file.
-      spack-manifest-root-sbd:
+      expected-root-spec-name:
         type: string
         required: true
         description: |
-          Within the spack manifest, the overarching spack bundle that contains all other packages.
-          Usually the first entry in the .spack.specs section of the manifest.
+          The expected overarching spack bundle that contains all other packages, set in the caller repository.
+          Usually .spack.specs[0] or .spack.definitions.ROOT_PACKAGE in the manifest, but draft PRs can override this.
     outputs:
       general-metadata-artifact-glob:
         value: ${{ jobs.deployment.outputs.general-metadata-artifact-glob }}
@@ -186,13 +186,18 @@ jobs:
         id: current
         uses: access-nri/build-cd/.github/actions/get-spack-root-spec@v4
 
-      - name: Check '@latest' version usage
+      - name: Check root spec usage
         if: >-
           (github.event_name == 'pull_request' && !github.event.pull_request.draft) ||
           (github.event_name == 'issue_comment' && !github.event.issue.draft)
         run: |
           if [[ "${{ steps.current.outputs.root-spec-ref }}" == "latest" ]]; then
               echo "::error::The '@latest' version string is not allowed in non-draft PRs. It is reserved for a spack package that moves often and cannot be used as a future release tag"
+              exit 1
+          fi
+
+          if [[ "${{ inputs.expected-root-spec-name }}" != "${{ steps.current.outputs.root-spec-name }}" ]]; then
+              echo "::error::The root spec in the spack manifest (${{ steps.current.outputs.root-spec-name }}) cannot be different from the expected root spec (${{ inputs.expected-root-spec-name }}) in non-Draft PRs."
               exit 1
           fi
 
@@ -290,7 +295,7 @@ jobs:
       - name: Set Spack Env Name String
         id: get-env-name
         # replace occurences of '.' with '_' in environment name as spack doesn't support '.'. Ex: 'access-om2-v1.0.0' -> 'access-om2-v1_0_0'.
-        run: echo "env-name=$(echo '${{ inputs.spack-manifest-root-sbd }}-${{ inputs.deployment-version }}' | tr '.' '_')" >> $GITHUB_OUTPUT
+        run: echo "env-name=$(echo '${{ inputs.expected-root-spec-name }}-${{ inputs.deployment-version }}' | tr '.' '_')" >> $GITHUB_OUTPUT
 
   deployment:
     name: ${{ inputs.deployment-target }}
@@ -299,13 +304,12 @@ jobs:
       - check-spack-yaml  # Verify spack manifest information is correct
     uses: access-nri/build-cd/.github/workflows/deploy-2-start.yml@v4
     with:
-      model: ${{ inputs.spack-manifest-root-sbd }}
       ref: ${{ inputs.deployment-ref }}
       version: ${{ inputs.deployment-version }}
       env-name: ${{ needs.check-spack-yaml.outputs.spack-env-name }}
       deployment-target: ${{ inputs.deployment-target }}
       deployment-type: ${{ inputs.deployment-type }}
-      root-sbd: ${{ inputs.spack-manifest-root-sbd }}
+      expected-root-spec-name: ${{ inputs.expected-root-spec-name }}
     secrets: inherit
 
   outputs-upload:

--- a/.github/workflows/deploy-2-start.yml
+++ b/.github/workflows/deploy-2-start.yml
@@ -49,7 +49,6 @@ on:
           General pattern for the artifact that contains the deployment metadata files for this invocation of the job.
           These files are of the form deploy-metadata.{{inputs.deployment-target}}
 env:
-  SPACK_YAML_MODULEFILE_PROJECTION_YQ: .spack.modules.default.tcl.projections.${{ inputs.root-sbd }}
   METADATA_PATH: /opt/metadata
   ARTIFACT_NAME: deploy-metadata.${{ inputs.deployment-target }}
 jobs:
@@ -102,14 +101,19 @@ jobs:
         # `pr<number>-<commit>` style. For example, `access-om3/pr12-2`.
         # Also removes the `@git.VERSION` specifier for Prereleases so
         # we don't have to shift tags around.
-        if: inputs.deployment-type == 'Prerelease' && inputs.root-sbd == steps.yq.outputs.root-spec-name
+        if: inputs.deployment-type == 'Prerelease'
         # If the expected inputs.root-sbd for the repository is the same as the one in the spack.yaml,
         # we can safely remove the @git.VERSION specifier. Otherwise it could be because the Prerelease
         # is being used to test something else.
+        env:
+          SPACK_YAML_MODULEFILE_PROJECTION_YQ: .spack.modules.default.tcl.projections.${{ steps.yq.outputs.root-spec-name }}
         run: |
-          yq -i '${{ steps.yq.outputs.yq-root-spec }} = "${{ inputs.root-sbd }}"' spack.yaml
+          if [[ "${{ inputs.root-sbd }}" == "${{ steps.yq.outputs.root-spec-name }}" ]]; then
+            yq -i '${{ steps.yq.outputs.yq-root-spec }} = "${{ inputs.root-sbd }}"' spack.yaml
+          fi
+
           yq -i '${{ env.SPACK_YAML_MODULEFILE_PROJECTION_YQ }} = "{name}/${{ inputs.version }}"' spack.yaml
-          echo '::notice::Prerelease accessible as module `${{ inputs.model}}/${{ inputs.version }}`'
+          echo '::notice::Prerelease accessible as module `${{ steps.yq.outputs.root-spec-name }}/${{ inputs.version }}`'
 
       - name: Copy spack.yaml
         run: |

--- a/.github/workflows/deploy-2-start.yml
+++ b/.github/workflows/deploy-2-start.yml
@@ -3,10 +3,6 @@ concurrency: ${{ inputs.deployment-target }} ${{ inputs.deployment-type }}
 on:
   workflow_call:
     inputs:
-      model:
-        type: string
-        required: true
-        description: The model to deploy
       ref:
         type: string
         required: true
@@ -32,10 +28,12 @@ on:
           The type of deployment.
           Can be one of: Release, Prerelease.
           Combined with inputs.deployment-target to create the GitHub Environment name.
-      root-sbd:
+      expected-root-spec-name:
         type: string
         required: true
-        description: The root SBD that is being used as the modulefile name
+        description: |
+          The expected root spec name that is defined at the repository level.
+          May be different from the actual root spec name in the spack manifest.
     outputs:
       modules-location:
         value: ${{ jobs.deploy-to-environment.outputs.modules-location }}
@@ -82,8 +80,8 @@ jobs:
           spack-version: ${{ steps.versions.outputs.spack }}
           deployment-environment: ${{ inputs.deployment-target }} ${{ inputs.deployment-type }}
 
-      - name: Get yq filters
-        id: yq
+      - name: Get manifest info
+        id: manifest
         # FIXME: We should pass through inputs.spack-manifest-path here (and below raw spack.yaml) - see ACCESS-NRI/build-cd#225
         uses: access-nri/build-cd/.github/actions/get-spack-root-spec@v4
 
@@ -102,24 +100,24 @@ jobs:
         # Also removes the `@git.VERSION` specifier for Prereleases so
         # we don't have to shift tags around.
         if: inputs.deployment-type == 'Prerelease'
-        # If the expected inputs.root-sbd for the repository is the same as the one in the spack.yaml,
+        # If the inputs.expected-root-spec-name for the repository is the same as the one in the spack.yaml,
         # we can safely remove the @git.VERSION specifier. Otherwise it could be because the Prerelease
         # is being used to test something else.
         env:
-          SPACK_YAML_MODULEFILE_PROJECTION_YQ: .spack.modules.default.tcl.projections.${{ steps.yq.outputs.root-spec-name }}
+          SPACK_YAML_MODULEFILE_PROJECTION_YQ: .spack.modules.default.tcl.projections.${{ steps.manifest.outputs.root-spec-name }}
         run: |
-          if [[ "${{ inputs.root-sbd }}" == "${{ steps.yq.outputs.root-spec-name }}" ]]; then
-            yq -i '${{ steps.yq.outputs.yq-root-spec }} = "${{ inputs.root-sbd }}"' spack.yaml
+          if [[ "${{ inputs.expected-root-spec-name }}" == "${{ steps.manifest.outputs.root-spec-name }}" ]]; then
+            yq -i '${{ steps.manifest.outputs.yq-root-spec }} = "${{ inputs.expected-root-spec-name }}"' spack.yaml
           fi
 
           yq -i '${{ env.SPACK_YAML_MODULEFILE_PROJECTION_YQ }} = "{name}/${{ inputs.version }}"' spack.yaml
-          echo '::notice::Prerelease accessible as module `${{ steps.yq.outputs.root-spec-name }}/${{ inputs.version }}`'
+          echo '::notice::Prerelease accessible as module `${{ steps.manifest.outputs.root-spec-name }}/${{ inputs.version }}`'
 
       - name: Copy spack.yaml
         run: |
           rsync -e 'ssh -i ${{ steps.ssh.outputs.private-key-path }}' \
             spack.yaml \
-            ${{ secrets.USER }}@${{ secrets.HOST_DATA }}:${{ vars.SPACK_YAML_LOCATION }}/${{ inputs.model }}.spack.yaml
+            ${{ secrets.USER }}@${{ secrets.HOST_DATA }}:${{ vars.SPACK_YAML_LOCATION }}/${{ inputs.expected-root-spec-name }}.spack.yaml
 
       - name: Fetch git sources for packages to build
         # Workaround for ACCESS-NRI/spack#2.
@@ -162,7 +160,7 @@ jobs:
           . ${{ steps.path.outputs.spack-config }}/spack-enable.bash
 
           # Create environment and build model
-          spack env create ${{ inputs.env-name }} ${{ vars.SPACK_YAML_LOCATION }}/${{ inputs.model }}.spack.yaml
+          spack env create ${{ inputs.env-name }} ${{ vars.SPACK_YAML_LOCATION }}/${{ inputs.expected-root-spec-name }}.spack.yaml
           spack env activate ${{ inputs.env-name }}
           spack --debug install --fresh ${{ vars.SPACK_INSTALL_PARALLEL_JOBS }} || exit $?
           spack module tcl refresh -y

--- a/.github/workflows/deploy-2-start.yml
+++ b/.github/workflows/deploy-2-start.yml
@@ -98,11 +98,14 @@ jobs:
             ${{ secrets.HOST_DATA }}
 
       - name: Prerelease spack.yaml Modifications
-        if: inputs.deployment-type == 'Prerelease'
         # Modifies the name of the prerelease modulefile to the
         # `pr<number>-<commit>` style. For example, `access-om3/pr12-2`.
         # Also removes the `@git.VERSION` specifier for Prereleases so
         # we don't have to shift tags around.
+        if: inputs.deployment-type == 'Prerelease' && inputs.root-sbd == steps.yq.outputs.root-spec-name
+        # If the expected inputs.root-sbd for the repository is the same as the one in the spack.yaml,
+        # we can safely remove the @git.VERSION specifier. Otherwise it could be because the Prerelease
+        # is being used to test something else.
         run: |
           yq -i '${{ steps.yq.outputs.yq-root-spec }} = "${{ inputs.root-sbd }}"' spack.yaml
           yq -i '${{ env.SPACK_YAML_MODULEFILE_PROJECTION_YQ }} = "{name}/${{ inputs.version }}"' spack.yaml


### PR DESCRIPTION
Closes #247 

## Background

We do modifications to the Prerelease spack.yaml so that the `@git.VERSION` is removed, since it is a tag that doesn't yet exist; and update the modulefile so it is in the form `{name}/prX-Y`.

However, if users change the root spec to be something else (say, for testings sake), the prerelease modification will replace `spack.specs[0]` with the original `inputs.root-sbd`, removing their changes.

This PR does the `spack.specs[0]` modification only if the intended root-sbd (`inputs.root-sbd`)  is the same as the actual one (`steps.yq.outputs.root-spec-name`).

## Open Questions

* Is changing the root SBD something that we should support, anyway? Maybe only in drafted PRs? It kind of goes against the 'primacy of the root spec' thing that we have going.
  * As an aside, a user can always just have a secondary spec to install stuff that isn't the root spec, although it will increase the install time. 
* Cleaning up modulefiles after this may be difficult, although that is [an open issue](https://github.com/ACCESS-NRI/build-cd/issues/155) currently. 

## Testing

* Manually ran through varying values for `steps.yq.outputs.root-spec-name` on a local `spack.yaml` and verified the correctness of the updates