### PR TITLE
Properly Support Multiple Manifests in one MDR

### DIFF
--- a/.github/actions/get-spack-root-spec/action.yml
+++ b/.github/actions/get-spack-root-spec/action.yml
@@ -3,7 +3,6 @@ description: Action that returns information about a Spack manifest file
 author: Tommy Gatti
 inputs:
   spack-manifest-path:
-    type: string
     required: false
     default: ./spack.yaml
     description: The path to the spack manifest file

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -93,15 +93,13 @@ jobs:
           target: ${{ matrix.target }}
           error-level: error
 
-  push-tag:
-    name: Tag Deployment
+  get-root-spec-ref:
+    name: Get root spec ref
     runs-on: ubuntu-latest
     needs:
       - verify-settings
-    permissions:
-      contents: write
     outputs:
-      name: ${{ steps.tag.outputs.root-spec-ref }}
+      root-spec-ref: ${{ steps.tag.outputs.root-spec-ref }}
     steps:
       - uses: actions/checkout@v4
 
@@ -111,8 +109,18 @@ jobs:
         with:
           spack-manifest-path: ${{ inputs.spack-manifest-path }}
 
+  push-tag:
+    name: Tag Deployment
+    if: inputs.tag-deployment
+    runs-on: ubuntu-latest
+    needs:
+      - get-root-spec-ref
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
       - name: Import Commit-Signing Key
-        if: inputs.tag-deployment
         uses: crazy-max/ghaction-import-gpg@01dd5d3ca463c7f10f7f4f7b4f177225ac661ee4  # v6.1.0
         with:
           gpg_private_key: ${{ secrets.GH_ACTIONS_BOT_GPG_PRIVATE_KEY }}
@@ -125,9 +133,8 @@ jobs:
           git_tag_gpgsign: true
 
       - name: Push Tag
-        if: inputs.tag-deployment
         env:
-          TAG: ${{ steps.tag.outputs.root-spec-ref }}
+          TAG: ${{ needs.get-root-spec-ref.outputs.root-spec-ref }}
         run: |
           if [[ "${{ env.TAG }}" == "latest" ]]; then
             echo "::error::The version 'latest' is reserved for a spack package that moves often and cannot be used as a release tag. Reset the 'main' or 'backport' branch, reopen the merged PR, and update the version."
@@ -141,7 +148,7 @@ jobs:
     name: Deploy Release
     needs:
       - defaults
-      - push-tag
+      - get-root-spec-ref
     strategy:
       matrix:
         target: ${{ fromJson(needs.defaults.outputs.targets) }}
@@ -150,7 +157,7 @@ jobs:
       deployment-target: ${{ matrix.target }}
       deployment-ref: ${{ github.ref_name }}
       deployment-type: Release
-      deployment-version: ${{ needs.push-tag.outputs.name }}
+      deployment-version: ${{ needs.get-root-spec-ref.outputs.root-spec-ref }}
       spack-manifest-path: ${{ inputs.spack-manifest-path }}
       expected-root-spec-name: ${{ needs.defaults.outputs.root-sbd }}
     secrets: inherit
@@ -165,6 +172,7 @@ jobs:
     if: inputs.tag-deployment
     needs:
       - defaults
+      - get-root-spec-ref
       - push-tag
       - deploy-release
     runs-on: ubuntu-latest
@@ -205,7 +213,7 @@ jobs:
         id: release-body
         env:
           J2_MODEL: ${{ inputs.model }}
-          J2_VERSION: ${{ needs.push-tag.outputs.name }}
+          J2_VERSION: ${{ needs.get-root-spec-ref.outputs.root-spec-ref }}
           J2_ROOT_SBD: ${{ needs.defaults.outputs.root-sbd }}
         run: |
           python -m scripts.jinja_template.render_deployment_info \
@@ -216,8 +224,8 @@ jobs:
       - name: Create Release
         uses: softprops/action-gh-release@69320dbe05506a9a39fc8ae11030b214ec2d1f87  # v2.0.5
         with:
