### PR TITLE
Update `spack install` var to `vars.SPACK_INSTALL_ADDITIONAL_ARGS`

### DIFF
--- a/.github/workflows/deploy-2-start.yml
+++ b/.github/workflows/deploy-2-start.yml
@@ -201,7 +201,7 @@ jobs:
           # Create environment and build model
           spack env create ${{ inputs.env-name }} ${{ vars.SPACK_YAML_LOCATION }}/${{ inputs.expected-root-spec-name }}-${{ github.run_id }}.spack.yaml
           spack env activate ${{ inputs.env-name }}
-          spack --debug install --fail-fast --fresh ${{ vars.SPACK_INSTALL_PARALLEL_JOBS }} || exit $?
+          spack --debug install --fail-fast --fresh ${{ vars.SPACK_INSTALL_ADDITIONAL_ARGS }} || exit $?
           spack module tcl refresh -y
           EOT
 


### PR DESCRIPTION
Closes #272

## Background

Advanced users may want to set `spack install` flags on a repo-by-repo basis. We unknowingly offer this via the `vars.SPACK_INSTALL_PARALLEL_JOBS` variable, but it isn't a great name. 

## The PR

In this PR:

* Make the variable that holds additional flags in `spack install` a more generic name - rather than `vars.SPACK_INSTALL_PARALLEL_JOBS`, it should be `vars.SPACK_INSTALL_ADDITIONAL_ARGS`. 

