### PR TITLE
Run both projection checks despite failure, run package projections on push (CD)

### DIFF
--- a/.github/workflows/deploy-1-setup.yml
+++ b/.github/workflows/deploy-1-setup.yml
@@ -175,7 +175,8 @@ jobs:
       - name: Validate ACCESS-NRI spack.yaml Restrictions
         if: >-
           (github.event_name == 'pull_request' && !github.event.pull_request.draft) ||
-          (github.event_name == 'issue_comment' && !github.event.issue.draft)
+          (github.event_name == 'issue_comment' && !github.event.issue.draft_) ||
+          (github.event_name == 'push')
         uses: access-nri/schema/.github/actions/validate-with-schema@main
         with:
           schema-version: ${{ vars.SPACK_YAML_SCHEMA_VERSION }}
@@ -189,7 +190,8 @@ jobs:
       - name: Check root spec usage
         if: >-
           (github.event_name == 'pull_request' && !github.event.pull_request.draft) ||
-          (github.event_name == 'issue_comment' && !github.event.issue.draft)
+          (github.event_name == 'issue_comment' && !github.event.issue.draft) ||
+          (github.event_name == 'push')
         run: |
           if [[ "${{ steps.current.outputs.root-spec-ref }}" == "latest" ]]; then
               echo "::error::The '@latest' version string is not allowed in non-draft PRs. It is reserved for a spack package that moves often and cannot be used as a future release tag"
@@ -268,9 +270,9 @@ jobs:
         id: projection-check-packages
         continue-on-error: true
         if: >-
-          (github.event_name == 'push') ||
           (github.event_name == 'pull_request' && !github.event.pull_request.draft) ||
-          (github.event_name == 'issue_comment' && !github.event.issue.draft)
+          (github.event_name == 'issue_comment' && !github.event.issue.draft) ||
+          (github.event_name == 'push')
         run: |
           FAILED="false"
           # Get all the defined projections (minus 'all' and the root spec) and make them suitable for a bash for loop

--- a/.github/workflows/deploy-1-setup.yml
+++ b/.github/workflows/deploy-1-setup.yml
@@ -246,6 +246,8 @@ jobs:
 
       - name: Check Projections - Specs
         # This step checks that the root spec has an appropriate projection in the spack.yaml file.
+        id: projection-check-spec
+        continue-on-error: true
         run: |
           git checkout ${{ inputs.deployment-ref }}
 
@@ -263,7 +265,10 @@ jobs:
         # This step checks that the defined projections have the same versions as the referenced packages in the spack.yaml file.
         # For example, mom5@git.2023.12.12 matches with the
         #  modulefile mom5/2023.12.12 (specifically, the version strings match)
+        id: projection-check-packages
+        continue-on-error: true
         if: >-
+          (github.event_name == 'push') ||
           (github.event_name == 'pull_request' && !github.event.pull_request.draft) ||
           (github.event_name == 'issue_comment' && !github.event.issue.draft)
         run: |
@@ -291,6 +296,13 @@ jobs:
           if [[ "$FAILED" == "true" ]]; then
             exit 1
           fi
+
+      - name: Check Projections - Error Notifier
+        # If either of the Check Projection steps failed earlier, exit here
+        if: steps.projection-check-spec.outcome == 'failure' || steps.projection-check-packages.outcome == 'failure'
+        run: |
+          echo "::error::Some projections in the spack manifest don't match."
+          exit 1
 
       - name: Set Spack Env Name String
         id: get-env-name

--- a/.github/workflows/deploy-1-setup.yml
+++ b/.github/workflows/deploy-1-setup.yml
@@ -159,6 +159,10 @@ jobs:
   check-spack-yaml:
     name: '${{ inputs.deployment-target }}: Check Spack Manifest'
     runs-on: ubuntu-latest
+    env:
+      # Note: since this is a string representation of a boolean, it must be compared as a string.
+      # Yes, github.event.issue.draft refers to the pull request if the comment is made on a pull request!
+      IS_NOT_DRAFT: ${{ (github.event_name == 'pull_request' && !github.event.pull_request.draft) || (github.event_name == 'issue_comment' && !github.event.issue.draft) }}
     permissions:
       pull-requests: write
     outputs:
@@ -173,10 +177,7 @@ jobs:
           ref: ${{ inputs.deployment-ref }}
 
       - name: Validate ACCESS-NRI spack.yaml Restrictions
-        if: >-
-          (github.event_name == 'pull_request' && !github.event.pull_request.draft) ||
-          (github.event_name == 'issue_comment' && !github.event.issue.draft_) ||
-          (github.event_name == 'push')
+        if: env.IS_NOT_DRAFT == 'true' || inputs.deployment-type == 'Release'
         uses: access-nri/schema/.github/actions/validate-with-schema@main
         with:
           schema-version: ${{ vars.SPACK_YAML_SCHEMA_VERSION }}
@@ -188,10 +189,7 @@ jobs:
         uses: access-nri/build-cd/.github/actions/get-spack-root-spec@v4
 
       - name: Check root spec usage
-        if: >-
-          (github.event_name == 'pull_request' && !github.event.pull_request.draft) ||
-          (github.event_name == 'issue_comment' && !github.event.issue.draft) ||
-          (github.event_name == 'push')
+        if: env.IS_NOT_DRAFT == 'true' || inputs.deployment-type == 'Release'
         run: |
           if [[ "${{ steps.current.outputs.root-spec-ref }}" == "latest" ]]; then
               echo "::error::The '@latest' version string is not allowed in non-draft PRs. It is reserved for a spack package that moves often and cannot be used as a future release tag"
@@ -224,11 +222,7 @@ jobs:
         # We don't want to fire off model deployment version checks if the PR is never going to be merged.
         # We determine this by checking if either the pull request, or the pull request that a comment
         # belongs to, is drafted.
-        # Yes, github.event.issue.draft refers to the pull request if the comment is made on a pull request!
-        if: >-
-          inputs.deployment-type != 'Release' && steps.checkout-base-spack.outcome != 'failure' &&
-          (github.event_name == 'pull_request' && !github.event.pull_request.draft) ||
-          (github.event_name == 'issue_comment' && !github.event.issue.draft)
+        if: inputs.deployment-type != 'Release' && steps.checkout-base-spack.outcome != 'failure' && env.IS_NOT_DRAFT == 'true'
         id: version-modified
         run: |
           if [[ "${{ steps.base.outputs.root-spec-ref }}" == "${{ steps.current.outputs.root-spec-ref }}" ]]; then
@@ -269,10 +263,7 @@ jobs:
         #  modulefile mom5/2023.12.12 (specifically, the version strings match)
         id: projection-check-packages
         continue-on-error: true
-        if: >-
-          (github.event_name == 'pull_request' && !github.event.pull_request.draft) ||
-          (github.event_name == 'issue_comment' && !github.event.issue.draft) ||
-          (github.event_name == 'push')
+        if: env.IS_NOT_DRAFT == 'true '|| inputs.deployment-type == 'Release'
         run: |
           FAILED="false"
           # Get all the defined projections (minus 'all' and the root spec) and make them suitable for a bash for loop


### PR DESCRIPTION
Closes #257

## Background

The package projection checks aren't running. This is due to some checks only running on pull_request and issue_comment non-draft, but not push (which we signify with `inputs.deployment-type == 'Release'`)!

## In This PR

* Run both projection checks (where appropriate) even if an earlier one fails
* Run the package projection checks on push
* Simplify the boolean logic
