### PR TITLE
Tar up prerelease installations on success or failure

### DIFF
--- a/.github/workflows/deploy-2-start.yml
+++ b/.github/workflows/deploy-2-start.yml
@@ -275,7 +275,11 @@ jobs:
           rm ./root-spec-pkg-hash.${{ github.run_id }}
 
       - name: Tar spack environment metadata
-        if: inputs.deployment-type == 'Prerelease'
+        # We want to attempt to tar up the .spack-env directory even if the install fails, so we can save inodes.
+        if: >-
+          always() &&
+          (steps.deploy.conclusion == 'success' || steps.deploy.conclusion == 'failure') &&
+          inputs.deployment-type == 'Prerelease'
         run: |
           ssh ${{ secrets.USER }}@${{ secrets.HOST }} -i ${{ steps.ssh.outputs.private-key-path }} /bin/bash <<'EOT'
           if [ -d "${{ steps.path.outputs.spack-environment }}/.spack-env" ]; then


### PR DESCRIPTION
Closes #307

## Background

We tar up environment metadata only on success, which can lead to many environments not being tarred up. 

## The PR

* Attempt to do the tar step on success or failure of the `deploy` step. 
