### PR TITLE
Update 0.22 spack-configs to 2025.08.000

### DIFF
--- a/config/settings.json
+++ b/config/settings.json
@@ -9,13 +9,13 @@
         },
         "0.22": {
           "spack": "a2ea017d84a296c41ea710d104adfcfff257fa6f",
-          "spack-config": "2025.07.001"
+          "spack-config": "2025.08.000"
         }
       },
       "Prerelease": {
         "0.22": {
           "spack": "a2ea017d84a296c41ea710d104adfcfff257fa6f",
-          "spack-config": "2025.07.001"
+          "spack-config": "2025.08.000"
         }
       }
     }


### PR DESCRIPTION
Update `spack-config` across `0.22` versions of `spack`.

Specifically, update it to https://github.com/ACCESS-NRI/spack-config/releases/tag/2025.08.000 (Adds `openmpi@5.0.8` to Gadi config).
