### PR TITLE
Spack V1 Migration Feature: `config/versions.json` `custom-scopes` Field

### DIFF
--- a/.github/workflows/deploy-2-start.yml
+++ b/.github/workflows/deploy-2-start.yml
@@ -82,6 +82,7 @@ jobs:
         run: |
           echo "spack=$(jq --compact-output --raw-output '.spack' ./config/versions.json)" >> $GITHUB_OUTPUT
           echo "packages=$(jq --compact-output --raw-output '."access-spack-packages"' ./config/versions.json)" >> $GITHUB_OUTPUT
+          echo "custom-scopes=$(jq --compact-output --raw-output '."custom-scopes" // [] | join(" ")' ./config/versions.json)" >> $GITHUB_OUTPUT
 
       - name: Get ${{ inputs.deployment-target }} ${{ inputs.deployment-type }} Remote Paths
         id: path
@@ -205,8 +206,13 @@ jobs:
           spack env activate ${{ inputs.env-name }} --create --envfile ${{ vars.SPACK_YAML_LOCATION }}/${{ inputs.expected-root-spec-name }}-${{ github.run_id }}.spack.yaml
 
           # Finally, install the spack manifest
-          spack --debug install --fail-fast --fresh ${{ vars.SPACK_INSTALL_ADDITIONAL_ARGS }} || exit $?
-          spack module tcl refresh -y
+          spack --debug \
+            $(for s in ${{ steps.versions.outputs.custom-scopes }}; do echo -n "--custom-scope $s "; done) \
+            install --fail-fast --fresh ${{ vars.SPACK_INSTALL_ADDITIONAL_ARGS }} || exit $?
+
+          spack \
+            $(for s in ${{ steps.versions.outputs.custom-scopes }}; do echo -n "--custom-scope $s "; done) \
+            module tcl refresh -y
           EOT
 
       - name: Move spack logs

--- a/.github/workflows/deploy-2-start.yml
+++ b/.github/workflows/deploy-2-start.yml
@@ -210,11 +210,11 @@ jobs:
 
           # Finally, install the spack manifest
           spack --debug \
-            $(for s in ${{ env.SCOPES }}; do echo -n "--custom-scope=${{ env.SCOPES_PATH }}/$s "; done) \
+            $(for s in ${{ env.SCOPES }}; do echo -n "--config-scope=${{ env.SCOPES_PATH }}/$s "; done) \
             install --fail-fast --fresh ${{ vars.SPACK_INSTALL_ADDITIONAL_ARGS }} || exit $?
 
           spack \
-            $(for s in ${{ env.SCOPES }}; do echo -n "--custom-scope=${{ env.SCOPES_PATH }}/$s "; done) \
+            $(for s in ${{ env.SCOPES }}; do echo -n "--config-scope=${{ env.SCOPES_PATH }}/$s "; done) \
             module tcl refresh -y
           EOT
 

--- a/.github/workflows/deploy-2-start.yml
+++ b/.github/workflows/deploy-2-start.yml
@@ -186,6 +186,9 @@ jobs:
 
       - name: Deploy to ${{ inputs.deployment-target }} ${{ inputs.deployment-type }}
         id: deploy
+        env:
+          SCOPES: ${{ steps.versions.outputs.custom-scopes }}
+          SCOPES_PATH: ${{ steps.path.outputs.spack-config }}/custom/cd
         # ssh into deployment environment, create and activate the env, install the spack manifest.
         run: |
           ssh ${{ secrets.USER}}@${{ secrets.HOST }} -i ${{ steps.ssh.outputs.private-key-path }} /bin/bash <<'EOT'
@@ -207,11 +210,11 @@ jobs:
 
           # Finally, install the spack manifest
           spack --debug \
