### PR TITLE
Remove Entrypoint `inputs.root-sbd`, Add `inputs.spack-manifest-path` Where Missing

### DIFF
--- a/.github/actions/get-spack-manifest/README.md
+++ b/.github/actions/get-spack-manifest/README.md
@@ -9,7 +9,7 @@ Action that returns information about a Spack manifest file.
 
 | Name | Type | Description | Required | Default | Example |
 | ---- | ---- | ----------- | -------- | ------- | ------- |
-| `spack-manifest-path` | `string` | The path to the spack manifest file | `false` | `"./spack.yaml"` | `"./some/other.spack.yaml"` |
+| `spack-manifest-path` | `string` | The path to the spack manifest file | `false` | `"spack.yaml"` | `"./some/other.spack.yaml"` |
 
 ## Outputs
 
@@ -31,7 +31,7 @@ jobs:
       - id: spec
         uses: access-nri/build-cd/.github/actions/get-spack-manifest@vX  # for some version `vX`
         with:
-          spack-manifest-path: ./spack.yaml
+          spack-manifest-path: spack.yaml
 
       - run: |
           echo "Deploying ${{ steps.spec.outputs.deployment-name }} at ${{ steps.spec.outputs.deployment-version }}"

--- a/.github/actions/get-spack-manifest/action.yml
+++ b/.github/actions/get-spack-manifest/action.yml
@@ -4,7 +4,7 @@ author: Tommy Gatti
 inputs:
   spack-manifest-path:
     required: false
-    default: ./spack.yaml
+    default: spack.yaml
     description: The path to the spack manifest file
 outputs:
   deployment-name:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -9,14 +9,7 @@ on:
       model:
         type: string
         required: true
-        description: The model that is being tested and deployed
-      root-sbd:
-        type: string
-        required: false
-        # default: The ${{ inputs.model }} above
-        description: |
-          The name of the root Spack Bundle Definition, if it is different from the model name.
-          This is often a package named similarly in ACCESS-NRI/spack-packages.
+        description: The human-readable model name that is being tested and deployed
       spack-manifest-path:
         type: string
         required: false
@@ -72,22 +65,20 @@ env:
   METADATA_PATH: /opt/metadata
   OUTPUTS_PATH: /opt/outputs
 jobs:
-  defaults:
-    name: Set Defaults
-    # Unfortunately, you can't set a dynamic default value based on `inputs` yet
+  init:
+    name: Initialize Deployment
     runs-on: ubuntu-latest
     outputs:
-      root-sbd: ${{ steps.root-sbd.outputs.default }}
+      deployment-name: ${{ steps.manifest.outputs.deployment-name }}
       targets: ${{ steps.target.outputs.valid-targets }}
     steps:
-      - name: root-sbd
-        id: root-sbd
-        run: |
-          if [ -z "${{ inputs.root-sbd }}" ]; then
-            echo "default=${{ inputs.model }}" >> $GITHUB_OUTPUT
-          else
-            echo "default=${{ inputs.root-sbd }}" >> $GITHUB_OUTPUT
-          fi
+      - uses: actions/checkout@v4
+
+      - name: Get manifest
+        id: manifest
+        uses: access-nri/build-cd/.github.actions/get-spack-manifest@v8
+        with:
+          spack-manifest-path: ${{ inputs.spack-manifest-path }}
 
       - name: Generate Deployment Target Matrix
         id: target
@@ -99,10 +90,10 @@ jobs:
     name: Verify Deployment Settings
     runs-on: ubuntu-latest
     needs:
-      - defaults
+      - init
     strategy:
       matrix:
