### PR TITLE
Pass in optional TRACKING_SERVICES_REPO_FETCH_TOKEN to upload script

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -309,6 +309,7 @@ jobs:
         env:
           TRACKING_SERVICES_POST_URL: ${{ vars.TRACKING_SERVICES_POST_URL }}
           TRACKING_SERVICES_POST_TOKEN: ${{ secrets.TRACKING_SERVICES_POST_TOKEN }}
+          TRACKING_SERVICES_REPO_FETCH_TOKEN: ${{ secrets.TRACKING_SERVICES_REPO_FETCH_TOKEN }}
         run: |
           python -m scripts.release_provenance.tracking_services_data \
             --repository ${{ github.repository }} \

--- a/scripts/release_provenance/tracking_services_data.py
+++ b/scripts/release_provenance/tracking_services_data.py
@@ -200,7 +200,11 @@ def get_repo_url_at_ref_or_raise(repository_url: str, ref: str) -> str:
         "Accept": "application/vnd.github+json",
         "X-GitHub-Api-Version": "2022-11-28",
     }
-    if os.getenv("GITHUB_TOKEN") is not None:
+
+    # CI can use an optional token to pull private repositories data
+    if os.getenv("TRACKING_SERVICES_REPO_FETCH_TOKEN") is not None:
+        repo_request_headers["Authorization"] = f"Bearer {os.getenv('TRACKING_SERVICES_REPO_FETCH_TOKEN')}"
+    elif os.getenv("GITHUB_TOKEN") is not None:
         repo_request_headers["Authorization"] = f"Bearer {os.getenv('GITHUB_TOKEN')}"
 
     # Check if the version is a release, tag, or commit SHA

--- a/scripts/release_provenance/tracking_services_data.py
+++ b/scripts/release_provenance/tracking_services_data.py
@@ -202,7 +202,7 @@ def get_repo_url_at_ref_or_raise(repository_url: str, ref: str) -> str:
     }
 
     # CI can use an optional token to pull private repositories data
-    if os.getenv("TRACKING_SERVICES_REPO_FETCH_TOKEN") is not None:
+    if os.getenv("TRACKING_SERVICES_REPO_FETCH_TOKEN") is not None and os.getenv("TRACKING_SERVICES_REPO_FETCH_TOKEN") != "":
         repo_request_headers["Authorization"] = f"Bearer {os.getenv('TRACKING_SERVICES_REPO_FETCH_TOKEN')}"
     elif os.getenv("GITHUB_TOKEN") is not None:
         repo_request_headers["Authorization"] = f"Bearer {os.getenv('GITHUB_TOKEN')}"


### PR DESCRIPTION
Closes #282

## Background

The upload script fails for Model components with private repositories (like `ACCESS-ESM1.*`), which means they need to be uploaded manually. 

The fix for this is to be able to pass in a PAT that has those repos readable. 

## The PR

* Allow passing in of an optional `TRACKING_SERVICES_REPO_FETCH_TOKEN` to the upload script

