### PR TITLE
Update spack v1.1 to v1.1.1

### DIFF
--- a/config/settings.json
+++ b/config/settings.json
@@ -12,7 +12,7 @@
           "spack-config": "2026.02.000"
         },
         "1.1": {
-          "spack": "89b3f0baae13477ee5384cd30ebf512489a69890",
+          "spack": "2e2169d5282d166f63e3ee4db8d4446c43cefa8a",
           "spack-config": "2026.02.001",
           "builtin-spack-packages": "8ed34337e15d759890b68682d704aa55dd243537"
         }
@@ -23,7 +23,7 @@
           "spack-config": "2026.02.000"
         },
         "1.1": {
-          "spack": "89b3f0baae13477ee5384cd30ebf512489a69890",
+          "spack": "2e2169d5282d166f63e3ee4db8d4446c43cefa8a",
           "spack-config": "2026.02.001",
           "builtin-spack-packages": "8ed34337e15d759890b68682d704aa55dd243537"
         }


### PR DESCRIPTION
## Background

Spack has a new tag, `v1.1.1`. This PR updates the Pre/Release instances of `spack v1.1` to use the latest commit as part of `v1.1.1`.