-          tag_name: ${{ needs.push-tag.outputs.name }}
-          name: ${{ inputs.model}} ${{ needs.push-tag.outputs.name }}
+          tag_name: ${{ needs.get-root-spec-ref.outputs.root-spec-ref }}
+          name: ${{ inputs.model}} ${{ needs.get-root-spec-ref.outputs.root-spec-ref }}
           body_path: ${{ env.TEMPLATED_RELEASE_BODY_PATH }}
           generate_release_notes: true
           fail_on_unmatched_files: true

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -17,6 +17,27 @@ on:
         description: |
           The name of the root Spack Bundle Definition, if it is different from the model name.
           This is often a package named similarly in ACCESS-NRI/spack-packages.
+      spack-manifest-path:
+        type: string
+        required: false
+        default: ./spack.yaml
+        description: |
+          The Spack manifest path relative to the caller repository that will be used for the deployment.
+          This is usually `./spack.yaml`, but can be overridden if needed.
+      tag-deployment:
+        type: boolean
+        required: false
+        default: true
+        description: |
+          Whether to tag the deployment with the root spec ref.
+          NOTE: Setting this to false is not recommended for model deployments.
+      upload-to-build-db:
+        type: boolean
+        required: false
+        default: true
+        description: |
+          Whether to upload the deployment information to the build database.
+          NOTE: Setting this to false is not recommended for model deployments.
   # Callers usually have the trigger:
   # push:
   #   branches:
@@ -74,6 +95,7 @@ jobs:
 
   push-tag:
     name: Tag Deployment
+    if: inputs.tag-deployment
     runs-on: ubuntu-latest
     needs:
       - verify-settings
@@ -87,6 +109,8 @@ jobs:
       - name: Get root spec ref
         id: tag
         uses: access-nri/build-cd/.github/actions/get-spack-root-spec@v5
+        with:
+          spack-manifest-path: ${{ inputs.spack-manifest-path }}
 
       - name: Import Commit-Signing Key
         uses: crazy-max/ghaction-import-gpg@01dd5d3ca463c7f10f7f4f7b4f177225ac661ee4  # v6.1.0
@@ -126,7 +150,7 @@ jobs:
       deployment-ref: ${{ github.ref_name }}
       deployment-type: Release
       deployment-version: ${{ needs.push-tag.outputs.name }}
-      spack-manifest-path: ./spack.yaml
+      spack-manifest-path: ${{ inputs.spack-manifest-path }}
       expected-root-spec-name: ${{ needs.defaults.outputs.root-sbd }}
     secrets: inherit
     permissions:
@@ -137,6 +161,7 @@ jobs:
 
   release:
     name: Create Release
+    if: inputs.tag-deployment
     needs:
       - defaults
       - push-tag
@@ -202,6 +227,7 @@ jobs:
 
   build-db:
     name: Build DB Metadata Upload
+    if: inputs.upload-to-build-db
     needs:
       - defaults
       - deploy-release

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -29,14 +29,14 @@ on:
         required: false
         default: true
         description: |
-          Whether to tag the deployment with the root spec ref.
+          Whether to tag the deployment with the root spec ref and create a release.
           NOTE: Setting this to false is not recommended for model deployments.
       upload-to-build-db:
         type: boolean
         required: false
         default: true
         description: |
-          Whether to upload the deployment information to the build database.
+          Whether to upload the deployment information to the build database (requires tag-deployment to also be true).
           NOTE: Setting this to false is not recommended for model deployments.
   # Callers usually have the trigger:
   # push:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -95,7 +95,6 @@ jobs:
 
   push-tag:
     name: Tag Deployment
-    if: inputs.tag-deployment
     runs-on: ubuntu-latest
     needs:
       - verify-settings
@@ -113,6 +112,7 @@ jobs:
           spack-manifest-path: ${{ inputs.spack-manifest-path }}
 
       - name: Import Commit-Signing Key
+        if: inputs.tag-deployment
         uses: crazy-max/ghaction-import-gpg@01dd5d3ca463c7f10f7f4f7b4f177225ac661ee4  # v6.1.0
         with:
           gpg_private_key: ${{ secrets.GH_ACTIONS_BOT_GPG_PRIVATE_KEY }}
