### PR TITLE
Simplify and Fix Cleanup Workflow

### DIFF
--- a/.github/workflows/undeploy-1-start.yml
+++ b/.github/workflows/undeploy-1-start.yml
@@ -77,12 +77,9 @@ jobs:
           envs=$(find ${{ steps.path.outputs.spack }}/../environments -type d -name '${{ inputs.version-pattern }}' -printf '%f ')
 
           for env in $envs; do
-            spack env activate $env
-            spack uninstall --dependents --yes-to-all --all
-            spack env deactivate
             spack env rm $env --yes-to-all
           done
-          spack gc --yes-to-all
+          spack gc --except-any-environment --yes-to-all
           EOT
 
       - name: Undeploy spack-packages


### PR DESCRIPTION
## Background

Seems that our existing cleanup workflow is insufficent. When we ran `spack gc --except-any-environment` in our Prerelease area, there were 400+ packages installed that didn't need to be. 

## In this PR

* Instead of uninstalling packages within an environment (which may have package dependencies on other, to-be-uninstalled environments), just remove the environment and then uninstall packages not part of any environment with the above command. 