-        target: ${{ fromJson(needs.defaults.outputs.targets) }}
+        target: ${{ fromJson(needs.init.outputs.targets) }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -163,18 +154,18 @@ jobs:
   deploy-release:
     name: Deploy Release
     needs:
-      - defaults
+      - init
       - get-deployment-version
       - push-tag
     # Pushing tags is optional if we are doing a non-model deployment
     if: >-
       always() &&
-      needs.defaults.result == 'success' &&
+      needs.init.result == 'success' &&
       needs.get-deployment-version.result == 'success' &&
       (needs.push-tag.result == 'success' || needs.push-tag.result == 'skipped')
     strategy:
       matrix:
-        target: ${{ fromJson(needs.defaults.outputs.targets) }}
+        target: ${{ fromJson(needs.init.outputs.targets) }}
     uses: access-nri/build-cd/.github/workflows/deploy-1-setup.yml@v8
     with:
       deployment-target: ${{ matrix.target }}
@@ -182,7 +173,7 @@ jobs:
       deployment-type: Release
       deployment-version: ${{ needs.get-deployment-version.outputs.version }}
       spack-manifest-path: ${{ inputs.spack-manifest-path }}
-      expected-root-spec-name: ${{ needs.defaults.outputs.root-sbd }}
+      expected-root-spec-name: ${{ needs.init.outputs.deployment-name }}
       spack-manifest-schema-path: ${{ inputs.spack-manifest-schema-path }}
       spack-manifest-schema-version: ${{ inputs.spack-manifest-schema-version }}
       config-versions-schema-version: ${{ inputs.config-versions-schema-version }}
@@ -198,7 +189,7 @@ jobs:
     name: Create Release
     if: inputs.tag-deployment
     needs:
-      - defaults
+      - init
       - get-deployment-version
       - push-tag
       - deploy-release
@@ -241,7 +232,7 @@ jobs:
         env:
           J2_MODEL: ${{ inputs.model }}
           J2_VERSION: ${{ needs.get-deployment-version.outputs.version }}
-          J2_ROOT_SBD: ${{ needs.defaults.outputs.root-sbd }}
+          J2_ROOT_SBD: ${{ needs.init.outputs.deployment-name }}
         run: |
           python -m scripts.jinja_template.render_deployment_info \
             --template scripts/jinja_template/templates/release-body.md.j2 \
@@ -265,7 +256,7 @@ jobs:
     name: Build DB Metadata Upload
     if: inputs.tag-deployment && inputs.upload-to-build-db
     needs:
-      - defaults
+      - init
       - deploy-release
       - release
     runs-on: ubuntu-latest
@@ -308,7 +299,7 @@ jobs:
         run: |
           python -m scripts.release_provenance.tracking_services_data \
             --repository ${{ github.repository }} \
-            --root-spec ${{ needs.defaults.outputs.root-sbd }} \
+            --root-spec ${{ needs.init.outputs.deployment-name }} \
             --deployment-outputs ${{ env.OUTPUTS_PATH }} \
             --metadata-outputs ${{ env.METADATA_PATH }} \
             --upload

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -13,10 +13,10 @@ on:
       spack-manifest-path:
         type: string
         required: false
-        default: ./spack.yaml
+        default: spack.yaml
         description: |
           The Spack manifest path relative to the caller repository that will be used for the deployment.
-          This is usually `./spack.yaml`, but can be overridden if needed.
+          This is usually `spack.yaml`, but can be overridden if needed.
       tag-deployment:
         type: boolean
         required: false

--- a/.github/workflows/ci-closed.yml
+++ b/.github/workflows/ci-closed.yml
@@ -12,7 +12,7 @@ on:
       spack-manifest-path:
         type: string
         required: false
-        default: ./spack.yaml
+        default: spack.yaml
   # Callers usually have the trigger:
   # pull_request:
   #   types:

--- a/.github/workflows/ci-closed.yml
+++ b/.github/workflows/ci-closed.yml
@@ -1,5 +1,5 @@
 name: PR Closed Cleanup
-run-name: ${{ inputs.model }} PR Closed Cleanup
+run-name: PR Closed Cleanup
 # Remove prereleases that were part of a closed PR, so we save space
 # on our deployment targets. If needed, one can still get the
 # spack.yaml as part of the closed PR and revive it themselves.
@@ -9,10 +9,10 @@ run-name: ${{ inputs.model }} PR Closed Cleanup
 on:
   workflow_call:
     inputs:
-      root-sbd:
+      spack-manifest-path:
         type: string
-        required: true
-        description: The model package name that is going to be removed
+        required: false
+        default: ./spack.yaml
   # Callers usually have the trigger:
   # pull_request:
   #   types:
@@ -31,10 +31,19 @@ jobs:
       version-pattern: ${{ steps.version.outputs.pattern }}
       targets: ${{ steps.target.outputs.valid-targets }}
     steps:
+      - name: Get data from ${{ github.repository }}
+        uses: actions/checkout@v4
+
+      - name: Get Deployment Name
+        id: manifest
+        uses: access-nri/build-cd/.github/actions/get-spack-manifest@v8
+        with:
+          spack-manifest-path: ${{ inputs.spack-manifest-path }}
+
       - name: Get Version Pattern
         id: version
         # For example, `access-om3-pr12-*`
-        run: echo "pattern=${{ inputs.root-sbd }}-pr${{ github.event.pull_request.number }}-*" >> $GITHUB_OUTPUT
+        run: echo "pattern=${{ steps.manifest.outputs.deployment-name }}-pr${{ github.event.pull_request.number }}-*" >> $GITHUB_OUTPUT
 
       - name: Generate Deployment Target Matrix
         id: target
@@ -52,7 +61,7 @@ jobs:
       fail-fast: false
     uses: access-nri/build-cd/.github/workflows/undeploy-1-start.yml@v8
     with:
-      version-pattern: ${{ inputs.root-sbd }}-pr${{ github.event.pull_request.number }}-*
+      version-pattern: ${{ needs.setup.outputs.version-pattern }}
       target: ${{ matrix.target }}
       type: Prerelease
     secrets: inherit

--- a/.github/workflows/ci-command-configs.yml
+++ b/.github/workflows/ci-command-configs.yml
@@ -2,18 +2,15 @@ name: Configs
 on:
   workflow_call:
     inputs:
+      spack-manifest-path:
+        type: string
+        required: false
+        default: spack.yaml
+        description: Path to the spack manifest in the model deployment repository
       model:
         type: string
         required: true
         description: The model that is being tested and deployed
-      root-sbd:
-        type: string
-        required: false
-        # The equivalent default is set in the defaults job below.
-        # default: ${{ inputs.model }}
-        description: |
-          The name of the root Spack Bundle Definition, if it is different from the model name.
-          This is often a package named similarly in ACCESS-NRI/spack-packages.
       auto-configs-pr-schema-version:
         type: string
         required: true
@@ -41,8 +38,8 @@ jobs:
     # and read configuration information from the caller repository.
     runs-on: ubuntu-latest
     outputs:
-      # Value for the defaulted root-sbd if not provided
-      root-sbd: ${{ steps.defaults.outputs.root-sbd }}
+      # Deployment Name for the spack manifest - corresponds to the root spec
+      deployment-name: ${{ steps.manifest.outputs.deployment-name }}
       # Caller PR branch ref
       pr-branch: ${{ steps.pr.outputs.ref }}
       # The profile to use from the MDRs config/auto-configs-pr.json
@@ -104,15 +101,6 @@ jobs:
           # Output processed args
           echo "profile=$profile" >> $GITHUB_OUTPUT
 
-      - name: Set defaults
-        id: defaults
-        run: |
-          if [[ "${{ inputs.root-sbd }}" == "" ]]; then
-            echo "root-sbd=${{ inputs.model }}" >> $GITHUB_OUTPUT
-          else
-            echo "root-sbd=${{ inputs.root-sbd }}" >> $GITHUB_OUTPUT
-          fi
-
       - name: Get caller repository ref
         id: pr
         # We need to find the PR ref of the caller repository explicitly, as this workflow trigger (issue_comment) is in the context of the default branch
@@ -122,26 +110,25 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ steps.pr.outputs.ref }}
-          path: caller
 
       - name: Validate auto configs PR configuration
         uses: access-nri/schema/.github/actions/validate-with-schema@main
         with:
           schema-version: ${{ inputs.auto-configs-pr-schema-version }}
           schema-location: au.org.access-nri/model/deployment/config/auto-configs-pr
