### PR TITLE
Support Custom Root Spec Modulefiles in Prerelease

### DIFF
--- a/.github/workflows/deploy-2-start.yml
+++ b/.github/workflows/deploy-2-start.yml
@@ -137,13 +137,9 @@ jobs:
         working-directory: cd
         run: |
           original_root_spec_projection=$(yq '.spack.modules.default.tcl.projections."${{ steps.manifest.outputs.root-spec-name }}"' ../${{ inputs.spack-manifest-path }})
-          if [[ "$original_root_spec_projection" == "null" ]]; then
-            # If there is no custom projection for the root spec, we just use the version as the projection, of the form `{name}/prX-Y`
-            echo "version=${{ inputs.version }}" >> $GITHUB_OUTPUT
-          else
-            # For custom root spec projections, the prerelease portion will be infixed
-            # Eg. `{name}/2025.01.000-{^dep.variants.x}` -> `{name}/prX-Y/2025.01.000-{^dep.variants.x}`
-            echo "version=${{ inputs.version }}/${original_root_spec_projection#*/}" >> $GITHUB_OUTPUT
+          if [[ "$original_root_spec_projection" != "null" ]]; then
+            # For custom root spec projections, we want to take everything after the first `/`
+            echo "custom-projection=${original_root_spec_projection#*/}" >> $GITHUB_OUTPUT
           fi
 
           python -m scripts.spack_manifest.injection.modules \
@@ -161,6 +157,7 @@ jobs:
           python -m scripts.spack_manifest.injection.prerelease \
             --manifest ../${{ inputs.spack-manifest-path }} \
             --version ${{ steps.modules-injection.outputs.version }} \
+            ${{ steps.modules-injection.outputs.custom-projection != '' && format('--custom-root-projection {0}', steps.modules-injection.outputs.custom-projection ) || ''}} \
             --spack-packages-path ${{ steps.path.outputs.spack-packages }} \
             --output ../${{ inputs.spack-manifest-path }}
 

--- a/.github/workflows/deploy-2-start.yml
+++ b/.github/workflows/deploy-2-start.yml
@@ -138,8 +138,7 @@ jobs:
         run: |
           original_root_spec_projection=$(yq '.spack.modules.default.tcl.projections."${{ steps.manifest.outputs.root-spec-name }}"' ../${{ inputs.spack-manifest-path }})
           if [[ "$original_root_spec_projection" != "null" ]]; then
-            # For custom root spec projections, we want to take everything after the first `/`
-            echo "custom-projection=${original_root_spec_projection#*/}" >> $GITHUB_OUTPUT
+            echo "custom-projection=${original_root_spec_projection}" >> $GITHUB_OUTPUT
           fi
 
           python -m scripts.spack_manifest.injection.modules \

--- a/.github/workflows/deploy-2-start.yml
+++ b/.github/workflows/deploy-2-start.yml
@@ -133,8 +133,19 @@ jobs:
 
       - name: Spack Manifest - Modules Injection
         # Injects relevant module projections and includes into the spack manifest so users don't have to
+        id: modules-injection
+        working-directory: cd
         run: |
-          cd cd
+          original_root_spec_projection=$(yq '.spack.modules.default.tcl.projections."${{ steps.manifest.outputs.root-spec-name }}"' ../${{ inputs.spack-manifest-path }})
+          if [[ "$original_root_spec_projection" == "null" ]]; then
+            # If there is no custom projection for the root spec, we just use the version as the projection, of the form `{name}/prX-Y`
+            echo "version=${{ inputs.version }}" >> $GITHUB_OUTPUT
+          else
+            # For custom root spec projections, the prerelease portion will be infixed
+            # Eg. `{name}/2025.01.000-{^dep.variants.x}` -> `{name}/prX-Y/2025.01.000-{^dep.variants.x}`
+            echo "version=${{ inputs.version }}/${original_root_spec_projection#*/}" >> $GITHUB_OUTPUT
+          fi
+
           python -m scripts.spack_manifest.injection.modules \
             --manifest ../${{ inputs.spack-manifest-path }} \
             --packages "${{ steps.config-packages.outputs.packages-for-injection }}" \
@@ -149,7 +160,7 @@ jobs:
         run: |
           python -m scripts.spack_manifest.injection.prerelease \
             --manifest ../${{ inputs.spack-manifest-path }} \
-            --version ${{ inputs.version }} \
+            --version ${{ steps.modules-injection.outputs.version }} \
             --spack-packages-path ${{ steps.path.outputs.spack-packages }} \
             --output ../${{ inputs.spack-manifest-path }}
 

