### PR TITLE
Automated Cleanup of Custom Spack Scopes

### DIFF
--- a/.github/workflows/undeploy-1-start.yml
+++ b/.github/workflows/undeploy-1-start.yml
@@ -64,16 +64,6 @@ jobs:
             ${{ secrets.HOST }}
             ${{ secrets.HOST_DATA }}
 
-      - uses: actions/checkout@v4
-        with:
-          repository: access-nri/build-cd
-
-      - name: Rsync alternative scopes
-        run: |
-          rsync -av --delete -e 'ssh -i ${{ steps.ssh.outputs.private-key-path }}' \
-            ./tools/custom-spack-scopes \
-            ${{ secrets.USER }}@${{ secrets.HOST_DATA }}:${{ steps.path.outputs.spack }}/..
-
       - name: Undeploy Environment
         # ssh into deployment environment, create and activate the env, remove all the unneeded environments
         run: |
@@ -94,7 +84,7 @@ jobs:
           spack gc --except-any-environment --yes-to-all
 
           # Custom scopes cleanup (like restricted scopes, etc)
-          scopes=$(find ${{ steps.path.outputs.spack }}/../custom-spack-scopes -mindepth 1 -maxdepth 1 -type d -printf '%p ')
+          scopes=$(find ${{ steps.path.outputs.spack-config }}/common/cd/custom-spack-scopes -mindepth 1 -maxdepth 1 -type d -printf '%p ')
           for scope in $scopes; do
             spack --config-scope $scope gc --except-any-environment --yes-to-all
           done

--- a/.github/workflows/undeploy-1-start.yml
+++ b/.github/workflows/undeploy-1-start.yml
@@ -84,7 +84,7 @@ jobs:
           spack gc --except-any-environment --yes-to-all
 
           # Custom scopes cleanup (like restricted scopes, etc)
-          scopes=$(find ${{ steps.path.outputs.spack-config }}/common/cd/custom-spack-scopes -mindepth 1 -maxdepth 1 -type d -printf '%p ')
+          scopes=$(find ${{ steps.path.outputs.spack-config }}/custom/cd -mindepth 1 -maxdepth 1 -type d -printf '%p ')
           for scope in $scopes; do
             spack --config-scope $scope gc --except-any-environment --yes-to-all
           done

--- a/.github/workflows/undeploy-1-start.yml
+++ b/.github/workflows/undeploy-1-start.yml
@@ -64,6 +64,16 @@ jobs:
             ${{ secrets.HOST }}
             ${{ secrets.HOST_DATA }}
 
+      - uses: actions/checkout@v4
+        with:
+          repository: access-nri/build-cd
+
+      - name: Rsync alternative scopes
+        run: |
+          rsync -av --delete -e 'ssh -i ${{ steps.ssh.outputs.private-key-path }}' \
+            ./tools/custom-spack-scopes \
+            ${{ secrets.USER }}@${{ secrets.HOST_DATA }}:${{ steps.path.outputs.spack }}/..
+
       - name: Undeploy Environment
         # ssh into deployment environment, create and activate the env, remove all the unneeded environments
         run: |
@@ -79,7 +89,16 @@ jobs:
           for env in $envs; do
             spack env rm $env --yes-to-all
           done
+
+          # Base scope cleanup (most environments are in this scope)
           spack gc --except-any-environment --yes-to-all
+
+          # Custom scopes cleanup (like restricted scopes, etc)
+          scopes=$(find ${{ steps.path.outputs.spack }}/../custom-spack-scopes -mindepth 1 -maxdepth 1 -type d -printf '%p ')
+          for scope in $scopes; do
+            spack --config-scope $scope gc --except-any-environment --yes-to-all
+          done
+
           EOT
 
       - name: Undeploy spack-packages

--- a/tools/custom-spack-scopes/restricted-scope/config.yaml
+++ b/tools/custom-spack-scopes/restricted-scope/config.yaml
@@ -1,0 +1,6 @@
+config:
+  install_tree:
+    root: $spack/../restricted/ukmo/release
+  source_cache: $spack/../restricted/ukmo/source_cache
+  build_stage:
+    - $TMPDIR/restricted/spack-stage

--- a/tools/custom-spack-scopes/restricted-scope/config.yaml
+++ b/tools/custom-spack-scopes/restricted-scope/config.yaml
@@ -1,6 +1,0 @@
-config:
-  install_tree:
-    root: $spack/../restricted/ukmo/release
-  source_cache: $spack/../restricted/ukmo/source_cache
-  build_stage:
-    - $TMPDIR/restricted/spack-stage


### PR DESCRIPTION
Closes #324

## Background

Currently, custom spack scopes defined at the environment level (for example, the `$spack/../restricted` scope) are not cleaned up automatically, since spack has no idea about those scopes when not in those environments. Since we delete the environment before running garbage collection, we will not know of the packages under non-standard directories (for example, `$spack/../restricted`). 

This PR adds these custom scopes to `tools/custom-spack-scopes`, and runs `spack --config-scope $SCOPE gc --except-any-environment` for each scope folder upon PR cleanup. 

## The PR

- **Add tools/custom-spack-scopes for tracking of all non-standard configuration scopes**
- **Updated undeploy workflow to clean up custom scopes on PR closed**

## Testing

Desk-checked on the `Prerelease 0.22` instance of spack on Gadi - note the new `$spack/../spack-custom-scopes` directory. 

```bash
tommy@work$ rsync -av --delete tools/custom-spack-scopes $SSH_USER@$SSH_HOST:/g/data/vk83/prerelease/apps/spack/0.22/spack/..
tommy@work$ ssh service_user@gadi

service_user@gadi$ scopes=$(find /g/data/vk83/prerelease/apps/spack/0.22/spack/../spack-custom-scopes -mindepth 1 -maxdepth 1 -type d -printf '%p ')
service_user@gadi$ echo $scopes
/g/data/vk83/prerelease/apps/spack/0.22/spack/../spack-custom-scopes/restricted-scope

service_user@gadi$ for scope in $scopes; do spack --config-scope $scope gc --except-any-environment; done

...
==> [2025-11-10-11:21:46.924243] 2111 packages will be uninstalled. Do you want to proceed? [y/N] n
==> [2025-11-10-11:22:04.766821] Aborting uninstall
```
