### PR TITLE
Allow access to `spack-cc-*` files

### DIFF
--- a/.github/workflows/create-deployment-spack.yml
+++ b/.github/workflows/create-deployment-spack.yml
@@ -67,6 +67,7 @@ jobs:
           git -C ${{ env.ROOT_VERSION_LOCATION }} clone https://github.com/ACCESS-NRI/spack-config.git --branch ${{ inputs.spack-config-version }}
           ln -s -r -v ${{ env.ROOT_VERSION_LOCATION }}/spack-config/v${{ steps.strip.outputs.version-dir }}/${{ vars.DEPLOYMENT_TARGET }}/* ${{ env.ROOT_VERSION_LOCATION }}/spack/etc/spack/
           mkdir ${{ env.ROOT_VERSION_LOCATION }}/release
+          mkdir ${{ env.ROOT_VERSION_LOCATION }}/logs
 
           # Create restricted folders
           mkdir -p ${{ env.ROOT_VERSION_LOCATION }}/restricted/ukmo/release

--- a/.github/workflows/deploy-2-start.yml
+++ b/.github/workflows/deploy-2-start.yml
@@ -203,6 +203,9 @@ jobs:
           spack env activate ${{ inputs.env-name }}
           spack --debug install --fail-fast --fresh ${{ vars.SPACK_INSTALL_PARALLEL_JOBS }} || exit $?
           spack module tcl refresh -y
+
+          # Move spack debug logs to $SPACK_ROOT/logs
+          mv ~/spack-cc-* ${{ steps.path.outputs.root }}/logs
           EOT
 
       - name: Export deployment target locations


### PR DESCRIPTION
Closes #270

## Background

Currently, debug spack files (`spack-cc-*`) are stored in the `~` directory of the service user, inaccessible to others. 

Once a model is installed, we should move these log files to somewhere accessible to all - like `$SPACK_ROOT/logs/`.

# The PR

- **deploy-2-start.yml: Move spack debug files into $SPACK_ROOT/logs**
- **create-deployment-spack: Create $SPACK_ROOT/logs folder**