-          data-location: caller/config/auto-configs-pr.json
+          data-location: config/auto-configs-pr.json
 
       - name: Read auto configs PR configuration
         id: read-config
         run: |
-          if ! jq --exit-status '.profiles."${{ steps.parse.outputs.profile }}"' caller/config/auto-configs-pr.json; then
+          if ! jq --exit-status '.profiles."${{ steps.parse.outputs.profile }}"' config/auto-configs-pr.json; then
             echo "::error::Profile ${{ steps.parse.outputs.profile }} does not exist in config/auto-configs-pr.json at ref ${{ steps.pr.outputs.ref }}"
             exit 1
           fi
 
-          configs=$(jq -cr '.profiles."${{ steps.parse.outputs.profile }}".configs | keys' caller/config/auto-configs-pr.json)
-          configs_formatted=$(jq -cr '.profiles."${{ steps.parse.outputs.profile }}".configs | keys | join(" ")' caller/config/auto-configs-pr.json)
-          configs_repo=$(jq -cr '.profiles."${{ steps.parse.outputs.profile }}".configs_repo' caller/config/auto-configs-pr.json)
+          configs=$(jq -cr '.profiles."${{ steps.parse.outputs.profile }}".configs | keys' config/auto-configs-pr.json)
+          configs_formatted=$(jq -cr '.profiles."${{ steps.parse.outputs.profile }}".configs | keys | join(" ")' config/auto-configs-pr.json)
+          configs_repo=$(jq -cr '.profiles."${{ steps.parse.outputs.profile }}".configs_repo' config/auto-configs-pr.json)
 
           echo "$configs"
           echo "$configs_formatted"
