### PR TITLE
Remove `--remove` from `spack uninstall` cleanup

### DIFF
--- a/.github/workflows/undeploy-1-start.yml
+++ b/.github/workflows/undeploy-1-start.yml
@@ -78,7 +78,7 @@ jobs:
 
           for env in $envs; do
             spack env activate $env
-            spack uninstall --remove --dependents --yes-to-all --all
+            spack uninstall --dependents --yes-to-all --all
             spack env deactivate
             spack env rm $env --yes-to-all
           done


### PR DESCRIPTION
## Background

Some environments aren't being removed during cleanup, and we now know why:

When comments are both in the speclist, and the speclist is indented, the `spack uninstall --remove` removes specs from the `spack.yaml`. This command does not format the spack.yaml correctly, which leads to failure to deactivate the environment. If we remove the `--remove` flag, this will no longer be an issue (in tandem with formatting the `spack.yaml` correctly). 

Since we are deleting the entire environment/manifests as part of clean up, there is no need to remove the specs from the manifest, so we can remove `--remove`. 

## The PR

* Remove the `--remove` flag from `spack uninstall` calls in cleanup. 


## Testing

### Erroneous comment and indentation combo

Tested the removal of the `--remove` flag solves the indented comment issue, via the following minimal example:

```yaml
spack:
  specs:
    # This is a comment
    - datetime-fortran
  concretizer:
    unify: false
  view: false
```

If one runs:
```bash
spack env create no_remove spack.yaml
spack env activate no_remove
spack install
spack uninstall --all --dependents -y  # Note the no --remove
spack env deactivate  # This will succeed, as the spack.yaml is unchanged and hence valid
```

You will note that the resultant spec in the environment is unchanged:

```yaml
spack:
  specs:
    # This is a comment
    - datetime-fortran
  concretizer:
    unify: false
  view: false
```

If we instead use the `--remove` flag, the error remains:

```bash
spack env create remove spack.taml
spack env activate remove
spack install
spack uninstall --all --dependents --remove -y  # remove flag in here
spack env deactivate  # !!! This will fail, as the manifest is in an invalid state
```

The `spack.yaml` will look instead like this, which is invalid yaml due to `spack`s ruyaml formatting rules:

```yaml
spack:
  specs:
    # This is a comment
[]
  concretizer: unify: false
  view: false
```