@@ -125,6 +125,7 @@ jobs:
           git_tag_gpgsign: true
 
       - name: Push Tag
+        if: inputs.tag-deployment
         env:
           TAG: ${{ steps.tag.outputs.root-spec-ref }}
         run: |
@@ -227,7 +228,7 @@ jobs:
 
   build-db:
     name: Build DB Metadata Upload
-    if: inputs.upload-to-build-db
+    if: inputs.tag-deployment && inputs.upload-to-build-db
     needs:
       - defaults
       - deploy-release

--- a/.github/workflows/ci-comment.yml
+++ b/.github/workflows/ci-comment.yml
@@ -1,8 +1,12 @@
 name: Comment Command
 run-name: ${{ inputs.model }} Comment Command
+
 # NOTE: This workflow requires:
 # permissions.contents:write
 # permissions.pull-requests:write
+
+# FIXME: We don't support any !bump from a spack manifest that is not in the default ./spack.yaml location.
+
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,13 @@ on:
         type: string
         required: true
         description: The pull request number that will be deployed as a prerelease
+      spack-manifest-path:
+        type: string
+        required: false
+        default: ./spack.yaml
+        description: |
+          The Spack manifest path relative to the caller repository that will be used for the deployment.
+          This is usually `./spack.yaml`, but can be overridden if needed.
   # Callers usually have the trigger:
   # pull_request:
   #   branches:
@@ -199,7 +206,7 @@ jobs:
       # Note that for multi-target prereleases, they share the same deployment number.
       deployment-version: ${{ needs.defaults.outputs.prerelease-version }}
       prerelease-compare-ref: ${{ needs.defaults.outputs.base-ref }}
-      spack-manifest-path: ./spack.yaml
+      spack-manifest-path: ${{ inputs.spack-manifest-path }}
       expected-root-spec-name: ${{ needs.defaults.outputs.root-sbd }}
     secrets: inherit
 
@@ -293,6 +300,7 @@ jobs:
           J2_CONFIG_ERRORS: ${{ steps.config-rollup.outputs.errors }}
           J2_HEAD_SHA: ${{ needs.defaults.outputs.head-sha }}
           J2_RUN_URL: ${{ env.RUN_URL }}
+          J2_SPACK_MANIFEST_PATH: ${{ inputs.spack-manifest-path }}
         run: |
           python -m scripts.jinja_template.render_deployment_info \
             --template scripts/jinja_template/templates/deployment-comment-body.md.j2 \

--- a/.github/workflows/deploy-1-setup.yml
+++ b/.github/workflows/deploy-1-setup.yml
@@ -213,7 +213,7 @@ jobs:
           fetch-depth: 0
           ref: ${{ inputs.deployment-ref }}
 
-      - name: Validate ACCESS-NRI spack.yaml Restrictions
+      - name: Validate ACCESS-NRI spack manifest restrictions
         if: env.IS_NOT_DRAFT == 'true' || inputs.deployment-type == 'Release'
         uses: access-nri/schema/.github/actions/validate-with-schema@main
         with:

--- a/.github/workflows/deploy-1-setup.yml
+++ b/.github/workflows/deploy-1-setup.yml
@@ -295,7 +295,7 @@ jobs:
 
 
       - name: Check Projections - Specs
-        # This step checks that the root spec has an appropriate projection in the spack.yaml file.
+        # This step checks that the root spec has an appropriate projection in the manifest file.
         id: projection-check-spec
         continue-on-error: true
         run: |

--- a/.github/workflows/deploy-1-setup.yml
+++ b/.github/workflows/deploy-1-setup.yml
@@ -36,10 +36,8 @@ on:
       spack-manifest-path:
         type: string
         required: true
-        default: spack.yaml
         description: |
-          Relative path in the Model Deployment Repository that contains the spack manifest file.
-          Usually a spack.yaml file.
+          The Spack manifest path relative to the caller repository that will be used for the deployment.
       expected-root-spec-name:
         type: string
         required: true
@@ -64,9 +62,13 @@ on:
     #     description: |
     #       Name of the model being deployed.
     #   model-deployment-repository:
-    #     value: ${{ github.repositoryUrl }}
+    #     value: ${{ github.event.repository.html_url }}
     #     description: |
     #       URL of the repository that contains the model being deployed.
+    #   model-deployment-repository-spack-manifest-path:
+    #     value: ${{ inputs.spack-manifest-path }}
+    #     description: |
+    #       Path to the spack manifest file in the model deployment repository.
     #   spack-version:
     #     value: ${{ jobs.check-config.outputs.spack-version }}
     #     description: |
@@ -222,6 +224,8 @@ jobs:
       - name: Get current (${{ inputs.deployment-ref }}) root spec version
         id: current
         uses: access-nri/build-cd/.github/actions/get-spack-root-spec@v5
+        with:
+          spack-manifest-path: ${{ inputs.spack-manifest-path }}
 
       - name: Check root spec usage
         if: env.IS_NOT_DRAFT == 'true' || inputs.deployment-type == 'Release'
@@ -243,15 +247,15 @@ jobs:
         run: |
           git checkout ${{ inputs.prerelease-compare-ref }}
 
-          if [ ! -f spack.yaml ]; then
-              echo "::notice::There is no previous version of the spack.yaml to check at ${{ inputs.prerelease-compare-ref }}, continuing..."
+          if [ ! -f ${{ inputs.spack-manifest-path }} ]; then
+              echo "::notice::There is no previous version of ${{ inputs.spack-manifest-path }} to check at ${{ inputs.prerelease-compare-ref }}, continuing..."
               exit 1
           fi
 
           # If the first commit in the repository is the template, there won't be anything defined in the speclist
           # So we should skip checking the version!
-          if ! yq --exit-status '.spack.specs' spack.yaml; then
-            echo "::notice::The spack.yaml at ${{ inputs.prerelease-compare-ref }} is a template, continuing..."
+          if ! yq --exit-status '.spack.specs' ${{ inputs.spack-manifest-path }}; then
+            echo "::notice::${{ inputs.spack-manifest-path }} at ${{ inputs.prerelease-compare-ref }} is a template, continuing..."
             exit 1
           fi
 
@@ -259,6 +263,8 @@ jobs:
         id: base
         if: inputs.deployment-type != 'Release' && steps.checkout-base-spack.outcome != 'failure'
         uses: access-nri/build-cd/.github/actions/get-spack-root-spec@v5
+        with:
+          spack-manifest-path: ${{ inputs.spack-manifest-path }}
 
       - name: Check Model Version Modified
         # We don't want to fire off model deployment version checks if the PR is never going to be merged.
@@ -268,19 +274,25 @@ jobs:
         id: version-modified
         run: |
           if [[ "${{ steps.base.outputs.root-spec-ref }}" == "${{ steps.current.outputs.root-spec-ref }}" ]]; then
-              echo "::warning::The version string hasn't been modified in this PR, but needs to be before merging."
+              echo "::warning::The version string in ${{ inputs.spack-manifest-path }} hasn't been modified in this PR, but needs to be before merging."
               exit 1
           fi
 
       - name: Same Model Version Failure Notifier
         if: failure() && steps.version-modified.outcome == 'failure'
+        # TODO: We don't yet support bumping files outside of ./spack.yaml, so this is a temporary solution.
+        env:
+          BUMP_COMMENT_BODY: |-
+            Alternatively, comment the following to have it updated and committed automatically:
+              * `!bump major` for feature releases
+              * `!bump minor` for bugfixes
         uses: access-nri/actions/.github/actions/pr-comment@main
         with:
           comment: |
               The model version in the `${{ inputs.spack-manifest-path }}` has not been updated.
-              Either update it manually, or comment the following to have it updated and committed automatically:
-              * `!bump major` for feature releases
-              * `!bump minor` for bugfixes
+              You can update it manually.
+              ${{ inputs.spack-manifest-path != './spack.yaml' && env.BUMP_COMMENT_BODY || '' }}
+
 
       - name: Check Projections - Specs
         # This step checks that the root spec has an appropriate projection in the spack.yaml file.
