### PR TITLE
Update `deploy-1-start` input in `cd.yml` to `expected-root-spec-name`

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -127,7 +127,7 @@ jobs:
       deployment-type: Release
       deployment-version: ${{ needs.push-tag.outputs.name }}
       spack-manifest-path: ./spack.yaml
-      spack-manifest-root-sbd: ${{ needs.defaults.outputs.root-sbd }}
+      expected-root-spec-name: ${{ needs.defaults.outputs.root-sbd }}
     secrets: inherit
     permissions:
       contents: write


### PR DESCRIPTION
Regression introduced in https://github.com/ACCESS-NRI/build-cd/pull/248, see https://github.com/ACCESS-NRI/ACCESS-ESM1.6/actions/runs/13915954144

## Background

In the linked PR, we updated a input variable to `expected-root-spec-name` but didn't pass this information on to the `cd.yml` workflow, only the `ci.yml` workflow. 

## In this PR

* Update the input in `cd.yml` to the expected one in `deploy-1-start.yml`. 
