### PR TITLE
Add back variants after Prerelease Root Spec modifications

### DIFF
--- a/.github/actions/get-spack-root-spec/action.yml
+++ b/.github/actions/get-spack-root-spec/action.yml
@@ -28,6 +28,11 @@ outputs:
       The spack version from the root spec in the spack manifest file.
       For example, 'release'.
     value: ${{ steps.spec.outputs.version }}
+  root-spec-variants:
+    description: |
+      The variants from the root spec in the spack manifest file.
+      For example: '~deterministic'.
+    value: ${{ steps.spec.outputs.variants }}
   yq-root-spec:
     description: |
       The yq filter for the root spec of the spack manifest file.
@@ -60,15 +65,16 @@ runs:
       id: spec
       shell: bash
       run: |
-        # Example: access-om2@git.2025.01.0=release ~variant
+        # Example: access-om2@git.2025.01.0=release ~variant +debug some=value
         full=$(yq '${{ steps.yq.outputs.filter }}' ${{ inputs.spack-manifest-path }})
 
         # Example of captured groups from the above:
         # name: anything before `@`. Ex: access-om2
         # ref: anything after `@` or `@git.`; but before `=` (for =VERSION syntax) or ` `/`+`/`~` (for variants). Ex: 2025.01.0
         # version: anything after a `=`, but before ` `/`+`/`~` (for variants). Ex: release
-        
-        groups_regex='(?<name>.+)@(?:git\\.)?(?<ref>[^=+~ ]+)(?:=(?<version>[^~+ ]+))?.*'
+        # variants: anything at the end that contains ` `/`+`/`~` Ex. ~variant +debug some=value
+
+        groups_regex='(?<name>.+)@(?:git\\.)?(?<ref>[^=+~ ]+)(?:=(?<version>[^~+ ]+))?(?<variants>[~+ ].+)?'
 
         groups=$(yq '${{ steps.yq.outputs.filter }} | capture("'"$groups_regex"'")' ${{ inputs.spack-manifest-path }})
 
@@ -76,10 +82,12 @@ runs:
         name=$(yq '.name' <<< "$groups")
         ref=$(yq '.ref' <<< "$groups")
         version=$(yq '.version' <<< "$groups")
+        variants=$(yq '.variants' <<< "$groups")
 
-        echo "Split '$full' into name: '$name', ref: '$ref', version: '$version'"
+        echo "Split '$full' into name: '$name', ref: '$ref', version: '$version', variants: '$variants'"
 
         echo "full=$full" >> $GITHUB_OUTPUT
         echo "name=$name" >> $GITHUB_OUTPUT
         echo "ref=$ref" >> $GITHUB_OUTPUT
         echo "version=$version" >> $GITHUB_OUTPUT
+        echo "variants=$variants" >> $GITHUB_OUTPUT

--- a/.github/workflows/deploy-2-start.yml
+++ b/.github/workflows/deploy-2-start.yml
@@ -106,9 +106,10 @@ jobs:
         # is being used to test something else.
         env:
           SPACK_YAML_MODULEFILE_PROJECTION_YQ: .spack.modules.default.tcl.projections.${{ steps.manifest.outputs.root-spec-name }}
+          OPTIONAL_VARIANTS: ${{ steps.manifest.outputs.root-spec-variants != 'null' && steps.manifest.outputs.root-spec-variants || '' }}
         run: |
           if [[ "${{ inputs.expected-root-spec-name }}" == "${{ steps.manifest.outputs.root-spec-name }}" ]]; then
-            yq -i '${{ steps.manifest.outputs.yq-root-spec }} = "${{ inputs.expected-root-spec-name }} ${{ steps.manifest.outputs.root-spec-variants }}"' spack.yaml
+            yq -i '${{ steps.manifest.outputs.yq-root-spec }} = "${{ inputs.expected-root-spec-name }} ${{ env.OPTIONAL_VARIANTS }}"' spack.yaml
           fi
 
           yq -i '${{ env.SPACK_YAML_MODULEFILE_PROJECTION_YQ }} = "{name}/${{ inputs.version }}"' spack.yaml

--- a/.github/workflows/deploy-2-start.yml
+++ b/.github/workflows/deploy-2-start.yml
@@ -108,7 +108,7 @@ jobs:
           SPACK_YAML_MODULEFILE_PROJECTION_YQ: .spack.modules.default.tcl.projections.${{ steps.manifest.outputs.root-spec-name }}
         run: |
           if [[ "${{ inputs.expected-root-spec-name }}" == "${{ steps.manifest.outputs.root-spec-name }}" ]]; then
-            yq -i '${{ steps.manifest.outputs.yq-root-spec }} = "${{ inputs.expected-root-spec-name }}"' spack.yaml
+            yq -i '${{ steps.manifest.outputs.yq-root-spec }} = "${{ inputs.expected-root-spec-name }} ${{ steps.manifest.outputs.root-spec-variants }}"' spack.yaml
           fi
 
           yq -i '${{ env.SPACK_YAML_MODULEFILE_PROJECTION_YQ }} = "{name}/${{ inputs.version }}"' spack.yaml


### PR DESCRIPTION
Closes #260

## Background

When we are doing our prerelease modifications, we replace the root spec with only the root spec name (removing any `@git.VERSION` as required), but we don't add back any variants that may have been in the original root spec definition. More details are in the linked issue. 

In this PR, we do our replacements a bit more carefully - so if the original spec was `access-om2@git.2025.03.0 +debug`, the replaced spec would be `access-om2 +debug` rather than `access-om2`.

## The PR

- **Export optional variants from get-spack-root-spec action**
- **Instead of just replacing the entire root spec with the root spec name, include the variants as well**

## Testing

* Tested out the hellish regex on `regex101` - https://regex101.com/r/AujFTw/1
* Tested in https://github.com/ACCESS-NRI/ACCESS-TEST/pull/34, specifically:
  * Space-separated variants are preserved :heavy_check_mark: [here](https://github.com/ACCESS-NRI/ACCESS-TEST/pull/34#issuecomment-2768030477)
  * 'Squished' variants are preserved :heavy_check_mark: [here](https://github.com/ACCESS-NRI/ACCESS-TEST/pull/34#issuecomment-2768035289)
  * If there are no variants, they are not added :heavy_check_mark: [here](https://github.com/ACCESS-NRI/ACCESS-TEST/pull/34#issuecomment-2768053083)