### PR TITLE
Add config for Prerelease 1.0 spack/spack-config

### DIFF
--- a/config/settings.json
+++ b/config/settings.json
@@ -16,6 +16,10 @@
         "0.22": {
           "spack": "f348dd2bcbd64e8da8a375ab3cfa300e77aca352",
           "spack-config": "2025.08.000"
+        },
+        "1.0": {
+          "spack": "17d34285729c1bb39dfbdef09c5b78d88bb9e3f9",
+          "spack-config": "2025.08.005"
         }
       }
     }


### PR DESCRIPTION
See deployment of Prerelease Spack v1.0 here: https://github.com/ACCESS-NRI/build-cd/actions/runs/17311612455

## Background

This PR adds configuration information for the above instance of spack. I note that the two events should be better connected - see https://github.com/ACCESS-NRI/build-cd/blob/b7c000e920c6d4e2806f14eb04eeb7d0d1dc4ec8/.github/workflows/settings-2-deploy.yml#L75-L78 
