### PR TITLE
Root Spec Version Template Check

### DIFF
--- a/.github/workflows/deploy-1-setup.yml
+++ b/.github/workflows/deploy-1-setup.yml
@@ -213,6 +213,13 @@ jobs:
               exit 1
           fi
 
+          # If the first commit in the repository is the template, there won't be anything defined in the speclist
+          # So we should skip checking the version!
+          if ! yq --exit-status '.spack.specs' spack.yaml; then
+            echo "::notice::The spack.yaml at ${{ inputs.prerelease-compare-ref }} is a template, continuing..."
+            exit 1
+          fi
+
       - name: Get base root spec version
         id: base
         if: inputs.deployment-type != 'Release' && steps.checkout-base-spack.outcome != 'failure'


### PR DESCRIPTION
Closes #265

## Background

We checkout the base branch `spack.yaml` in a PR deployment so we can check if the root specs version has been modified. If the base branch is actually the first commit in the repo, and the repo was generated from `access-nri/model-deployment-template`, there won't be a root spec, since it's just a template! We need to check for this before attempting to get the root spec version. 


## The PR

* Add a check before calling the `get-spack-root-spec` action, that checks if the `spack.yaml` they are about to compare is the unfilled template `spack.yaml`!


## Testing

Tested conditional locally against repositories whos main branch was a template (ACCESS-ISSM) and ones that weren't (ACCESS-OM2, ACCESS-OM3)
