### PR TITLE
Tar Prerelease Spack Environment Metadata Post-Install

### DIFF
--- a/.github/actions/get-deploy-paths/README.md
+++ b/.github/actions/get-deploy-paths/README.md
@@ -20,6 +20,7 @@ This action constructs paths relevant to a deployment of `spack`.
 | `spack-config` | `string` | Path to the ACCESS-NRI/spack-config repository associated with the install of spack. | `"/some/dir/apps/spack/0.21/spack-config"` |
 | `spack-packages-root` | `string` | Path to the folder containing all ACCESS-NRI/spack-packages repositories used in the install of spack | `"/some/dir/apps/spack/0.21/spack-packages"` |
 | `spack-packages` | `string` | Path to the ACCESS-NRI/spack-packages repository associated with the environment created in the install of spack. | For Release: `"/some/dir/apps/spack/0.21/spack-packages"`, for Prerelease: `"/some/dir/apps/spack/0.21/spack-packages/access-om2-pr12-12/spack-packages"` |
+| `spack-environment` | `string` | Path to the spack environment folder for the given `inputs.spack-environment` | `"/some/dir/apps/spack/0.21/environments/access-om2-pr12-12"` |
 
 ## Example
 

--- a/.github/actions/get-deploy-paths/action.yml
+++ b/.github/actions/get-deploy-paths/action.yml
@@ -3,22 +3,18 @@ description: Action that returns important paths for a spack install on a deploy
 author: Tommy Gatti
 inputs:
   spack-installs-root-path:
-    type: string
     required: true
     # For example, `some/apps/spack` is the root, `some/apps/spack/0.21/` is a specific spack deployment, `some/apps/spack/0.21/spack` is a specific spack install.
     description: Path to a directory within which all versions of spack are installed
   spack-version:
-    type: string
     required: true
     description: |
       Version of spack deployed.
       Used to construct a specific spack installation path, in conjunction with `spack-installs-root-path`.
   deployment-environment:
-    type: string
     required: true
     description: Name of the GitHub deployment target environment
   spack-environment:
-    type: string
     required: true
     description: |
       Spack environment name that is used for this deployment.
@@ -44,6 +40,9 @@ outputs:
   spack-packages:
     description: Path to the ACCESS-NRI/spack-packages repository associated with the environment created in the install of spack.
     value: ${{ steps.path.outputs.spack-packages }}
+  spack-environment:
+    description: Path to the spack environment folder for the given inputs.spack-environment.
+    value: ${{ steps.path.outputs.spack-environment }}
 runs:
   using: composite
   steps:
@@ -82,3 +81,5 @@ runs:
         elif [[ '${{ steps.validate.outputs.type }}' == Prerelease ]]; then
           echo "spack-packages=$root/spack-packages/${{ inputs.spack-environment }}/spack-packages" >> $GITHUB_OUTPUT
         fi
+
+        echo "spack-environment=$root/environments/${{ inputs.spack-environment }}" >> $GITHUB_OUTPUT

--- a/.github/workflows/deploy-2-start.yml
+++ b/.github/workflows/deploy-2-start.yml
@@ -226,8 +226,6 @@ jobs:
       - name: Get metadata from ${{ inputs.deployment-target }} ${{ inputs.deployment-type}}
         id: metadata
         # Get the metadata from the spack environment regarding build database packages
-        env:
-          SPACK_ENV_PATH: ${{ steps.path.outputs.spack }}/../environments/${{ inputs.env-name }}
         run: |
           ssh ${{ secrets.USER }}@${{ secrets.HOST }} -i ${{ steps.ssh.outputs.private-key-path }} /bin/bash <<'EOT'
           # Export vars.DEPLOYMENT_TARGET
@@ -237,13 +235,13 @@ jobs:
           . ${{ steps.path.outputs.spack-config }}/spack-enable.bash
           spack env activate ${{ inputs.env-name }}
 
-          spack find --paths > ${{ env.SPACK_ENV_PATH }}/spack.location
+          spack find --paths > ${{ steps.path.outputs.spack-environment }}/spack.location
 
           # output the root-spec-pkg-hash into a file that is accessible outside the ssh session
-          echo "root-spec-pkg-hash=$(spack find --format '{hash}' ${{ inputs.expected-root-spec-name }})" > ${{ env.SPACK_ENV_PATH }}/root-spec-pkg-hash.${{ github.run_id }}
+          echo "root-spec-pkg-hash=$(spack find --format '{hash}' ${{ inputs.expected-root-spec-name }})" > ${{ steps.path.outputs.spack-environment }}/root-spec-pkg-hash.${{ github.run_id }}
 
           # Get the information associated with the packages for the build database
