### PR TITLE
Fail fast when installing manifest

### DIFF
--- a/.github/workflows/deploy-2-start.yml
+++ b/.github/workflows/deploy-2-start.yml
@@ -196,7 +196,7 @@ jobs:
           # Create environment and build model
           spack env create ${{ inputs.env-name }} ${{ vars.SPACK_YAML_LOCATION }}/${{ inputs.expected-root-spec-name }}-${{ github.run_id }}.spack.yaml
           spack env activate ${{ inputs.env-name }}
-          spack --debug install --fresh ${{ vars.SPACK_INSTALL_PARALLEL_JOBS }} || exit $?
+          spack --debug install --fail-fast --fresh ${{ vars.SPACK_INSTALL_PARALLEL_JOBS }} || exit $?
           spack module tcl refresh -y
           EOT
 


### PR DESCRIPTION
## Background

When installing models, the cause of installation failure causes can be obscured by `spack` continuing to install other dependencies. With `--fail-fast`, spack will exit more quickly and the cause of failures will no longer require a lot of scrolling. 

## The PR

* Add `--fail-fast` to the `spack install` flags