--- a/scripts/spack_manifest/injection/prerelease.py
+++ b/scripts/spack_manifest/injection/prerelease.py
@@ -132,7 +132,12 @@ def update_root_spec_projection_version(
 ) -> dict[str, Any]:
 
     if custom_root_projection is not None and custom_root_projection != "":
-        updated_version: str = f"{{name}}/{root_spec_version}/{custom_root_projection}"
+        projection_components = custom_root_projection.split("/", 1)
+
+        if len(projection_components) == 1:
+            updated_version: str = f"{{name}}/{root_spec_version}/{projection_components[0]}"
+        else:
+            updated_version: str = f"{{name}}/{root_spec_version}/{projection_components[1]}"
     else:
         updated_version: str = f"{{name}}/{root_spec_version}"
 

--- a/scripts/spack_manifest/injection/prerelease.py
+++ b/scripts/spack_manifest/injection/prerelease.py
@@ -36,6 +36,7 @@ yaml.add_representer(YamlExplicitQuotedString, yaml_explicit_quoted_string_repre
 def inject_prerelease_information(
     manifest_path: str,
     version: str,
+    custom_root_projection: str | None = None,
     keep_root_spec_intact: bool = False,
     spack_packages_path: str | None = None,
 ) -> str:
@@ -57,7 +58,7 @@ def inject_prerelease_information(
 
     # We want the root spec projection to be of the form {name}/prX-Y
     updated_manifest = update_root_spec_projection_version(
-        updated_manifest, root_spec_name, version
+        updated_manifest, root_spec_name, version, custom_root_projection
     )
 
     # We want all other projections to be of the form {name}/prX-Y/VERSION
@@ -127,9 +128,13 @@ def remove_potential_root_spec_git_version(manifest: dict[str, Any]) -> dict[str
 
 
 def update_root_spec_projection_version(
-    manifest: dict[str, Any], root_spec_name: str, root_spec_version: str
+    manifest: dict[str, Any], root_spec_name: str, root_spec_version: str, custom_root_projection: str | None = None
 ) -> dict[str, Any]:
-    updated_version: str = f"{{name}}/{root_spec_version}"
+
+    if custom_root_projection is not None and custom_root_projection != "":
+        updated_version: str = f"{{name}}/{root_spec_version}/{custom_root_projection}"
+    else:
+        updated_version: str = f"{{name}}/{root_spec_version}"
 
     manifest.setdefault("spack", {}).setdefault("modules", {}).setdefault("default", {}).setdefault("tcl", {}).setdefault("projections", {})
 
@@ -168,6 +173,13 @@ def parse_args(args: list[str]) -> argparse.Namespace:
         help="Version to be used for projections in the manifest",
     )
 
+    parser.add_argument(
+        "--custom-root-projection",
+        type=str,
+        required=False,
+        help="Custom projection string to be used for the root spec in the manifest",
+    )
+
     # This option is for the special case where the root spec defined at the repository level (a bundle with
     # a version that doesn't yet exist) is not the same as the root spec defined in the manifest (which could
     # be a regular package with a meaningful version). This is not recommended, but can be useful for special builds.
@@ -201,6 +213,7 @@ def main():
     injected_manifest: str = inject_prerelease_information(
         args.manifest,
         args.version,
+        args.custom_root_projection,
         args.keep_root_spec_intact,
         args.spack_packages_path,
     )

--- a/tests/scripts/spack_manifest/injection/outputs/expected.prerelease.spack.yaml
+++ b/tests/scripts/spack_manifest/injection/outputs/expected.prerelease.spack.yaml
@@ -44,7 +44,7 @@ spack:
         - oasis3-mct
         projections:
           access-om2: '{name}/pr12-12/2024.03.0'
-          mom5: 'access-om2/dependencies/pr12-12/2024.03.0/{name}/2023.11.09-{hash:7}'
+          mom5: 'access-om2/dependencies/pr12-12/{name}/2023.11.09-{hash:7}'
   repos::
   - /some/spack-packages
   - $spack/var/spack/repos/builtin

--- a/tests/scripts/spack_manifest/injection/outputs/expected.prerelease.spack.yaml
+++ b/tests/scripts/spack_manifest/injection/outputs/expected.prerelease.spack.yaml
@@ -43,8 +43,8 @@ spack:
         - libaccessom2
         - oasis3-mct
         projections:
-          access-om2: '{name}/pr12-12'
-          mom5: 'access-om2/dependencies/pr12-12/{name}/2023.11.09-{hash:7}'
+          access-om2: '{name}/pr12-12/2024.03.0'
+          mom5: 'access-om2/dependencies/pr12-12/2024.03.0/{name}/2023.11.09-{hash:7}'
   repos::
   - /some/spack-packages
   - $spack/var/spack/repos/builtin

--- a/tests/scripts/spack_manifest/injection/test_prerelease.py
+++ b/tests/scripts/spack_manifest/injection/test_prerelease.py
@@ -26,11 +26,12 @@ class TestUpdateRootSpecProjectionVersion:
             }
         }
         root_spec_name = "access-om2"