-          jq -n '[]' > ${{ env.SPACK_ENV_PATH }}/build-db-pkgs.json
+          jq -n '[]' > ${{ steps.path.outputs.spack-environment }}/build-db-pkgs.json
 
           for pkg in ${{ vars.BUILD_DB_PACKAGES }}; do
             hash=$(spack find --format '{hash}' $pkg)
@@ -259,9 +257,9 @@ jobs:
               --arg l "$location" \
               --arg r "$pkg_repo_url" \
               '. += [{"name": $p, "version": $v, "hash": $h, "location": $l, "url": $r}]' \
-              ${{ env.SPACK_ENV_PATH }}/build-db-pkgs.json > ${{ env.SPACK_ENV_PATH }}/build-db-pkgs.json.tmp
+              ${{ steps.path.outputs.spack-environment }}/build-db-pkgs.json > ${{ steps.path.outputs.spack-environment }}/build-db-pkgs.json.tmp
 
-            mv -f ${{ env.SPACK_ENV_PATH }}/build-db-pkgs.json.tmp ${{ env.SPACK_ENV_PATH }}/build-db-pkgs.json
+            mv -f ${{ steps.path.outputs.spack-environment }}/build-db-pkgs.json.tmp ${{ steps.path.outputs.spack-environment }}/build-db-pkgs.json
           done
 
           spack env deactivate
@@ -270,7 +268,7 @@ jobs:
           # Output root spec package hash from ssh session
           rsync -e 'ssh -i ${{ steps.ssh.outputs.private-key-path }}' \
             --remove-source-files \
-            ${{ secrets.USER }}@${{ secrets.HOST }}:${{ env.SPACK_ENV_PATH }}/root-spec-pkg-hash.${{ github.run_id }} \
+            ${{ secrets.USER }}@${{ secrets.HOST }}:${{ steps.path.outputs.spack-environment }}/root-spec-pkg-hash.${{ github.run_id }} \
             ./root-spec-pkg-hash.${{ github.run_id }}
 
           echo "$(cat ./root-spec-pkg-hash.${{ github.run_id }})" >> $GITHUB_OUTPUT
@@ -278,23 +276,18 @@ jobs:
 
       - name: Tar spack environment metadata
         if: inputs.deployment-type == 'Prerelease'
-        env:
-          SPACK_ENV_PATH: ${{ steps.path.outputs.spack }}/../environments/${{ inputs.env-name }}
         run: |
           ssh ${{ secrets.USER }}@${{ secrets.HOST }} -i ${{ steps.ssh.outputs.private-key-path }} /bin/bash <<'EOT'
-          tar --remove-files --create --file ${{ env.SPACK_ENV_PATH }}.spack-env.tar ${{ env.SPACK_ENV_PATH }}/.spack-env
+          tar --remove-files --create --file ${{ steps.path.outputs.spack-environment }}.spack-env.tar ${{ steps.path.outputs.spack-environment }}/.spack-env
           EOT
 
       # Release
       - name: Get Release Metadata
-        env:
-          # TODO: Can we put both envs above in a $GITHUB_ENV file instead?
-          SPACK_ENV_PATH: ${{ steps.path.outputs.spack }}/../environments/${{ inputs.env-name }}
         # Copy both the spack.* files and the build-db-pkgs.json file to the artifact
         run: |
           rsync -e 'ssh -i ${{ steps.ssh.outputs.private-key-path }}' \
-            '${{ secrets.USER }}@${{ secrets.HOST_DATA }}:${{ env.SPACK_ENV_PATH }}/spack.*' \
-            '${{ secrets.USER }}@${{ secrets.HOST_DATA }}:${{ env.SPACK_ENV_PATH }}/build-db-pkgs.json' \
+            '${{ secrets.USER }}@${{ secrets.HOST_DATA }}:${{ steps.path.outputs.spack-environment }}/spack.*' \
+            '${{ secrets.USER }}@${{ secrets.HOST_DATA }}:${{ steps.path.outputs.spack-environment }}/build-db-pkgs.json' \
             ./${{ env.ARTIFACT_NAME }}
 
           # Rename the files to include the deployment environment

--- a/.github/workflows/deploy-2-start.yml
+++ b/.github/workflows/deploy-2-start.yml
@@ -278,7 +278,11 @@ jobs:
         if: inputs.deployment-type == 'Prerelease'
         run: |
           ssh ${{ secrets.USER }}@${{ secrets.HOST }} -i ${{ steps.ssh.outputs.private-key-path }} /bin/bash <<'EOT'
