### PR TITLE
Update spack 0.22 Release/Prerelease to include babeltrace2

### DIFF
--- a/config/settings.json
+++ b/config/settings.json
@@ -8,13 +8,13 @@
           "spack-config": "2024.03.22"
         },
         "0.22": {
-          "spack": "f348dd2bcbd64e8da8a375ab3cfa300e77aca352",
+          "spack": "357ff5dde01a32612911fd2021e1feefd33a3a3c",
           "spack-config": "2025.08.000"
         }
       },
       "Prerelease": {
         "0.22": {
-          "spack": "f348dd2bcbd64e8da8a375ab3cfa300e77aca352",
+          "spack": "357ff5dde01a32612911fd2021e1feefd33a3a3c",
           "spack-config": "2025.08.000"
         }
       }


### PR DESCRIPTION
References ACCESS-NRI/spack@357ff5dde01a32612911fd2021e1feefd33a3a3c

## Background

`babeltrace2` has been incorporated into `ACCESS-NRI/spack`s `builtin` packages repository. 

## The PR

* Update spack `0.22`s Prerelease and Release areas to use the above referenced commit
