### PR TITLE
Conditionally mv spack-cc-* files

### DIFF
--- a/.github/workflows/deploy-2-start.yml
+++ b/.github/workflows/deploy-2-start.yml
@@ -205,7 +205,7 @@ jobs:
           spack module tcl refresh -y
 
           # Move spack debug logs to $SPACK_ROOT/logs
-          mv ~/spack-cc-* ${{ steps.path.outputs.root }}/logs
+          find . -maxdepth 1 -regex './spack-cc-.+' -exec mv {} ${{ steps.path.outputs.root }}/logs \;
           EOT
 
       - name: Export deployment target locations


### PR DESCRIPTION
## Background

`spack-cc-*` files are not always created, so the current implementation of moving the log files fails. 

## The PR

* Attempt to `find` the `spack-cc-*` files first before `mv`ing them. 

## Testing

* Tested the updated command on the service user