-            $(for s in ${{ steps.versions.outputs.custom-scopes }}; do echo -n "--custom-scope $s "; done) \
+            $(for s in ${{ env.SCOPES }}; do echo -n "--custom-scope ${{ env.SCOPES_PATH }}/$s "; done) \
             install --fail-fast --fresh ${{ vars.SPACK_INSTALL_ADDITIONAL_ARGS }} || exit $?
 
           spack \
-            $(for s in ${{ steps.versions.outputs.custom-scopes }}; do echo -n "--custom-scope $s "; done) \
+            $(for s in ${{ env.SCOPES }}; do echo -n "--custom-scope ${{ env.SCOPES_PATH }}/$s "; done) \
             module tcl refresh -y
           EOT
 

--- a/.github/workflows/deploy-2-start.yml
+++ b/.github/workflows/deploy-2-start.yml
@@ -210,11 +210,11 @@ jobs:
 
           # Finally, install the spack manifest
           spack --debug \
-            $(for s in ${{ env.SCOPES }}; do echo -n "--custom-scope ${{ env.SCOPES_PATH }}/$s "; done) \
+            $(for s in ${{ env.SCOPES }}; do echo -n "--custom-scope=${{ env.SCOPES_PATH }}/$s "; done) \
             install --fail-fast --fresh ${{ vars.SPACK_INSTALL_ADDITIONAL_ARGS }} || exit $?
 
           spack \
-            $(for s in ${{ env.SCOPES }}; do echo -n "--custom-scope ${{ env.SCOPES_PATH }}/$s "; done) \
+            $(for s in ${{ env.SCOPES }}; do echo -n "--custom-scope=${{ env.SCOPES_PATH }}/$s "; done) \
             module tcl refresh -y
           EOT
 

--- a/.github/workflows/deploy-2-start.yml
+++ b/.github/workflows/deploy-2-start.yml
@@ -94,12 +94,6 @@ jobs:
           deployment-type: ${{ inputs.deployment-type }}
           spack-environment: ${{ inputs.env-name }}
 
-      - name: Get manifest info
-        id: manifest
-        uses: access-nri/build-cd/.github/actions/get-spack-root-spec@v8
-        with:
-          spack-manifest-path: ${{ inputs.spack-manifest-path }}
-
       - name: Setup SSH
         id: ssh
         uses: access-nri/actions/.github/actions/setup-ssh@main


### PR DESCRIPTION
References #334

> [!IMPORTANT]
> This is also another major change, but it is being rolled into other major changes, see ACCESS-NRI/build-cd#326

## Background

Currently, we use a custom `spack.config.install_tree` in `ACCESS-ESM1.[56]` for UKMO-restricted content. 
We also use an equivalent custom scope under `spack-config`s `custom/cd/ukmo-restricted-scope` for `build-cd` cleanup activities. 
It is worth moving towards the latter so there is no custom logic in MDR manifests. See the linked issue for more context. 

## The PR

* Add a loop of `--config-scope`s to the `spack install` and `spack module` commands during deployment, which are populated by the `config/versions.json`s `custom-scopes` field.

## Testing

### Scopeless Deployment

This is equivalent to our non-`ukmo`-related models that require no special scopes - see the [`versions.json`](https://github.com/ACCESS-NRI/ACCESS-TEST/commit/46978dc011fec57bc08476bb2346e3fdf560a758) that has no `custom-scopes` field. This succeeded: https://github.com/ACCESS-NRI/ACCESS-TEST/actions/runs/21120479337/job/60732483183?pr=61#step:16:38

### Scoped Deployment (`ukmo-restricted-scope`)

This is equivalent to our `ukmo`-related models that require the `ukmo-restricted-scope` - see the [`versions.json`](https://github.com/ACCESS-NRI/ACCESS-TEST/commit/cbd9d46de766a441fe5182b417bf3b47486d7d4c) that has a `custom-scopes` field. This succeeded, too: https://github.com/ACCESS-NRI/ACCESS-TEST/actions/runs/21121351219/job/60734747451?pr=61#step:16:260
