### PR TITLE
Tar Spack Environments on `Release`

### DIFF
--- a/.github/workflows/deploy-2-start.yml
+++ b/.github/workflows/deploy-2-start.yml
@@ -297,10 +297,7 @@ jobs:
 
       - name: Tar spack environment metadata
         # We want to attempt to tar up the .spack-env directory even if the install fails, so we can save inodes.
-        if: >-
-          always() &&
-          (steps.deploy.conclusion == 'success' || steps.deploy.conclusion == 'failure') &&
-          inputs.deployment-type == 'Prerelease'
+        if: always() && (steps.deploy.conclusion == 'success' || steps.deploy.conclusion == 'failure')
         run: |
           ssh ${{ secrets.USER }}@${{ secrets.HOST }} -i ${{ steps.ssh.outputs.private-key-path }} /bin/bash <<'EOT'
           if [ -d "${{ steps.path.outputs.spack-environment }}/.spack-env" ]; then


### PR DESCRIPTION
Closes #315

## Background

We tar up Prerelease Environments to save inodes, but we can also do the same for Releases, since the actual `spack` part of the infrastructure is rarely used post-install. 

> [!NOTE]
> This PR also coincides with modification to the Gadi Releases, in which all the existing environments are `tar`red up.

## The PR

* Remove condition on tar clean up being only for `inputs.deployment-type == 'Prerelease'`.