-        root_spec_version = "pr12-2/1.0.0"
+        root_spec_version = "pr12-2"
+        custom_root_spec_projection = "1.0.0"
 
-        updated_manifest = update_root_spec_projection_version(manifest, root_spec_name, root_spec_version)
+        updated_manifest = update_root_spec_projection_version(manifest, root_spec_name, root_spec_version, custom_root_spec_projection)
 
-        assert updated_manifest["spack"]["modules"]["default"]["tcl"]["projections"][root_spec_name] == f"{{name}}/{root_spec_version}"
+        assert updated_manifest["spack"]["modules"]["default"]["tcl"]["projections"][root_spec_name] == f"{{name}}/{root_spec_version}/{custom_root_spec_projection}"
 
     def test_update_root_spec_projection_version__valid_new(self):
         manifest = {

--- a/tests/scripts/spack_manifest/injection/test_prerelease.py
+++ b/tests/scripts/spack_manifest/injection/test_prerelease.py
@@ -26,7 +26,7 @@ class TestUpdateRootSpecProjectionVersion:
             }
         }
         root_spec_name = "access-om2"
-        root_spec_version = "pr12-2"
+        root_spec_version = "pr12-2/1.0.0"
 
         updated_manifest = update_root_spec_projection_version(manifest, root_spec_name, root_spec_version)
 
@@ -139,9 +139,9 @@ class TestAddPrereleaseReposSection:
         assert last_three_lines.strip() == expected_last_three_lines.strip()
 
 class TestInjectPrereleaseInformation:
-    def test_inject_prerelease_information__valid(self):
+    def test_inject_prerelease_information__valid_custom_version(self):
         manifest_path = "tests/scripts/spack_manifest/injection/inputs/prerelease.spack.yaml"
-        root_spec_version = "pr12-12"
+        root_spec_version = "pr12-12/2024.03.0"
         spack_packages_path = "/some/spack-packages"
 
         updated_manifest_str: str = inject_prerelease_information(

--- a/tests/scripts/spack_manifest/injection/test_prerelease.py
+++ b/tests/scripts/spack_manifest/injection/test_prerelease.py
@@ -139,13 +139,14 @@ class TestAddPrereleaseReposSection:
         assert last_three_lines.strip() == expected_last_three_lines.strip()
 
 class TestInjectPrereleaseInformation:
-    def test_inject_prerelease_information__valid_custom_version(self):
+    def test_inject_prerelease_information__valid_custom_projection(self):
         manifest_path = "tests/scripts/spack_manifest/injection/inputs/prerelease.spack.yaml"
-        root_spec_version = "pr12-12/2024.03.0"
+        root_spec_version = "pr12-12"
+        custom_root_projection = "2024.03.0"
         spack_packages_path = "/some/spack-packages"
 
         updated_manifest_str: str = inject_prerelease_information(
-            manifest_path, root_spec_version, False, spack_packages_path
+            manifest_path, root_spec_version, custom_root_projection, False, spack_packages_path
         )
 
         expected_manifest_path = "tests/scripts/spack_manifest/injection/outputs/expected.prerelease.spack.yaml"


### PR DESCRIPTION
Closes #329

## Background

A corner case in our Prerelease Injection is in the case where a custom root spec projection is overwritten by the prerelease injection. This is usually fine, as we don't put anything too important in the projections. 

However, in the case where we have multiple top-level specs that share the same name, but different properties (eg. variants in dependencies that need to added to the modulefile, like in `{name}/2025.11.000-{^cice5.variants.x}x{^cice5.variants.y}`), we overwrite it to `{name}/prX-Y`. 

In this PR, rather than directly overwriting the custom projection, we infix the PR number, so we get `{name}/prX-Y/VERSION`, eg. `{name}/pr12-23/2025.11.000-{^cice.variants.x}x{^cice.variants.y}`. This gives us both modulefile uniqueness, and capture the unique properties of the custom projection

## The PR

In this PR:

- **deploy-2-start: infix prerelease version into existing projection**
- **Update tests**

## Testing

Rerun and updated unit tests.