@@ -150,6 +137,12 @@ jobs:
           echo "configs=$configs" >> $GITHUB_OUTPUT
           echo "configs-formatted=$configs_formatted" >> $GITHUB_OUTPUT
           echo "configs-repo=$configs_repo" >> $GITHUB_OUTPUT
+
+      - name: Get caller deployment name
+        id: manifest
+        uses: access-nri/build-cd/.github/actions/get-spack-manifest@v8
+        with:
+          spack-manifest-path: ${{ inputs.spack-manifest-path }}
 
   update-configs:
     name: Update
@@ -223,7 +216,7 @@ jobs:
       - name: Open PR
         id: open-pr
         env:
-          DEPLOYMENT_IDENTIFIER: ${{ needs.setup.outputs.root-sbd }}/pr${{ github.event.issue.number }}-${{ steps.previous-deployments.outputs.deployments }}
+          DEPLOYMENT_IDENTIFIER: ${{ needs.setup.outputs.deployment-name }}/pr${{ github.event.issue.number }}-${{ steps.previous-deployments.outputs.deployments }}
         run: |
           pr_branch_name="auto/pr${{ github.event.issue.number }}-${{ steps.previous-deployments.outputs.deployments }}/${{ env.CONFIG }}"
 
@@ -250,7 +243,7 @@ jobs:
           PYTHONPATH=build-cd python3 -m scripts.model_config_manifest.prerelease_update \
             --manifest caller-configs/config.yaml \
             --deployment-target Gadi \
-            --root-sbd ${{ needs.setup.outputs.root-sbd }} \
+            --root-sbd ${{ needs.setup.outputs.deployment-name }} \
             --module ${{ env.DEPLOYMENT_IDENTIFIER }}
 
           echo "Committing and pushing changes..."

--- a/.github/workflows/ci-comment.yml
+++ b/.github/workflows/ci-comment.yml
@@ -5,8 +5,6 @@ run-name: ${{ inputs.model }} Comment Command
 # permissions.contents:write
 # permissions.pull-requests:write
 
-# FIXME: We don't support any !bump from a spack manifest that is not in the default ./spack.yaml location.
-
 on:
   workflow_call:
     inputs:
@@ -14,14 +12,11 @@ on:
         type: string
         required: true
         description: The model that is being tested and deployed
-      root-sbd:
+      spack-manifest-path:
         type: string
         required: false
-        # The equivalent default is set in the defaults job below.
-        # default: ${{ inputs.model }}
-        description: |
-          The name of the root Spack Bundle Definition, if it is different from the model name.
-          This is often a package named similarly in ACCESS-NRI/spack-packages.
+        default: spack.yaml
+        description: Path the the spack manifest in the caller
   # Callers usually have the trigger:
   # issue_comment:
   #   types:
@@ -30,34 +25,15 @@ on:
 env:
   RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
 jobs:
-  defaults:
-    name: Set Defaults
-    # Unfortunately, you can't set a dynamic default value based on `inputs` yet.
-    runs-on: ubuntu-latest
-    outputs:
-      root-sbd: ${{ steps.root-sbd.outputs.default }}
-    steps:
-      - name: root-sbd default
-        id: root-sbd
-        run: |
-          if [[ "${{ inputs.root-sbd }}" == "" ]]; then
-            echo "default=${{ inputs.model }}" >> $GITHUB_OUTPUT
-          else
-            echo "default=${{ inputs.root-sbd }}" >> $GITHUB_OUTPUT
-          fi
-
   bump-version:
     name: Bump spack.yaml
     if: github.event.issue.pull_request && startsWith(github.event.comment.body, '!bump')
-    needs:
-      - defaults
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
       contents: write
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      SPACK_YAML_MODEL_PROJECTION_YQ: .spack.modules.default.tcl.projections.${{ needs.defaults.outputs.root-sbd }}
     steps:
       - name: Get branch from issue
         id: issue
