### PR TITLE
Schema Versions as Entrypoint Inputs Over `vars`

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -38,6 +38,27 @@ on:
         description: |
           Whether to upload the deployment information to the build database (requires tag-deployment to also be true).
           NOTE: Setting this to false is not recommended for model deployments.
+      spack-manifest-schema-path:
+        type: string
+        required: false
+        default: au.org.access-nri/model/spack/environment/deployment
+        description: |
+          The path to the Spack manifest schema directory relative to the ACCESS-NRI/schema repository.
+      spack-manifest-schema-version:
+        type: string
+        required: true
+        description: |
+          The version of the Spack manifest schema to use for validation, from the ACCESS-NRI/schema repository.
+      config-versions-schema-version:
+        type: string
+        required: true
+        description: |
+          The version of the config/versions.json schema to use for validation, from the ACCESS-NRI/schema repository.
+      config-packages-schema-version:
+        type: string
+        required: true
+        description: |
+          The version of the config/packages.json schema to use for validation, from the ACCESS-NRI/schema repository.
   # Callers usually have the trigger:
   # push:
   #   branches:
@@ -167,6 +188,10 @@ jobs:
       deployment-version: ${{ needs.get-root-spec-ref.outputs.root-spec-ref }}
       spack-manifest-path: ${{ inputs.spack-manifest-path }}
       expected-root-spec-name: ${{ needs.defaults.outputs.root-sbd }}
+      spack-manifest-schema-path: ${{ inputs.spack-manifest-schema-path }}
+      spack-manifest-schema-version: ${{ inputs.spack-manifest-schema-version }}
+      config-versions-schema-version: ${{ inputs.config-versions-schema-version }}
+      config-packages-schema-version: ${{ inputs.config-packages-schema-version }}
     secrets: inherit
     permissions:
       contents: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,27 @@ on:
         description: |
           The Spack manifest path relative to the caller repository that will be used for the deployment.
           This is usually `./spack.yaml`, but can be overridden if needed.
+      spack-manifest-schema-path:
+        type: string
+        required: false
+        default: au.org.access-nri/model/spack/environment/deployment
+        description: |
+          The path to the Spack manifest schema directory relative to the ACCESS-NRI/schema repository.
+      spack-manifest-schema-version:
+        type: string
+        required: true
+        description: |
+          The version of the Spack manifest schema to use for validation, from the ACCESS-NRI/schema repository.
+      config-versions-schema-version:
+        type: string
+        required: true
+        description: |
+          The version of the config/versions.json schema to use for validation, from the ACCESS-NRI/schema repository.
+      config-packages-schema-version:
+        type: string
+        required: true
+        description: |
+          The version of the config/packages.json schema to use for validation, from the ACCESS-NRI/schema repository.
   # Callers usually have the trigger:
   # pull_request:
   #   branches:
@@ -208,6 +229,11 @@ jobs:
       prerelease-compare-ref: ${{ needs.defaults.outputs.base-ref }}
       spack-manifest-path: ${{ inputs.spack-manifest-path }}
       expected-root-spec-name: ${{ needs.defaults.outputs.root-sbd }}
+      # Pass versions and paths for schemas into the deploy workflow
+      spack-manifest-schema-path: ${{ inputs.spack-manifest-schema-path }}
+      spack-manifest-schema-version: ${{ inputs.spack-manifest-schema-version }}
+      config-versions-schema-version: ${{ inputs.config-versions-schema-version }}
+      config-packages-schema-version: ${{ inputs.config-packages-schema-version }}
     secrets: inherit
 
   redeploy-post:

--- a/.github/workflows/deploy-1-setup.yml
+++ b/.github/workflows/deploy-1-setup.yml
@@ -44,6 +44,26 @@ on:
         description: |
           The expected overarching spack bundle that contains all other packages, set in the caller repository.
           Usually .spack.specs[0] or .spack.definitions.ROOT_PACKAGE in the manifest, but draft PRs can override this.
+      spack-manifest-schema-path:
+        type: string
+        required: true
+        description: |
+          The path to the Spack manifest schema directory relative to the ACCESS-NRI/schema repository.
+      spack-manifest-schema-version:
+        type: string
+        required: true
+        description: |
+          The version of the Spack manifest schema to use for validation, from the ACCESS-NRI/schema repository.
+      config-versions-schema-version:
+        type: string
+        required: true
+        description: |
+          The version of the config/versions.json schema to use for validation, from the ACCESS-NRI/schema repository.
+      config-packages-schema-version:
+        type: string
+        required: true
+        description: |
+          The version of the config/packages.json schema to use for validation, from the ACCESS-NRI/schema repository.
     outputs:
       general-metadata-artifact-glob:
         value: ${{ jobs.deployment.outputs.general-metadata-artifact-glob }}
@@ -144,14 +164,14 @@ jobs:
       - name: Validate ${{ github.repository }} config/versions.json
         uses: access-nri/schema/.github/actions/validate-with-schema@main
         with:
-          schema-version: ${{ vars.CONFIG_VERSIONS_SCHEMA_VERSION }}
+          schema-version: ${{ inputs.config-versions-schema-version }}
           schema-location: au.org.access-nri/model/deployment/config/versions
           data-location: ./model/config/versions.json
 
       - name: Validate ${{ github.repository }} config/packages.json
         uses: access-nri/schema/.github/actions/validate-with-schema@main
         with:
-          schema-version: ${{ vars.CONFIG_PACKAGES_SCHEMA_VERSION }}
+          schema-version: ${{ inputs.config-packages-schema-version }}
           schema-location: au.org.access-nri/model/deployment/config/packages
           data-location: ./model/config/packages.json
 
@@ -224,8 +244,8 @@ jobs:
         if: env.IS_NOT_DRAFT == 'true' || inputs.deployment-type == 'Release'
         uses: access-nri/schema/.github/actions/validate-with-schema@main
         with:
-          schema-version: ${{ vars.SPACK_YAML_SCHEMA_VERSION }}
-          schema-location: au.org.access-nri/model/spack/environment/deployment
+          schema-version: ${{ inputs.spack-manifest-schema-version }}
+          schema-location: ${{ inputs.spack-manifest-schema-path }}
           data-location: ${{ inputs.spack-manifest-path }}
 
       - name: Get current (${{ inputs.deployment-ref }}) root spec version


### PR DESCRIPTION
Closes #239

## Background

`vars` are difficult to find, can't be versioned, and apply to the whole repository. In the linked issue, this was a reason to get rid of them. 

Now, the versions for the various schema are instead passed in to the entrypoint workflow, giving provenance as to when they changed and PR/commit-level granularity. 

The new inputs are:

* `spack-manifest-schema-path` (Optional, defaults to `au.org.access-nri/model/spack/environment/deployment`): The path to the schema relative to `ACCESS-NRI/schema`. Useful for using different schema depending on the type of software deployed - for example, models vs general software deployment via `spack`
* `spack-manifest-schema-version` (**Required**): The version for the schema (under `spack-manifest-schema-path`) that validates spack manifests. 
* `config-versions-schema-version` (**Required**): The version for the schema that validates the `config/versions.json` file.
* `config-packages-schema-version` (**Required**): The version for the schema that validates the `config/packages.json` file.

> [!IMPORTANT]
> Because we are adding **new, required** inputs to the entrypoint workflows, this will be a MAJOR update. 

## The PR

- **Change schema vars to required inputs, add optional spack manifest schema path for potentially different schemas**
- **Add required schema version inputs, and optional spack manifest schema paths to entrypoint workflows**

## Testing

Since we will be effectively retesting the same code, we will do the main test under the `dev-v6` -> `v6` PR. 