### PR TITLE
Remove workflow-level `concurrency` due to job cancellations

### DIFF
--- a/.github/workflows/deploy-2-start.yml
+++ b/.github/workflows/deploy-2-start.yml
@@ -1,5 +1,4 @@
 name: Deploy Start
-concurrency: ${{ inputs.deployment-target }} ${{ inputs.deployment-type }}
 on:
   workflow_call:
     inputs:


### PR DESCRIPTION
Closes #251

## Background

The concurrency that GitHub offers only allows for a single pending job while another is in progress. If another job in the same concurrency job is created, the previously `pending` job would be `cancelled`, and the new job would be `pending`. This isn't good for repositories with high levels of activity.

## The PR:

In this PR:

* Remove the `concurrency` key and see if `spack` can handle multiple installations at the same time at the repository level. We already allow multiple installations at the organisation level.