@@ -74,6 +50,8 @@ jobs:
       - name: Original version
         id: original
         uses: access-nri/build-cd/.github/actions/get-spack-manifest@v8
+        with:
+          spack-manifest-path: ${{ inputs.spack-manifest-path }}
 
       - name: Setup
         id: setup
@@ -132,20 +110,20 @@ jobs:
 
       - name: Update, Commit and Push the Bump
         run: |
-          yq -i '.spack.definitions[]._version[0] = "${{ steps.bump.outputs.after }}"' spack.yaml
-          git add spack.yaml
-          git commit -m "spack.yaml: Updated deployment version from ${{ steps.original.outputs.deployment-version }} to ${{ steps.bump.outputs.after }}"
+          yq -i '.spack.definitions[]._version[0] = "${{ steps.bump.outputs.after }}"' ${{ inputs.spack-manifest-path }}
+          git add ${{ inputs.spack-manifest-path }}
+          git commit -m "${{ inputs.spack-manifest-path }}: Updated deployment version from ${{ steps.original.outputs.deployment-version }} to ${{ steps.bump.outputs.after }}"
           git push
 
       - name: Success Notifier
         uses: access-nri/actions/.github/actions/pr-comment@main
         with:
           comment: |
-            :white_check_mark: Version bumped from `${{ steps.original.outputs.deployment-version }}` to `${{ steps.bump.outputs.after }}` :white_check_mark:
+            :white_check_mark: ${{ inputs.spack-manifest-path }} version bumped from `${{ steps.original.outputs.deployment-version }}` to `${{ steps.bump.outputs.after }}` :white_check_mark:
 
       - name: Failure Notifier
         if: failure()
         uses: access-nri/actions/.github/actions/pr-comment@main
         with:
           comment: |
-            :x: Failed to bump version or commit changes, see ${{ env.RUN_URL }} :x:
+            :x: Failed to bump version or commit changes to ${{ inputs.spack-manifest-path }}, see ${{ env.RUN_URL }} :x:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,17 +15,6 @@ on:
         type: string
         required: true
         description: The model that is being tested and deployed
-      root-sbd:
-        type: string
-        required: false
-        # default: The ${{ inputs.model }} above
-        description: |
-          The name of the root Spack Bundle Definition, if it is different from the model name.
-          This is often a package named similarly in ACCESS-NRI/spack-packages.
-      pr:
-        type: string
-        required: true
-        description: The pull request number that will be deployed as a prerelease
       spack-manifest-path:
         type: string
         required: false
@@ -68,17 +57,17 @@ on:
   #     - edited
 env:
   RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+  PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
 jobs:
-  defaults:
-    name: Set Defaults
-    # Unfortunately, you can't set a dynamic default value based on `inputs` yet.
-    # We also set the PR and branch metadata here because it's used in multiple places,
+  init:
+    name: Setup CI
+    # We set the PR and branch metadata here because it's used in multiple places,
     # including the deploy reusable workflow, which can't access the `env` context.
     runs-on: ubuntu-latest
     env:
       GH_TOKEN: ${{ github.token }}
     outputs:
-      root-sbd: ${{ steps.root-sbd.outputs.default }}
+      deployment-name: ${{ steps.manifest.outputs.deployment-name }}
       head-ref: ${{ steps.pr.outputs.head }}
       head-sha: ${{ steps.pr.outputs.sha }}
       base-ref: ${{ steps.pr.outputs.base }}
@@ -86,21 +75,12 @@ jobs:
       prerelease-version: ${{ steps.prerelease.outputs.version }}
       targets: ${{ steps.target.outputs.valid-targets }}
     steps:
-      - name: root-sbd default
-        id: root-sbd
-        run: |
-          if [[ "${{ inputs.root-sbd }}" == "" ]]; then
-            echo "default=${{ inputs.model }}" >> $GITHUB_OUTPUT
-          else
-            echo "default=${{ inputs.root-sbd }}" >> $GITHUB_OUTPUT
-          fi
-
       - name: PR metadata
         id: pr
         run: |
-          pr_metadata=$(gh pr view ${{ inputs.pr }} --repo ${{ github.repository }} --json headRefName,headRefOid,baseRefName)
+          pr_metadata=$(gh pr view ${{ env.PR_NUMBER }} --repo ${{ github.repository }} --json headRefName,headRefOid,baseRefName)
           if [ -z "$pr_metadata" ]; then
