### PR TITLE
Update spack-config for Release, Prerelease to 2025.07.001

### DIFF
--- a/config/settings.json
+++ b/config/settings.json
@@ -9,13 +9,13 @@
         },
         "0.22": {
           "spack": "c7212686da637a15fc70ece26cf3f6640f24e2a6",
-          "spack-config": "2025.06.001"
+          "spack-config": "2025.07.001"
         }
       },
       "Prerelease": {
         "0.22": {
           "spack": "c7212686da637a15fc70ece26cf3f6640f24e2a6",
-          "spack-config": "2025.06.001"
+          "spack-config": "2025.07.001"
         }
       }
     }


### PR DESCRIPTION
Update `spack-config` for `0.22` `Release`/`Prerelease` to `2025.07.001`. 

List of changes since last update can be found in https://github.com/ACCESS-NRI/spack-config/compare/2025.06.001...2025.07.001