@@ -293,9 +305,9 @@ jobs:
           expected_projection_prefix='{name}/${{ steps.current.outputs.root-spec-ref }}'
 
           if [[ "$current_projection" == "$expected_projection_prefix"* ]]; then
-              echo "Current root spec projection ($current_projection) and expected projection prefix ($expected_projection_prefix) match."
+              echo "${{ inputs.spack-manifest-path }}: Current root spec projection ($current_projection) and expected projection prefix ($expected_projection_prefix) match."
           else
-              echo "::error::Current root spec projection ($current_projection) and expected projection prefix ($expected_projection_prefix) don't match."
+              echo "::error::${{ inputs.spack-manifest-path }}: Current root spec projection ($current_projection) and expected projection prefix ($expected_projection_prefix) don't match."
               exit 1
           fi
 
@@ -309,22 +321,22 @@ jobs:
         run: |
           FAILED="false"
           # Get all the defined projections (minus 'all' and the root spec) and make them suitable for a bash for loop
-          DEPS=$(yq '.spack.modules.default.tcl.projections | del(.all) | del(.${{ steps.current.outputs.root-spec-name }}) | keys | join(" ")' spack.yaml)
+          DEPS=$(yq '.spack.modules.default.tcl.projections | del(.all) | del(.${{ steps.current.outputs.root-spec-name }}) | keys | join(" ")' ${{ inputs.spack-manifest-path }})
 
           # for each of the module names
           for DEP in $DEPS; do
             # Capture the section after '@git.' or '@' (if it's not a git-attributed version) and before a possible '=' for a given dependency.
             # Ex. '@git.2024.02.11' -> '2024.02.11', '@access-esm1.5' -> 'access-esm1.5', '@git.2024.05.21=access-esm1.5' -> '2024.05.21'
-            package_ver=$(yq ".spack.packages.\"$DEP\".require[0] | match(\"^@(?:git.)?([^=]*)\").captures[0].string" spack.yaml)
+            package_ver=$(yq ".spack.packages.\"$DEP\".require[0] | match(\"^@(?:git.)?([^=]*)\").captures[0].string" ${{ inputs.spack-manifest-path }})
             expected_projection_prefix="{name}/$package_ver"
 
             # Projections must start with '{name}/VERSION'. For example, '{name}/2024.11.11', or '{name}/2024.11.11-{hash:7}'
-            current_projection=$(yq ".spack.modules.default.tcl.projections.\"$DEP\"" spack.yaml)
+            current_projection=$(yq ".spack.modules.default.tcl.projections.\"$DEP\"" ${{ inputs.spack-manifest-path }})
 
             if [[ "$current_projection" == "$expected_projection_prefix"* ]]; then
-              echo "$DEP: Current projection ($current_projection) and expected projection prefix ($expected_projection_prefix) match."
+              echo "$DEP in ${{ inputs.spack-manifest-path }}: Current projection ($current_projection) and expected projection prefix ($expected_projection_prefix) match."
             else
-              echo "::error::$DEP: Current projection ($current_projection) and expected projection prefix ($expected_projection_prefix) don't match."
+              echo "::error::$DEP in ${{ inputs.spack-manifest-path }}: Current projection ($current_projection) and expected projection prefix ($expected_projection_prefix) don't match."
               FAILED='true'
             fi
           done
@@ -336,7 +348,7 @@ jobs:
         # If either of the Check Projection steps failed earlier, exit here
         if: steps.projection-check-spec.outcome == 'failure' || steps.projection-check-packages.outcome == 'failure'
         run: |
-          echo "::error::Some projections in the spack manifest don't match."
+          echo "::error::Some projections in ${{ inputs.spack-manifest-path }} don't match."
           exit 1
 
       - name: Set Spack Env Name String
@@ -357,6 +369,7 @@ jobs:
       deployment-target: ${{ inputs.deployment-target }}
       deployment-type: ${{ inputs.deployment-type }}
       expected-root-spec-name: ${{ inputs.expected-root-spec-name }}
+      spack-manifest-path: ${{ inputs.spack-manifest-path }}
     secrets: inherit
 
   outputs-upload:
@@ -382,6 +395,7 @@ jobs:
           jq --null-input '{
             model_name: "${{ github.event.repository.name }}",
             model_deployment_repository: "${{ github.event.repository.html_url }}",
+            model_deployment_repository_spack_manifest_path: "${{ inputs.spack-manifest-path }}",
             spack_version: "${{ needs.check-config.outputs.spack-version }}",
             spack_git_hash: "${{ needs.check-config.outputs.spack-git-hash }}",
             spack_config_version: "${{ needs.check-config.outputs.spack-config-version }}",

--- a/.github/workflows/deploy-2-start.yml
+++ b/.github/workflows/deploy-2-start.yml
@@ -33,6 +33,10 @@ on:
         description: |
           The expected root spec name that is defined at the repository level.
           May be different from the actual root spec name in the spack manifest.
+      spack-manifest-path:
+        type: string
+        required: true
+        description: The path to the spack manifest file, relative to the model deployment repository.
     outputs:
       root-spec-pkg-hash:
         value: ${{ jobs.deploy-to-environment.outputs.root-spec-pkg-hash }}
@@ -86,8 +90,9 @@ jobs:
 
       - name: Get manifest info
         id: manifest
-        # FIXME: We should pass through inputs.spack-manifest-path here (and below raw spack.yaml) - see ACCESS-NRI/build-cd#225
         uses: access-nri/build-cd/.github/actions/get-spack-root-spec@v5
+        with:
+          spack-manifest-path: ${{ inputs.spack-manifest-path }}
 
       - name: Setup SSH
         id: ssh
@@ -113,14 +118,14 @@ jobs:
           OPTIONAL_VARIANTS: ${{ steps.manifest.outputs.root-spec-variants != 'null' && steps.manifest.outputs.root-spec-variants || '' }}
         run: |
           if [[ "${{ inputs.expected-root-spec-name }}" == "${{ steps.manifest.outputs.root-spec-name }}" ]]; then
-            yq -i '${{ steps.manifest.outputs.yq-root-spec }} = "${{ inputs.expected-root-spec-name }} ${{ env.OPTIONAL_VARIANTS }}"' spack.yaml
+            yq -i '${{ steps.manifest.outputs.yq-root-spec }} = "${{ inputs.expected-root-spec-name }} ${{ env.OPTIONAL_VARIANTS }}"' ${{ inputs.spack-manifest-path }}
           fi
 
-          yq -i '${{ env.SPACK_YAML_MODULEFILE_PROJECTION_YQ }} = "{name}/${{ inputs.version }}"' spack.yaml
+          yq -i '${{ env.SPACK_YAML_MODULEFILE_PROJECTION_YQ }} = "{name}/${{ inputs.version }}"' ${{ inputs.spack-manifest-path }}
 
           # Add the specific prerelease spack-packages repo to the environment
           # We can't use yq as we are using a non-standard spack-specific '::' construct to ignore higher config scopes
-          cat << 'EOF' >> spack.yaml
+          cat << 'EOF' >> ${{ inputs.spack-manifest-path }}
             repos::
                 - ${{ steps.path.outputs.spack-packages }}
                 - $spack/var/spack/repos/builtin
@@ -128,10 +133,10 @@ jobs:
 
           echo '::notice::Prerelease accessible as module ${{ steps.manifest.outputs.root-spec-name }}/${{ inputs.version }}'
 
-      - name: Copy spack.yaml
+      - name: Copy ${{ inputs.spack-manifest-path }}
         run: |
           rsync -e 'ssh -i ${{ steps.ssh.outputs.private-key-path }}' \
-            spack.yaml \
+            ${{ inputs.spack-manifest-path }} \
             ${{ secrets.USER }}@${{ secrets.HOST_DATA }}:${{ vars.SPACK_YAML_LOCATION }}/${{ inputs.expected-root-spec-name }}-${{ github.run_id }}.spack.yaml
 
       - name: Fetch git sources for packages to build

--- a/.github/workflows/deploy-2-start.yml
+++ b/.github/workflows/deploy-2-start.yml
@@ -5,7 +5,7 @@ on:
       ref:
         type: string
         required: true