-            echo "::error::Failed to get PR ${{ inputs.pr }} metadata."
+            echo "::error::Failed to get PR ${{ env.PR_NUMBER }} metadata."
             exit 1
           fi
 
@@ -117,7 +97,7 @@ jobs:
             '$pr.baseRefName'
           )
 
-          echo "PR ${{ inputs.pr }} with '$head' ('$sha') -> '$base'"
+          echo "PR ${{ env.PR_NUMBER }} with '$head' ('$sha') -> '$base'"
           echo "head=$head" >> $GITHUB_OUTPUT
           echo "sha=$sha" >> $GITHUB_OUTPUT
           echo "base=$base" >> $GITHUB_OUTPUT
@@ -126,7 +106,7 @@ jobs:
         id: previous-deploys
         uses: access-nri/build-cd/.github/actions/get-pr-deployments@v7
         with:
-          pr: ${{ inputs.pr }}
+          pr: ${{ env.PR_NUMBER }}
 
       - name: Branch metadata
         id: prerelease
@@ -138,7 +118,7 @@ jobs:
           echo "Next Deployment Number is ${{ steps.previous-deploys.outputs.deployments }} + $next_deployment_is_pr_deployment = $next_deployment_number"
           echo "next-deployment-number=$next_deployment_number" >> $GITHUB_OUTPUT
 
-          version="pr${{ inputs.pr }}-$next_deployment_number"
+          version="pr${{ env.PR_NUMBER }}-$next_deployment_number"
           echo "Prerelease version will be $version"
           echo "version=$version" >> $GITHUB_OUTPUT
 
@@ -148,11 +128,21 @@ jobs:
         with:
           targets: ${{ vars.PRERELEASE_DEPLOYMENT_TARGETS }}
 
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.pr.outputs.head }}
+
+      - name: Get Deployment Name from Spack Manifest
+        id: manifest
+        uses: access-nri/build-cd/.github/actions/get-spack-manifest@v8
+        with:
+          spack-manifest-path: ${{ inputs.spack-manifest-path }}
+
   redeploy-pre:
     name: '!redeploy Pending'
     if: github.event_name == 'issue_comment' && startsWith(github.event.comment.body, '!redeploy')
     needs:
-      - defaults
+      - init
     runs-on: ubuntu-latest
     permissions:
       statuses: write
@@ -188,38 +178,38 @@ jobs:
         # We don't want to use history expansion (the '!')
         shell: bash +H {0}
         run: |
-          echo 'context=!redeploy Number ${{ needs.defaults.outputs.next-deployment-number }}' >> $GITHUB_OUTPUT
+          echo 'context=!redeploy Number ${{ needs.init.outputs.next-deployment-number }}' >> $GITHUB_OUTPUT
           echo 'description=Redeploy Prerelease' >> $GITHUB_OUTPUT
 
       - name: Set Commit Status Pending
         uses: myrotvorets/set-commit-status-action@3730c0a348a2ace3c110851bed53331bc6406e9f  # v2.0.1
         with:
           status: pending
-          sha: ${{ needs.defaults.outputs.head-sha }}
+          sha: ${{ needs.init.outputs.head-sha }}
           context: ${{ steps.commit-status-args.outputs.context }}
           description: ${{ steps.commit-status-args.outputs.description }}
 
   deploy:
     name: Deploy
     needs:
-      - defaults
+      - init
     strategy:
       fail-fast: false
       matrix:
         # Example: ['Gadi', 'Setonix', ...]
-        target: ${{ fromJson(needs.defaults.outputs.targets) }}
+        target: ${{ fromJson(needs.init.outputs.targets) }}
     uses: access-nri/build-cd/.github/workflows/deploy-1-setup.yml@v8
     with:
       deployment-target: ${{ matrix.target }}
-      deployment-ref: ${{ needs.defaults.outputs.head-ref }}
+      deployment-ref: ${{ needs.init.outputs.head-ref }}
       deployment-type: Prerelease
       # The prerelease looks like: `pr<pull request number>-<number of deployments of pull request>`.
       # Ex. Pull Request #12 with 2 deployments on branch -> `pr12-2`.
       # Note that for multi-target prereleases, they share the same deployment number.
