### PR TITLE
Correct spack v1.1 builtin-spack-packages to spack-config version

### DIFF
--- a/config/settings.json
+++ b/config/settings.json
@@ -14,7 +14,7 @@
         "1.1": {
           "spack": "2e2169d5282d166f63e3ee4db8d4446c43cefa8a",
           "spack-config": "2026.02.001",
-          "builtin-spack-packages": "8ed34337e15d759890b68682d704aa55dd243537"
+          "builtin-spack-packages": "39aeb9dbcc13b6a53e40c77b672c397e1f4c93ec"
         }
       },
       "Prerelease": {
@@ -25,7 +25,7 @@
         "1.1": {
           "spack": "2e2169d5282d166f63e3ee4db8d4446c43cefa8a",
           "spack-config": "2026.02.001",
-          "builtin-spack-packages": "8ed34337e15d759890b68682d704aa55dd243537"
+          "builtin-spack-packages": "39aeb9dbcc13b6a53e40c77b672c397e1f4c93ec"
         }
       }
     }


### PR DESCRIPTION
## Background

For some reason, `spack v1.1` Pre/Release is using an older version of `builtin-spack-packages`. This PR updates it to be in line with `spack-config`s values for it. 

Future updates to `build-cd` mean that this `builtin-spack-packages` key will be removed, as we will be informed by `spack-config` for the `builtin-spack-packages` repo. 
