### PR TITLE
`spack-packages` concurrent access issue

### DIFF
--- a/.github/actions/get-deploy-paths/README.md
+++ b/.github/actions/get-deploy-paths/README.md
@@ -9,6 +9,7 @@ This action constructs paths relevant to a deployment of `spack`.
 | `spack-installs-root-path` | `string` | Path to a directory within which all versions of spack are installed | `true` | N/A | `"/some/dir/apps/spack"` |
 | `spack-version` | `string` | Version of spack deployed. Used to construct a specific spack installation path, in conjunction with `spack-installs-root-path`. | `true` | N/A | `"0.21"` |
 | `deployment-environment` | `string` | Name of the GitHub deployment target environment | `true` | N/A | `"Gadi Prerelease"` |
+| `spack-environment` | `string` | Spack environment name that is used for this deployment. Used to construct Prerelease spack-packages path, which is demarcated by the environment name | `true` | N/A | `"access-om2-pr12-12"` |
 
 ## Outputs
 
@@ -17,7 +18,8 @@ This action constructs paths relevant to a deployment of `spack`.
 | `root` | `string` | Path to the root of a specific deployment of `spack`. This path contains `spack-{packages,config}` repositories as well. | `"/some/dir/apps/spack/0.21"` |
 | `spack` | `string` | Path to a specific installation of `spack`. | `"/some/dir/apps/spack/0.21/spack"` |
 | `spack-config` | `string` | Path to the ACCESS-NRI/spack-config repository associated with the install of spack. | `"/some/dir/apps/spack/0.21/spack-config"` |
-| `spack-packages` | `string` | Path to the ACCESS-NRI/spack-packages repository associated with the install of spack. | `"/some/dir/apps/spack/0.21/spack-packages"` |
+| `spack-packages-root` | `string` | Path to the folder containing all ACCESS-NRI/spack-packages repositories used in the install of spack | `"/some/dir/apps/spack/0.21/spack-packages"` |
+| `spack-packages` | `string` | Path to the ACCESS-NRI/spack-packages repository associated with the environment created in the install of spack. | For Release: `"/some/dir/apps/spack/0.21/spack-packages"`, for Prerelease: `"/some/dir/apps/spack/0.21/spack-packages/access-om2-pr12-12/spack-packages"` |
 
 ## Example
 
@@ -35,6 +37,7 @@ jobs:
           spack-installs-root-path: ${{ vars.SPACK_INSTALLS_ROOT_PATH }}
           spack-version: "0.21"
           deployment-environment: ${{ inputs.deployment-environment }}