-      deployment-version: ${{ needs.defaults.outputs.prerelease-version }}
-      prerelease-compare-ref: ${{ needs.defaults.outputs.base-ref }}
+      deployment-version: ${{ needs.init.outputs.prerelease-version }}
+      prerelease-compare-ref: ${{ needs.init.outputs.base-ref }}
       spack-manifest-path: ${{ inputs.spack-manifest-path }}
-      expected-root-spec-name: ${{ needs.defaults.outputs.root-sbd }}
+      expected-root-spec-name: ${{ needs.init.outputs.deployment-name }}
       # Pass versions and paths for schemas into the deploy workflow
       spack-manifest-schema-path: ${{ inputs.spack-manifest-schema-path }}
       spack-manifest-schema-version: ${{ inputs.spack-manifest-schema-version }}
@@ -234,7 +224,7 @@ jobs:
     # failed, skipped, cancelled redeploy = failure commit status
     if: always() && needs.redeploy-pre.result == 'success'
     needs:
-      - defaults  # to get access to the head-sha
+      - init  # to get access to the head-sha
       - redeploy-pre  # to get the initial commit status context and description
       - deploy  # to get the overall status of this workflow
     runs-on: ubuntu-latest
@@ -252,7 +242,7 @@ jobs:
         uses: myrotvorets/set-commit-status-action@3730c0a348a2ace3c110851bed53331bc6406e9f  # v2.0.1
         with:
           status: ${{ needs.deploy.result == 'success' && 'success' || 'failure' }}
-          sha: ${{ needs.defaults.outputs.head-sha }}
+          sha: ${{ needs.init.outputs.head-sha }}
           context: ${{ needs.redeploy-pre.outputs.commit-status-context }}
           description: ${{ needs.redeploy-pre.outputs.commit-status-description }}
 
@@ -260,7 +250,7 @@ jobs:
     name: Post-Deploy Notifier
     if: always()
     needs:
-      - defaults  # so we can access `inputs.root-sbd` that could have defaulted to `inputs.model`
+      - init  # so we can access `inputs.root-sbd` that could have defaulted to `inputs.model`
       - deploy  # so we can access deployment information such as versions used, status of deployments, etc.
     runs-on: ubuntu-latest
     permissions:
@@ -311,11 +301,11 @@ jobs:
         # Creates a comment of the form: https://github.com/ACCESS-NRI/ACCESS-TEST/pull/15#issuecomment-2558675980
         env:
           J2_MODEL: ${{ inputs.model }}
-          J2_PRERELEASE_VERSION: ${{ needs.defaults.outputs.prerelease-version }}
-          J2_ROOT_SBD: ${{ needs.defaults.outputs.root-sbd }}
+          J2_PRERELEASE_VERSION: ${{ needs.init.outputs.prerelease-version }}
+          J2_ROOT_SBD: ${{ needs.init.outputs.deployment-name }}
           J2_DEPLOYMENT_ERRORS: ${{ steps.deployment-rollup.outputs.errors }}
           J2_CONFIG_ERRORS: ${{ steps.config-rollup.outputs.errors }}
-          J2_HEAD_SHA: ${{ needs.defaults.outputs.head-sha }}
+          J2_HEAD_SHA: ${{ needs.init.outputs.head-sha }}
           J2_RUN_URL: ${{ env.RUN_URL }}
           J2_SPACK_MANIFEST_PATH: ${{ inputs.spack-manifest-path }}
         run: |
@@ -336,9 +326,9 @@ jobs:
           PR_BODY_PATH: ./body.txt
           PR_BODY_PATH_UPDATED: ./updated.body.txt
           PRERELEASE_SECTION_REGEX: "^:rocket: .* :rocket:$"
-          PRERELEASE_SECTION: ":rocket: The latest prerelease `${{ needs.defaults.outputs.root-sbd }}/${{ needs.defaults.outputs.prerelease-version }}` at ${{ needs.defaults.outputs.head-sha }} is here: ${{ steps.comment.outputs.comment-link }} :rocket:"
+          PRERELEASE_SECTION: ":rocket: The latest prerelease `${{ needs.init.outputs.deployment-name }}/${{ needs.init.outputs.prerelease-version }}` at ${{ needs.init.outputs.head-sha }} is here: ${{ steps.comment.outputs.comment-link }} :rocket:"
         run: |
