### PR TITLE
Update `spack 0.22` to Include Newer `gh` Versions

### DIFF
--- a/config/settings.json
+++ b/config/settings.json
@@ -8,13 +8,13 @@
           "spack-config": "2024.03.22"
         },
         "0.22": {
-          "spack": "357ff5dde01a32612911fd2021e1feefd33a3a3c",
+          "spack": "f92f4c062e0cd593fa78b3b6e12bc3560b4a4f80",
           "spack-config": "2025.08.000"
         }
       },
       "Prerelease": {
         "0.22": {
-          "spack": "357ff5dde01a32612911fd2021e1feefd33a3a3c",
+          "spack": "f92f4c062e0cd593fa78b3b6e12bc3560b4a4f80",
           "spack-config": "2025.08.000"
         }
       }


### PR DESCRIPTION
# Background

In order to support (in the interim) a Release of `gh` with less restrictive targets (see https://github.com/ACCESS-NRI/system-tools/pull/17) but a different version, we need to backport newer versions of `gh` to avoid spack environment name clashes. Spack PR here: https://github.com/ACCESS-NRI/spack/pull/23



# The PR

* Update `spack 0.22 Pre/Release` to https://github.com/ACCESS-NRI/spack/commit/f92f4c062e0cd593fa78b3b6e12bc3560b4a4f80