+          spack-environment: ${{ inputs.env-name }}
 
       - run: echo 'Spack is installed in `${{ steps.paths.outputs.spack }}` and spack-packages is installed in `${{ steps.paths.outputs.spack-packages }}`'
 ```

--- a/.github/actions/get-deploy-paths/action.yml
+++ b/.github/actions/get-deploy-paths/action.yml
@@ -48,14 +48,14 @@ runs:
   using: composite
   steps:
     - name: Validate Inputs
-      id: valid
+      id: validate
       shell: bash
       env:
         ACCEPTABLE_DEPLOYMENT_ENVIRONMENT_TARGETS: Release Prerelease
       run: |
         # Check that the inputs.spack-installs-root-path exists - it's usually a var
         if [ -z '${{ inputs.spack-installs-root-path }}' ]; then
-          echo '::error::`spack-installs-root-path` does not exist in `${{ github.repository }}`s `${{ inputs.deployment-environment }}` environment. Check Environment vars.'
+          echo '::error::inputs.spack-installs-root-path does not exist in ${{ github.repository }}s ${{ inputs.deployment-environment }} environment. Check Environment vars.'
           exit 1
         fi
 
@@ -77,8 +77,8 @@ runs:
         echo "spack-config=$root/spack-config" >> $GITHUB_OUTPUT
         echo "spack-packages-root=$root/spack-packages" >> $GITHUB_OUTPUT
 
-        if [[ '${{ steps.valid.outputs.type }}' == Release ]]; then
+        if [[ '${{ steps.validate.outputs.type }}' == Release ]]; then
           echo "spack-packages=$root/spack-packages" >> $GITHUB_OUTPUT
-        elif [[ '${{ steps.valid.outputs.type }}' == Prerelease ]]; then
+        elif [[ '${{ steps.validate.outputs.type }}' == Prerelease ]]; then
           echo "spack-packages=$root/spack-packages/${{ inputs.spack-environment }}/spack-packages" >> $GITHUB_OUTPUT
         fi

--- a/.github/actions/get-deploy-paths/action.yml
+++ b/.github/actions/get-deploy-paths/action.yml
@@ -16,8 +16,13 @@ inputs:
   deployment-environment:
     type: string
     required: true
-    # Used for logging, essentially
     description: Name of the GitHub deployment target environment
+  spack-environment:
+    type: string
+    required: true
+    description: |
+      Spack environment name that is used for this deployment.
+      Used to construct Prerelease spack-packages path, which is demarcated by the environment name.
 outputs:
   root:
     description: |
@@ -30,23 +35,50 @@ outputs:
   spack-config:
     description: Path to the ACCESS-NRI/spack-config repository associated with the install of spack.
     value: ${{ steps.path.outputs.spack-config }}
+  spack-packages-root:
+    description: |
+      Path to the folder containing all ACCESS-NRI/spack-packages repositories used in the install of spack.
+      For Release inputs.deployment-environment, this is the repository itself.
+      For Prerelease inputs.deployment-environment, this is the folder containing multiple spack-packages repositories.
+    value: ${{ steps.path.outputs.spack-packages-root }}
   spack-packages:
-    description: Path to the ACCESS-NRI/spack-packages repository associated with the install of spack.
+    description: Path to the ACCESS-NRI/spack-packages repository associated with the environment created in the install of spack.
     value: ${{ steps.path.outputs.spack-packages }}
 runs:
   using: composite
   steps:
-    - name: Get ${{ inputs.deployment-environment }} Remote Paths
-      id: path
+    - name: Validate Inputs
+      id: valid
       shell: bash
+      env:
+        ACCEPTABLE_DEPLOYMENT_ENVIRONMENT_TARGETS: Release Prerelease
       run: |
+        # Check that the inputs.spack-installs-root-path exists - it's usually a var
         if [ -z "${{ inputs.spack-installs-root-path }}" ]; then
           echo '::error::`spack-installs-root-path` does not exist in `${{ github.repository }}`s `${{ inputs.deployment-environment }}` environment. Check Environment vars.'
           exit 1
         fi
 
+        # We want the type of deployment environment, which is the last word in the string.
+        type=$(echo "${{ inputs.deployment-environment }}" | rev | cut -d ' ' -f 1 | rev)
+        if [[ ! "${{ env.ACCEPTABLE_DEPLOYMENT_ENVIRONMENT_TARGETS}}" =~ "$type" ]]; then
+          echo "::error::inputs.deployment-environment must be one of ${{ env.ACCEPTABLE_ENVIRONMENT_TARGETS }}."
+          exit 1
+        fi
+        echo "type=$type" >> $GITHUB_OUTPUT
+
+    - name: Get ${{ inputs.deployment-environment }} Remote Paths
+      id: path
+      shell: bash
+      run: |
         root=${{ inputs.spack-installs-root-path }}/${{ inputs.spack-version }}
         echo "root=$root" >> $GITHUB_OUTPUT
         echo "spack=$root/spack" >> $GITHUB_OUTPUT
         echo "spack-config=$root/spack-config" >> $GITHUB_OUTPUT
-        echo "spack-packages=$root/spack-packages" >> $GITHUB_OUTPUT
+        echo "spack-packages-root=$root/spack-packages" >> $GITHUB_OUTPUT
+
+        if [[ "${{ steps.valid.outputs.type }}" == "Release" ]]; then
+          echo "spack-packages=$root/spack-packages" >> $GITHUB_OUTPUT
+        elif [[ "${{ steps.valid.outputs.type }}" == "Prerelease" ]]; then
+          echo "spack-packages=$root/spack-packages/${{ inputs.spack-environment }}/spack-packages" >> $GITHUB_OUTPUT
+        fi

--- a/.github/actions/get-deploy-paths/action.yml
+++ b/.github/actions/get-deploy-paths/action.yml
@@ -54,15 +54,15 @@ runs:
         ACCEPTABLE_DEPLOYMENT_ENVIRONMENT_TARGETS: Release Prerelease
       run: |
         # Check that the inputs.spack-installs-root-path exists - it's usually a var
-        if [ -z "${{ inputs.spack-installs-root-path }}" ]; then
+        if [ -z '${{ inputs.spack-installs-root-path }}' ]; then
           echo '::error::`spack-installs-root-path` does not exist in `${{ github.repository }}`s `${{ inputs.deployment-environment }}` environment. Check Environment vars.'
           exit 1
         fi
 
         # We want the type of deployment environment, which is the last word in the string.
-        type=$(echo "${{ inputs.deployment-environment }}" | rev | cut -d ' ' -f 1 | rev)
-        if [[ ! "${{ env.ACCEPTABLE_DEPLOYMENT_ENVIRONMENT_TARGETS}}" =~ "$type" ]]; then
-          echo "::error::inputs.deployment-environment must be one of ${{ env.ACCEPTABLE_ENVIRONMENT_TARGETS }}."
+        type=$(echo '${{ inputs.deployment-environment }}' | rev | cut -d ' ' -f 1 | rev)
+        if [[ ! '${{ env.ACCEPTABLE_DEPLOYMENT_ENVIRONMENT_TARGETS}}' =~ "$type" ]]; then
+          echo '::error::inputs.deployment-environment must be one of ${{ env.ACCEPTABLE_ENVIRONMENT_TARGETS }}.'
           exit 1
         fi
         echo "type=$type" >> $GITHUB_OUTPUT
@@ -77,8 +77,8 @@ runs:
         echo "spack-config=$root/spack-config" >> $GITHUB_OUTPUT
         echo "spack-packages-root=$root/spack-packages" >> $GITHUB_OUTPUT
 
-        if [[ "${{ steps.valid.outputs.type }}" == "Release" ]]; then
+        if [[ '${{ steps.valid.outputs.type }}' == Release ]]; then
           echo "spack-packages=$root/spack-packages" >> $GITHUB_OUTPUT
-        elif [[ "${{ steps.valid.outputs.type }}" == "Prerelease" ]]; then
+        elif [[ '${{ steps.valid.outputs.type }}' == Prerelease ]]; then
           echo "spack-packages=$root/spack-packages/${{ inputs.spack-environment }}/spack-packages" >> $GITHUB_OUTPUT
         fi

--- a/.github/workflows/deploy-2-start.yml
+++ b/.github/workflows/deploy-2-start.yml
@@ -161,12 +161,15 @@ jobs:
             git clone https://github.com/ACCESS-NRI/spack-packages.git "${{ steps.path.outputs.spack-packages }}"
           fi
 
-          git -C ${{ steps.path.outputs.spack-packages }} fetch --all --tags
+          cd ${{ steps.path.outputs.spack-packages }} || exit 1
+
+          git fetch --all --tags
 
           if git ls-remote --exit-code --heads origin ${{ steps.versions.outputs.packages }}; then  # If the ref is a branch
-            # Checkout the branch at the latest commit
+            echo "Checking out the branch at the latest commit"
             git checkout -B ${{ steps.versions.outputs.packages }} origin/${{ steps.versions.outputs.packages }}
           else  # checkout the tag/commit
+            echo "Checking out the tag/commit"
             git checkout ${{ steps.versions.outputs.packages }}
           fi
           EOT

--- a/.github/workflows/deploy-2-start.yml
+++ b/.github/workflows/deploy-2-start.yml
@@ -149,16 +149,16 @@ jobs:
         run: |
           ssh ${{ secrets.USER}}@${{ secrets.HOST }} -i ${{ steps.ssh.outputs.private-key-path }} /bin/bash <<'EOT'
           # Check that a suitable spack-packages location exists
-          if [ ! -d "${{ steps.path.outputs.spack-packages-root }}" ]; then
+          if [ ! -d '${{ steps.path.outputs.spack-packages-root }}' ]; then
             echo '::error::spack-packages does not exist in `${{ steps.path.outputs.root }}` for `${{ inputs.deployment-target }} ${{ inputs.deployment-type}}`'
             exit 1
           fi
 
           # In the case of a Prerelease, we need to create a new instance of spack-packages per commit, so there is no concurrent access problems.
-          if [ ! -d "${{ steps.path.outputs.spack-packages }}" ]; then
-            echo "Creating spack-packages instance for ${{ inputs.env-name }} under ${{ steps.path.outputs.spack-packages }}"
+          if [ ! -d '${{ steps.path.outputs.spack-packages }}' ]; then
+            echo 'Creating spack-packages instance for ${{ inputs.env-name }} under ${{ steps.path.outputs.spack-packages }}'
             mkdir -p ${{ steps.path.outputs.spack-packages }}
-            git clone https://github.com/ACCESS-NRI/spack-packages.git "${{ steps.path.outputs.spack-packages }}"
+            git clone https://github.com/ACCESS-NRI/spack-packages.git '${{ steps.path.outputs.spack-packages }}'
           fi
 
           cd ${{ steps.path.outputs.spack-packages }} || exit 1

--- a/.github/workflows/deploy-2-start.yml
+++ b/.github/workflows/deploy-2-start.yml
@@ -121,7 +121,7 @@ jobs:
                 - $spack/var/spack/repos/builtin
           EOF
 
-          echo '::notice::Prerelease accessible as module `${{ steps.manifest.outputs.root-spec-name }}/${{ inputs.version }}`'
+          echo '::notice::Prerelease accessible as module ${{ steps.manifest.outputs.root-spec-name }}/${{ inputs.version }}'
 
       - name: Copy spack.yaml
         run: |
@@ -152,7 +152,7 @@ jobs:
           ssh ${{ secrets.USER}}@${{ secrets.HOST }} -i ${{ steps.ssh.outputs.private-key-path }} /bin/bash <<'EOT'
           # Check that a suitable spack-packages location exists
           if [ ! -d '${{ steps.path.outputs.spack-packages-root }}' ]; then
-            echo '::error::spack-packages does not exist in `${{ steps.path.outputs.root }}` for `${{ inputs.deployment-target }} ${{ inputs.deployment-type}}`'
+            echo '::error::spack-packages does not exist in ${{ steps.path.outputs.root }} for ${{ inputs.deployment-target }} ${{ inputs.deployment-type}}'
             exit 1
           fi
 
@@ -182,7 +182,7 @@ jobs:
           ssh ${{ secrets.USER}}@${{ secrets.HOST }} -i ${{ steps.ssh.outputs.private-key-path }} /bin/bash <<'EOT'
           # Check that a suitable deployment location exists
           if [ ! -d "${{ steps.path.outputs.root }}" ]; then
-            echo '::error::A deployment of spack does not exist in `${{ steps.path.outputs.root }}` for `${{ inputs.deployment-target }} ${{ inputs.deployment-type}}`'
+            echo '::error::A deployment of spack does not exist in ${{ steps.path.outputs.root }} for ${{ inputs.deployment-target }} ${{ inputs.deployment-type}}'
             exit 1
           fi
 

--- a/.github/workflows/deploy-2-start.yml
+++ b/.github/workflows/deploy-2-start.yml
@@ -78,6 +78,7 @@ jobs:
           spack-installs-root-path: ${{ vars.SPACK_INSTALLS_ROOT_LOCATION }}
           spack-version: ${{ steps.versions.outputs.spack }}
           deployment-environment: ${{ inputs.deployment-target }} ${{ inputs.deployment-type }}
+          spack-environment: ${{ inputs.env-name }}
 
       - name: Get manifest info
         id: manifest
@@ -136,6 +137,32 @@ jobs:
           done
           EOT
 
+      - name: Update spack-packages repository
+        run: |
+          ssh ${{ secrets.USER}}@${{ secrets.HOST }} -i ${{ steps.ssh.outputs.private-key-path }} /bin/bash <<'EOT'
+          # Check that a suitable spack-packages location exists
+          if [ ! -d "${{ steps.path.outputs.spack-packages-root }}" ]; then
+            echo '::error::spack-packages does not exist in `${{ steps.path.outputs.root }}` for `${{ inputs.deployment-target }} ${{ inputs.deployment-type}}`'
+            exit 1
+          fi
+
+          # In the case of a Prerelease, we need to create a new instance of spack-packages per commit, so there is no concurrent access problems.
+          if [ ! -d "${{ steps.path.outputs.spack-packages }}" ]; then
+            echo "Creating spack-packages instance for ${{ inputs.env-name }} under ${{ steps.path.outputs.spack-packages }}"
+            mkdir -p ${{ steps.path.outputs.spack-packages }}
+            git clone https://github.com/ACCESS-NRI/spack-packages.git "${{ steps.path.outputs.spack-packages }}"
+          fi
+
+          git -C ${{ steps.path.outputs.spack-packages }} fetch --all --tags
+
+          if git ls-remote --exit-code --heads origin ${{ steps.versions.outputs.packages }}; then  # If the ref is a branch
+            # Checkout the branch at the latest commit
+            git checkout -B ${{ steps.versions.outputs.packages }} origin/${{ steps.versions.outputs.packages }}
+          else  # checkout the tag/commit
+            git checkout ${{ steps.versions.outputs.packages }}
+          fi
+          EOT
+
       - name: Deploy to ${{ inputs.deployment-target }} ${{ inputs.deployment-type }}
         # ssh into deployment environment, create and activate the env, install the spack.yaml.
         run: |
@@ -149,11 +176,6 @@ jobs:
           # Export vars.DEPLOYMENT_TARGET
           export DEPLOYMENT_TARGET="${{ vars.DEPLOYMENT_TARGET }}"
           echo "DEPLOYMENT_TARGET exported as $DEPLOYMENT_TARGET"
-
-          # Update spack-packages
-          git -C ${{ steps.path.outputs.spack-packages }} fetch
-          git -C ${{ steps.path.outputs.spack-packages }} checkout --force ${{ steps.versions.outputs.packages }}
-          git -C ${{ steps.path.outputs.spack-packages }} reset --hard origin/${{ steps.versions.outputs.packages }}
 
           # Enable spack
           . ${{ steps.path.outputs.spack-config }}/spack-enable.bash

--- a/.github/workflows/deploy-2-start.yml
+++ b/.github/workflows/deploy-2-start.yml
@@ -99,6 +99,7 @@ jobs:
         # `pr<number>-<commit>` style. For example, `access-om3/pr12-2`.
         # Also removes the `@git.VERSION` specifier for Prereleases so
         # we don't have to shift tags around.
+        # Also adds a repos section that points to the PRs specific spack-packages repo.
         if: inputs.deployment-type == 'Prerelease'
         # If the inputs.expected-root-spec-name for the repository is the same as the one in the spack.yaml,
         # we can safely remove the @git.VERSION specifier. Otherwise it could be because the Prerelease
@@ -111,6 +112,13 @@ jobs:
           fi
 
           yq -i '${{ env.SPACK_YAML_MODULEFILE_PROJECTION_YQ }} = "{name}/${{ inputs.version }}"' spack.yaml
+
+          # Add the specific prerelease spack-packages repo to the environment
+          # We can't use yq as we are using a non-standard spack-specific '::' construct to ignore higher config scopes
+          echo '  repos::' >> spack.yaml
+          echo '  - ${{ steps.path.outputs.spack-packages }}' >> spack.yaml
+          echo '  - $spack/var/spack/repos/builtin' >> spack.yaml
+
           echo '::notice::Prerelease accessible as module `${{ steps.manifest.outputs.root-spec-name }}/${{ inputs.version }}`'
 
       - name: Copy spack.yaml

--- a/.github/workflows/deploy-2-start.yml
+++ b/.github/workflows/deploy-2-start.yml
@@ -115,9 +115,11 @@ jobs:
 
           # Add the specific prerelease spack-packages repo to the environment
           # We can't use yq as we are using a non-standard spack-specific '::' construct to ignore higher config scopes
-          echo '  repos::' >> spack.yaml
-          echo '  - ${{ steps.path.outputs.spack-packages }}' >> spack.yaml
-          echo '  - $spack/var/spack/repos/builtin' >> spack.yaml
+          cat << 'EOF' >> spack.yaml
+            repos::
+                - ${{ steps.path.outputs.spack-packages }}
+                - $spack/var/spack/repos/builtin
+          EOF
 
           echo '::notice::Prerelease accessible as module `${{ steps.manifest.outputs.root-spec-name }}/${{ inputs.version }}`'
 

--- a/.github/workflows/undeploy-1-start.yml
+++ b/.github/workflows/undeploy-1-start.yml
@@ -67,7 +67,7 @@ jobs:
       - name: Undeploy spack-packages
         # ssh into deployment environment, remove all the unneeded spack-packages installations
         run: |
-          ssh ${{ secrets.USER}}@${{ secrets.HOST }} -i ${{ steps.ssh.outputs.private-key-path }} /bin/bash <<EOT
+          ssh ${{ secrets.USER}}@${{ secrets.HOST }} -i ${{ steps.ssh.outputs.private-key-path }} /bin/bash <<'EOT'
           find "${{ steps.path.outputs.spack-packages-root }}" \
             -mindepth 1 -maxdepth 1 \
             -type d -name "${{ inputs.version-pattern }}" \

--- a/.github/workflows/undeploy-1-start.yml
+++ b/.github/workflows/undeploy-1-start.yml
@@ -97,4 +97,4 @@ jobs:
 
       - name: Undeploy Status Notifier
         if: failure()
-        run: echo "::error::Deployment ${{ inputs.version-pattern }} couldn't be removed from ${{ inputs.target }} ${{ inputs.type }}, found at ${{ steps.path.outputs.spack }}. Please check manually."
+        run: echo '::error::Deployment ${{ inputs.version-pattern }} could not be removed from ${{ inputs.target }} ${{ inputs.type }}, found at ${{ steps.path.outputs.spack }}. Please check manually.'

--- a/.github/workflows/undeploy-1-start.yml
+++ b/.github/workflows/undeploy-1-start.yml
@@ -68,7 +68,10 @@ jobs:
         # ssh into deployment environment, remove all the unneeded spack-packages installations
         run: |
           ssh ${{ secrets.USER}}@${{ secrets.HOST }} -i ${{ steps.ssh.outputs.private-key-path }} /bin/bash <<EOT
-          rm -rfv "${{ steps.path.outputs.spack-packages }}"
+          find "${{ steps.path.outputs.spack-packages-root }}" \
+            -mindepth 1 -maxdepth 1 \
+            -type d -name "${{ inputs.version-pattern }}" \
+            -exec rm -rfv {} +
           EOT
 
       - name: Undeploy Environment

--- a/.github/workflows/undeploy-1-start.yml
+++ b/.github/workflows/undeploy-1-start.yml
@@ -53,6 +53,7 @@ jobs:
           spack-installs-root-path: ${{ vars.SPACK_INSTALLS_ROOT_LOCATION }}
           spack-version: ${{ steps.versions.outputs.spack }}
           deployment-environment: ${{ inputs.target }} ${{ inputs.type }}
+          spack-environment: ${{ inputs.version-pattern }}
 
       - name: Setup SSH
         id: ssh
@@ -63,9 +64,15 @@ jobs:
             ${{ secrets.HOST }}
             ${{ secrets.HOST_DATA }}
 
-      - name: Undeploy
+      - name: Undeploy spack-packages
+        # ssh into deployment environment, remove all the unneeded spack-packages installations
+        run: |
+          ssh ${{ secrets.USER}}@${{ secrets.HOST }} -i ${{ steps.ssh.outputs.private-key-path }} /bin/bash <<EOT
+          rm -rfv "${{ steps.path.outputs.spack-packages }}"
+          EOT
+
+      - name: Undeploy Environment
         # ssh into deployment environment, create and activate the env, remove all the unneeded environments
-        id: undeploy
         run: |
           ssh ${{ secrets.USER}}@${{ secrets.HOST }} -i ${{ steps.ssh.outputs.private-key-path }} /bin/bash <<'EOT'
 
@@ -86,10 +93,5 @@ jobs:
           EOT
 
       - name: Undeploy Status Notifier
-        if: always()
-        run: |
-          if [[ "${{ steps.undeploy.outcome }}" == "success" ]]; then
-            echo "::notice::Deployment ${{ inputs.version-pattern }} was successfully removed from ${{ inputs.target }} ${{ inputs.type }}, found at ${{ steps.path.outputs.spack }}"
-          else
-            echo "::error::Deployment ${{ inputs.version-pattern }} couldn't be removed from ${{ inputs.target }} ${{ inputs.type }}, found at ${{ steps.path.outputs.spack }}. Please check manually."
-          fi
+        if: failure()
+        run: echo "::error::Deployment ${{ inputs.version-pattern }} couldn't be removed from ${{ inputs.target }} ${{ inputs.type }}, found at ${{ steps.path.outputs.spack }}. Please check manually."


### PR DESCRIPTION
Closes #255

## Background 

There is a possibility that multiple deployments to an instance of `spack` may lead to `spack-packages` being updated (and locked) during install time. Even though spack actually does copy the `packages.py` relevant to to the install prior to install, there is still a possibility that the version is changed before the `spack env create` call. 

The solution is to have an instance of `spack-packages` per commit, that each uses. Since the repository is only 1MB, this shouldn't be too much space. We link the commit-specific `spack-packages` in the `spack.yaml` at install-time via a `repos:: ["COMMMIT_SPECIFIC_SPACK_PACKAGES", "BUILTINS"]` section.

We also remove the `spack-packages` repositories when we close the PR. 

## The PR

In this PR:

- **Deployment: Handle having either a single spack-packages repo (for Release) or multiple (for Prerelease)**
- **Deployment: Add prerelease-specific repos:: section to spack.yaml**
- **Undeployment: Add new step to undeploy workflow that removes all spack-packages repos given by glob inputs.version-pattern**

## Testing

This branch is tested on `ACCESS-TEST`, specifically https://github.com/ACCESS-NRI/ACCESS-TEST/pull/33. It uses the https://github.com/ACCESS-NRI/build-cd/tree/255-spack-packages-concurrent-access-issue_TEST branch, which replaces all `@vX` references with `255-spack-packages-concurrent-access-issue_TEST`, which means that the entire pipeline uses the same commit, rather than just the entrypoints. 

### Runtime Modifications Test

Verified that the runtime spack-packages was successfully injected, having the form:
```yaml
spack:
  # ...
  repos::
  - /g/data/vk83/testing/apps/spack/0.22/spack-packages/access-test-pr33-3/spack-packages
  - $spack/var/spack/repos/builtin
```

### `spack-packages` Creation Logic During PR With Branch Ref

Success, see https://github.com/ACCESS-NRI/ACCESS-TEST/actions/runs/14025657298/job/39263794979?pr=33#step:10:33


### `spack-packages` Creation Logic During PR With Tag Ref

Success, see https://github.com/ACCESS-NRI/ACCESS-TEST/actions/runs/14025872250/job/39264344516?pr=33#step:10:35

### `spack-packages` Cleanup Logic During PR

Success, see https://github.com/ACCESS-NRI/ACCESS-TEST/actions/runs/14026246926/job/39265322646#step:6:1

### `spack-packages` Creation Logic During Release

Success, the `spack-packages` used is the one under `.../0.22/spack-packages`, rather than a child directory, see https://github.com/ACCESS-NRI/ACCESS-TEST/actions/runs/14026652957/job/39266451218#step:10:35