-          tar --remove-files --create --file ${{ steps.path.outputs.spack-environment }}.spack-env.tar ${{ steps.path.outputs.spack-environment }}/.spack-env
+          if [ -d "${{ steps.path.outputs.spack-environment }}/.spack-env" ]; then
+            tar --remove-files --create --file ${{ steps.path.outputs.spack-environment }}.spack-env.tar ${{ steps.path.outputs.spack-environment }}/.spack-env
+          else
+            echo "::warning::No .spack-env directory found in ${{ steps.path.outputs.spack-environment }}, not tarring. There may be an issue with the environment."
+          fi
           EOT
 
       # Release

--- a/.github/workflows/deploy-2-start.yml
+++ b/.github/workflows/deploy-2-start.yml
@@ -279,7 +279,7 @@ jobs:
         run: |
           ssh ${{ secrets.USER }}@${{ secrets.HOST }} -i ${{ steps.ssh.outputs.private-key-path }} /bin/bash <<'EOT'
           if [ -d "${{ steps.path.outputs.spack-environment }}/.spack-env" ]; then
-            tar --remove-files --create --file ${{ steps.path.outputs.spack-environment }}.spack-env.tar ${{ steps.path.outputs.spack-environment }}/.spack-env
+            tar --remove-files --create --file ${{ steps.path.outputs.spack-environment }}/.spack-env.tar ${{ steps.path.outputs.spack-environment }}/.spack-env
           else
             echo "::warning::No .spack-env directory found in ${{ steps.path.outputs.spack-environment }}, not tarring. There may be an issue with the environment."
           fi

--- a/.github/workflows/deploy-2-start.yml
+++ b/.github/workflows/deploy-2-start.yml
@@ -276,6 +276,15 @@ jobs:
           echo "$(cat ./root-spec-pkg-hash.${{ github.run_id }})" >> $GITHUB_OUTPUT
           rm ./root-spec-pkg-hash.${{ github.run_id }}
 
+      - name: Tar spack environment metadata
+        if: inputs.deployment-type == 'Prerelease'
+        env:
+          SPACK_ENV_PATH: ${{ steps.path.outputs.spack }}/../environments/${{ inputs.env-name }}
+        run: |
+          ssh ${{ secrets.USER }}@${{ secrets.HOST }} -i ${{ steps.ssh.outputs.private-key-path }} /bin/bash <<'EOT'
+          tar --remove-files --create --file ${{ env.SPACK_ENV_PATH }}.spack-env.tar ${{ env.SPACK_ENV_PATH }}/.spack-env
+          EOT
+
       # Release
       - name: Get Release Metadata
         env:

--- a/scripts/jinja_template/templates/deployment-comment-body.md.j2
+++ b/scripts/jinja_template/templates/deployment-comment-body.md.j2
@@ -23,7 +23,7 @@ module load {{ root_sbd }}/{{ prerelease_version}}
 When using the above modules, the binaries shall be on your `$PATH`.
 
 For advanced users, this Prerelease is also accessible on `{{ deployment.name }}` via `{{ deployment.spack_location }}` in the `{{ root_sbd }}-{{ prerelease_version }}` environment.
-Due to inode-saving measures, one will have to manually untar the environment metadata before environment activation with `tar -xf .spack-env .spack-env.tar`.
+Due to inode-saving measures, one will have to manually untar the environment metadata before environment activation with `tar -xf .spack-env .spack-env.tar`. It will require one to have write privileges.
 
 </details>
 

--- a/scripts/jinja_template/templates/deployment-comment-body.md.j2
+++ b/scripts/jinja_template/templates/deployment-comment-body.md.j2
@@ -23,6 +23,7 @@ module load {{ root_sbd }}/{{ prerelease_version}}
 When using the above modules, the binaries shall be on your `$PATH`.
 
 For advanced users, this Prerelease is also accessible on `{{ deployment.name }}` via `{{ deployment.spack_location }}` in the `{{ root_sbd }}-{{ prerelease_version }}` environment.
+Due to inode-saving measures, one will have to manually untar the environment metadata before environment activation with `tar -xf .spack-env .spack-env.tar`.
 
 </details>
 


### PR DESCRIPTION
Closes #277

## Background

Spack environments have large inode requirements. It [has been found](https://github.com/ACCESS-NRI/build-cd/issues/277#issuecomment-3007165768) that tarring up the `.spack-env` directory inside the spack environment saves a large amount of inodes, and we can still perform environment-aware commands (most notably, `spack env rm` and `spack gc -E`).

For all future prereleases, we should tar up this directory post-install. Users who use the spack instance for development (very few at this point) can either `tar -xf .spack-env .spack-env.tar` before use, otherwise the majority of the infromation will be recreated on install.

## The PR 

- **Add step tarring spack environment metadata to save inodes**
- **Update get-deploy-paths to output spack environment location**
- **Replace all refs to env.SPACK_ENV_PATH to the new steps.path.outputs.spack-environment**
- **Update guidance on spack environment comment**