-          gh pr view ${{ inputs.pr }} --repo ${{ github.repository }} --json body --jq .body > ${{ env.PR_BODY_PATH }}
+          gh pr view ${{ env.PR_NUMBER }} --repo ${{ github.repository }} --json body --jq .body > ${{ env.PR_BODY_PATH }}
 
           # `awk` is a series of `CONDITION { ACTION }` pairs. No 'CONDITION' means 'TRUE', no '{ ACTION }' means 'print'.
           if grep -q '${{ env.PRERELEASE_SECTION_REGEX }}' ${{ env.PR_BODY_PATH }}; then  # there is an existing prerelease section
@@ -354,4 +344,4 @@ jobs:
 
           cat ${{ env.PR_BODY_PATH_UPDATED }}
 
-          gh pr edit ${{ inputs.pr }} --repo ${{ github.repository }} --body-file ${{ env.PR_BODY_PATH_UPDATED }}
+          gh pr edit ${{ env.PR_NUMBER }} --repo ${{ github.repository }} --body-file ${{ env.PR_BODY_PATH_UPDATED }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,10 +18,10 @@ on:
       spack-manifest-path:
         type: string
         required: false
-        default: ./spack.yaml
+        default: spack.yaml
         description: |
           The Spack manifest path relative to the caller repository that will be used for the deployment.
-          This is usually `./spack.yaml`, but can be overridden if needed.
+          This is usually `spack.yaml`, but can be overridden if needed.
       spack-manifest-schema-path:
         type: string
         required: false

--- a/tests/scripts/jinja_template/inputs/deploy-outputs.Gadi
+++ b/tests/scripts/jinja_template/inputs/deploy-outputs.Gadi
@@ -1,7 +1,7 @@
 {
   "model_name": "ACCESS-ISSM",
   "model_deployment_repository": "https://github.com/ACCESS-NRI/ACCESS-ISSM",
-  "model_deployment_repository_spack_manifest_path": "./spack.yaml",
+  "model_deployment_repository_spack_manifest_path": "spack.yaml",
   "spack_version": "0.22",
   "spack_git_hash": "ee9a10e5cafdcd3224b436d3f477a73ef8669b4b",
   "spack_config_version": "2024.11.27",

--- a/tests/scripts/jinja_template/inputs/deploy-outputs.Setonix
+++ b/tests/scripts/jinja_template/inputs/deploy-outputs.Setonix
@@ -1,7 +1,7 @@
 {
   "model_name": "ACCESS-ISSM",
   "model_deployment_repository": "https://github.com/ACCESS-NRI/ACCESS-ISSM",
-  "model_deployment_repository_spack_manifest_path": "./spack.yaml",
+  "model_deployment_repository_spack_manifest_path": "spack.yaml",
   "spack_version": "0.22",
   "spack_git_hash": "ee9a10e5cafdcd3224b436d3f477a73ef8669b4b",
   "spack_config_version": "2024.11.27",


### PR DESCRIPTION
Closes #342
References #326

> [!IMPORTANT]
> This is a major update to the infrastructure (due to the removal of an entrypoint input). However, it is being rolled into the proposed `v8` changes in ACCESS-NRI/build-cd#326

## Background

While we are making major-level changes, we might as well go through the entrypoint inputs. 

As we move towards the Reserved Definition `_name` being used as the root spec, we no longer need the MDR to populate this as an entrypoint input - it creates duplication.

Futhermore, some entrypoints were still requiring the MDR to populate the `PR` number depending on if the trigger was `on.pull_request` vs `on.issue_comment` - we can infer that from the caller ourselves. 

Finally, some entrypoints did not have a `spack-manifest-path` input - even if we don't intend to go past the default of `./spack.yaml`, it's good to have all the entrypoints in line with this. 

## The PR

- **ci: Removed entrypoint inputs.root-sbd, inputs.pr**
- **cd: Removed entrypoint inputs.root-sbd**
- **ci-closed: Removed entrypoint inputs.root-sbd, added inputs.spack-manifest-path**
- **ci-command-configs: Removed entrypoint inputs.root-sbd, added inputs.spack-manifest-path, removed caller path for checkout**
- **ci-comment (!bump): Removed entrypoint inputs.root-sbd, added inputs.spack-manifest-path**

## Testing

Success - see https://github.com/ACCESS-NRI/ACCESS-TEST/actions/runs/21159184318/job/60850244732?pr=62

## Once Merged...

- [x] Update all MDRs to remove the deprecated entrypoint inputs, and add ones that are needed