-        description: The git commit-ish ref where the `spack.yaml` is located
+        description: The git commit-ish ref where the spack manifest is located
       version:
         type: string
         required: true
@@ -103,14 +103,14 @@ jobs:
             ${{ secrets.HOST }}
             ${{ secrets.HOST_DATA }}
 
-      - name: Prerelease spack.yaml Modifications
+      - name: Prerelease spack manifest modifications
         # Modifies the name of the prerelease modulefile to the
         # `pr<number>-<commit>` style. For example, `access-om3/pr12-2`.
         # Also removes the `@git.VERSION` specifier for Prereleases so
         # we don't have to shift tags around.
         # Also adds a repos section that points to the PRs specific spack-packages repo.
         if: inputs.deployment-type == 'Prerelease'
-        # If the inputs.expected-root-spec-name for the repository is the same as the one in the spack.yaml,
+        # If the inputs.expected-root-spec-name for the repository is the same as the one in the spack manifest,
         # we can safely remove the @git.VERSION specifier. Otherwise it could be because the Prerelease
         # is being used to test something else.
         env:
@@ -187,7 +187,7 @@ jobs:
           EOT
 
       - name: Deploy to ${{ inputs.deployment-target }} ${{ inputs.deployment-type }}
-        # ssh into deployment environment, create and activate the env, install the spack.yaml.
+        # ssh into deployment environment, create and activate the env, install the spack manifest.
         run: |
           ssh ${{ secrets.USER}}@${{ secrets.HOST }} -i ${{ steps.ssh.outputs.private-key-path }} /bin/bash <<'EOT'
           # Check that a suitable deployment location exists

--- a/scripts/jinja_template/templates/deployment-comment-body.md.j2
+++ b/scripts/jinja_template/templates/deployment-comment-body.md.j2
@@ -10,7 +10,7 @@
 <details>
 <summary>Usage Instructions</summary>
 
-This `{{ model }}` model will be deployed to `{{ deployment.name }}` as:
+`{{ model }}`, defined in `{{ spack_manifest_path }}`, will be deployed to `{{ deployment.name }}` as:
 * `{{ deployment.release_version }}` as a Release (when merged).
 * `{{ prerelease_version }}` as a Prerelease (during this PR).
 


### PR DESCRIPTION
## Background

We *almost* support the use of spack manifest files in places other than `./spack.yaml`. There was just a little bit more modifying to get it to work. 

We also make tagging and uploading to the build provenance DB optional, for the case where non-model repositories using the `build-cd` logic just to deploy. It is not recommended for non-MDRs. 

Use cases include:

* Non-model repositories (eg. `model-tools`) being able to deploy multiple tools via multiple manifests in a single repository (requires a matrix at the MDR level calling these workflows). 
* Model repositories that potentially contain a plethora of variants that need to be deployed, rather than having one MDR per variant. 

## The PR

In this PR:

- **Add new non-required spack-manifest-path option to ci.yml**
- **Percolate inputs.spack-manifest-path properly through the CI pipeline**
- **Add non-required inputs spack-manifest-path, tag-deployment and upload-to-build-db**
- **Add FIXME regarding !bump for non-default manifest paths**

## Testing

Testing for this PR was done on the `225-multi-spack-yaml_TEST` branch (which replaced all workflow refs with itself). 

The relevant `ACCESS-TEST` PR is https://github.com/ACCESS-NRI/ACCESS-TEST/pull/45

### Prerelease Tests

#### Drafted, Default Location

Success, see https://github.com/ACCESS-NRI/ACCESS-TEST/pull/45#issuecomment-2920966120

#### Drafted, Subdirectory Location

Success, see https://github.com/ACCESS-NRI/ACCESS-TEST/pull/45#issuecomment-2920998734

#### Non-Draft, Subdirectory Location

Success, see https://github.com/ACCESS-NRI/ACCESS-TEST/pull/45#issuecomment-2921116173

### Release Tests

#### Subdirectory Location

Success, see https://github.com/ACCESS-NRI/ACCESS-TEST/actions/runs/15339349146