### PR TITLE
`!update-configs` Comment Command Fixes

### DIFF
--- a/.github/workflows/ci-command-configs.yml
+++ b/.github/workflows/ci-command-configs.yml
@@ -223,7 +223,7 @@ jobs:
           echo "Checking PR branch $pr_branch_name from ${{ env.CONFIG }}..."
           git -C caller-configs checkout ${{ env.CONFIG }}
 
-          if git -C caller-configs ls-remote --exit-code --heads origin $pr_branch_name; then
+          if git -C caller-configs ls-remote --exit-code --heads origin $pr_branch_name &> /dev/null; then
             git -C caller-configs checkout $pr_branch_name
           else
             git -C caller-configs checkout -b $pr_branch_name
@@ -250,7 +250,7 @@ jobs:
           git -C caller-configs commit -am "auto: use ${{ env.DEPLOYMENT_IDENTIFIER }} from ${{ env.RUN_URL }}"
           git -C caller-configs push
 
-          if ! gh pr view; then
+          if ! pr_url=$(gh pr view --json url --jq .url 2>/dev/null); then
             echo "Opening PR for branch $pr_branch_name in repo ${{ needs.setup.outputs.configs-repo }}..."
             pr_url=$(gh pr create \
               --draft \
@@ -263,7 +263,6 @@ jobs:
             echo "pr_url=$pr_url" >> $GITHUB_OUTPUT
             echo "::notice:: Opened $pr_url"
           else
-            pr_url=$(gh pr view --json url --jq .url)
             echo "pr_url=$pr_url" >> $GITHUB_OUTPUT
             echo "::notice:: Updated $pr_url"
           fi

--- a/.github/workflows/ci-command-configs.yml
+++ b/.github/workflows/ci-command-configs.yml
@@ -218,18 +218,17 @@ jobs:
         env:
           DEPLOYMENT_IDENTIFIER: ${{ needs.setup.outputs.deployment-name }}/pr${{ github.event.issue.number }}-${{ steps.previous-deployments.outputs.deployments }}
         run: |
-          pr_branch_name="auto/pr${{ github.event.issue.number }}-${{ steps.previous-deployments.outputs.deployments }}/${{ env.CONFIG }}"
+          pr_branch_name="auto/pr${{ github.event.issue.number }}/${{ env.CONFIG }}"
 
-          echo "Creating PR branch $pr_branch_name from ${{ env.CONFIG }}..."
+          echo "Checking PR branch $pr_branch_name from ${{ env.CONFIG }}..."
           git -C caller-configs checkout ${{ env.CONFIG }}
 
           if git -C caller-configs ls-remote --exit-code --heads origin $pr_branch_name; then
-            # TODO: Feature: Append to the existing PR instead of continuing
-            echo "::error::Branch $pr_branch_name already exists for ${{ env.CONFIG }}, so a gh PR can't be created from it"
-            exit 1
+            git -C caller-configs checkout $pr_branch_name
+          else
+            git -C caller-configs checkout -b $pr_branch_name
+            git -C caller-configs push --set-upstream origin $pr_branch_name
           fi
-
-          git -C caller-configs checkout -b $pr_branch_name
 
           if [ ! -f caller-configs/config.yaml ]; then
             echo "::error::File config.yaml not found in ${{ needs.setup.outputs.configs-repo }} on branch ${{ env.CONFIG }}, cannot automatically open configs PRs"
@@ -248,21 +247,26 @@ jobs:
 
           echo "Committing and pushing changes..."
           git -C caller-configs diff
-          git -C caller-configs commit -am "Auto update to use ${{ env.DEPLOYMENT_IDENTIFIER }} as part of ${{ env.RUN_URL }}"
-          git -C caller-configs push --set-upstream origin $pr_branch_name
+          git -C caller-configs commit -am "auto: use ${{ env.DEPLOYMENT_IDENTIFIER }} from ${{ env.RUN_URL }}"
+          git -C caller-configs push
 
-          echo "Opening PR for branch $pr_branch_name in repo ${{ needs.setup.outputs.configs-repo }}..."
-          pr_url=$(gh pr create \
-            --draft \
-            --repo "${{ needs.setup.outputs.configs-repo }}" \
-            --title "Auto update ${{ env.CONFIG }} to use ${{ env.DEPLOYMENT_IDENTIFIER }}" \
-            --body "Auto-generated PR to update ${{ env.CONFIG }} to use ${{ env.DEPLOYMENT_IDENTIFIER }} from ${{ github.repository }}#${{ github.event.issue.number }}, see ${{ env.RUN_URL }}" \
-            --head "$pr_branch_name" \
-            --base "${{ env.CONFIG }}"
-          )
-
-          echo "::notice::Opened PR: $pr_url"
-          echo "pr_url=$pr_url" >> $GITHUB_OUTPUT
+          if ! gh pr view; then
+            echo "Opening PR for branch $pr_branch_name in repo ${{ needs.setup.outputs.configs-repo }}..."
+            pr_url=$(gh pr create \
+              --draft \
+              --repo "${{ needs.setup.outputs.configs-repo }}" \
+              --title "Auto update ${{ env.CONFIG }} to use ${{ env.DEPLOYMENT_IDENTIFIER }}" \
+              --body "Auto-generated PR to update ${{ env.CONFIG }} to use ${{ env.DEPLOYMENT_IDENTIFIER }} from ${{ github.repository }}#${{ github.event.issue.number }}, see ${{ env.RUN_URL }}" \
+              --head "$pr_branch_name" \
+              --base "${{ env.CONFIG }}"
+            )
+            echo "pr_url=$pr_url" >> $GITHUB_OUTPUT
+            echo "::notice:: Opened $pr_url"
+          else
+            pr_url=$(gh pr view --json url --jq .url)
+            echo "pr_url=$pr_url" >> $GITHUB_OUTPUT
+            echo "::notice:: Updated $pr_url"
+          fi
 
       - name: Determine if repro check required
         id: repro-check

--- a/scripts/jinja_template/templates/auto-prs-comment-body.md.j2
+++ b/scripts/jinja_template/templates/auto-prs-comment-body.md.j2
@@ -1,4 +1,4 @@
-:wrench: Opening Model Configuration PRs in `{{ model_configs_repo if model_configs_repo != '' else 'an unknown configs repository' }}`
+:wrench: Opening/Updating Model Configuration PRs in `{{ model_configs_repo if model_configs_repo != '' else 'an unknown configs repository' }}`
 
 {% if error == 'true' %}
 :x: One or more errors occurred with the workflow
@@ -19,15 +19,15 @@ No configs were requested.
 </details>
 
 <details>
-<summary>Pull Requests Opened</summary>
+<summary>Pull Requests Opened/Updated</summary>
 
 {% if pr_urls %}
-The following PRs were opened:
+The following PRs were opened/updated:
 {% for pr_url in pr_urls.split() %}
 - {{ pr_url }}
 {% endfor %}
 {% else %}
-No PRs were opened
+No PRs were opened/updated
 {% endif %}
 
 </details>

--- a/scripts/model_config_manifest/prerelease_update.py
+++ b/scripts/model_config_manifest/prerelease_update.py
@@ -1,7 +1,7 @@
 import argparse
-import re
 import sys
-import yaml
+
+import ruamel.yaml
 
 # Essentially we are looking to do the following substitutions in yq:
 # yq -i '.modules.use += ["/g/data/vk83/prerelease/modules"]' config.yaml
@@ -124,9 +124,12 @@ def parse_args(args: list[str]) -> argparse.Namespace:
 
 def main():
     args = parse_args(sys.argv[1:])
+    
+    yaml=ruamel.yaml.YAML()
+    yaml.preserve_quotes = True
 
     with open(args.manifest, "r") as f:
-        manifest = yaml.safe_load(f)
+        manifest = yaml.load(f)
 
     updated_manifest = update_model_config_manifest(
         manifest,
@@ -136,7 +139,7 @@ def main():
     )
 
     with open(args.manifest, "w") as f:
-        yaml.safe_dump(updated_manifest, f)
+        yaml.dump(updated_manifest, f)
 
 
 if __name__ == "__main__":

--- a/scripts/model_config_manifest/prerelease_update.py
+++ b/scripts/model_config_manifest/prerelease_update.py
@@ -124,9 +124,19 @@ def parse_args(args: list[str]) -> argparse.Namespace:
 
 def main():
     args = parse_args(sys.argv[1:])
-    
+
+    # Setting up the YAML parser...
     yaml=ruamel.yaml.YAML()
+    # To cut down on large diffs, keep the original quoting of config.yaml
     yaml.preserve_quotes = True
+    # Some files have 'foo: null' being updated to 'foo: ' - this will ensure that
+    # original 'null' values are still represented as 'null'
+    yaml.representer.add_representer(
+        type(None), lambda self, _: self.represent_scalar("tag:yaml.org,2002:null", "null")
+    )
+    # Some extra-long values are being wrapped, which increases the diff size.
+    # This ensures that wrapping only occurs at the extreme end of file width...
+    yaml.width = 1000
 
     with open(args.manifest, "r") as f:
         manifest = yaml.load(f)

--- a/scripts/model_config_manifest/requirements.txt
+++ b/scripts/model_config_manifest/requirements.txt
@@ -1,1 +1,1 @@
-PyYAML==6.0.2
+ruamel.yaml==0.19.1


### PR DESCRIPTION
Closes #354
Closes #341

## Background

The `!update-configs` comment command has been pretty useful so far, but there are a couple of issues aluded to in the above issues. Namely:

* The updated `config.yaml` has it's keys sorted, and removes comments, leading to a large diff
* New branches are created for every invocation of `!update-configs`, of the form `auto/prX-Y/CONFIG`, for each prerelease build

The fixes in this PR address both of these, respectively:

* We now use `ruamel` over `PyYaml`, which preserves comments and doesn't sort keys by default
* We now append commits to the `auto/prX/CONFIG` branch if a PR already exists. Note the lack of a `-Y` in `prX-Y` - we now create branches based on MDR PRs, not individual builds

## The PR

- **Use ruamel instead of PyYaml to preserve order/comments**
- **Append commits to existing auto/prX/CONFIG PR if they are from the same MDR PR**

## Testing

### Testing of the script

Testing of the script itself was done on the `config.yaml` of https://github.com/ACCESS-NRI/access-om3-configs/blob/release-MC_25km_jra_iaf/config.yaml, giving the following diff, mostly with whitespace changes:

<details>
<summary>Large diff in this section</summary>

```diff
@@ -9,19 +9,19 @@
 # Using payu sync is recommend to copy data from ephemeral scratch space to 
 # longer term storage
 sync:
-    enable: False # set path below and change to true
-    path: null # Set to location on /g/data (e.g. /g/data/PROJECT/USER/EXPERIMENT)
-    restarts: True
-    exclude_uncollated: False
+  enable: false   # set path below and change to true
+  path: null   # Set to location on /g/data (e.g. /g/data/PROJECT/USER/EXPERIMENT)
+  restarts: true
+  exclude_uncollated: false
 
 #Model software version
 modules:
-    use:
-        - /g/data/vk83/modules
-    load:
-        - access-om3/2025.08.001
-        - model-tools/mppnccombine-fast
-
+  use:
+  - /g/data/vk83/modules
+  - /g/data/vk83/prerelease/modules
+  load:
+  - access-om3/prX-Y
+  - model-tools/mppnccombine-fast
 queue: normalsr
 ncpus: 2704
 jobfs: 10GB
@@ -32,34 +32,34 @@ jobname: 25km_jra_iaf
 model: access-om3
 exe: access-om3-MOM6-CICE6
 input:
-    - /g/data/vk83/configurations/inputs/access-om3/cice/grids/global.25km/2025.11.27/kmt.nc
-    - /g/data/vk83/configurations/inputs/access-om3/mom/grids/mosaic/global.25km/2025.09.02/ocean_hgrid.nc
-    - /g/data/vk83/configurations/inputs/access-om3/mom/grids/vertical/global.25km/2025.03.12/ocean_vgrid.nc
-    - /g/data/vk83/configurations/inputs/access-om3/mom/initial_conditions/global.25km/2025.10.24/woa23_ts_01_mom.nc
-    - /g/data/vk83/configurations/inputs/access-om3/mom/surface_salt_restoring/global.25km/2025.10.24/salt_sfc_restore.nc
-    - /g/data/vk83/configurations/inputs/access-om3/mom/tidal_external_files/global.25km/2025.09.03/bottom_roughness.nc
-    - /g/data/vk83/configurations/inputs/access-om3/mom/tidal_external_files/global.25km/2025.09.03/tideamp.nc
-    - /g/data/vk83/configurations/inputs/access-om3/share/grids/global.25km/2025.11.27/topog.nc
-    - /g/data/vk83/configurations/inputs/access-om3/mom/chlorophyll/global.25km/2025.11.21/chl_globcolour_monthly_clim.nc
-    - /g/data/vk83/configurations/inputs/access-om3/share/meshes/global.25km/2025.11.27/access-om3-25km-ESMFmesh.nc
-    - /g/data/vk83/configurations/inputs/access-om3/share/meshes/global.25km/2025.11.27/access-om3-25km-nomask-ESMFmesh.nc
-    - /g/data/vk83/configurations/inputs/access-om3/share/meshes/share/2024.09.16/JRA55do-datm-ESMFmesh.nc
-    - /g/data/vk83/configurations/inputs/access-om3/share/meshes/share/2024.09.16/JRA55do-drof-ESMFmesh.nc
-    - /g/data/vk83/configurations/inputs/access-om3/cmeps/remap_weights/global.25km/2025.11.27/access-om3-25km-rof-remap-weights.nc
-    - /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/
-    - /g/data/vk83/configurations/inputs/access-om3/share/grids/global.25km/2025.11.27/mask_table.1038.63x56
+- /g/data/vk83/configurations/inputs/access-om3/cice/grids/global.25km/2025.11.27/kmt.nc
+- /g/data/vk83/configurations/inputs/access-om3/mom/grids/mosaic/global.25km/2025.09.02/ocean_hgrid.nc
+- /g/data/vk83/configurations/inputs/access-om3/mom/grids/vertical/global.25km/2025.03.12/ocean_vgrid.nc
+- /g/data/vk83/configurations/inputs/access-om3/mom/initial_conditions/global.25km/2025.10.24/woa23_ts_01_mom.nc
+- /g/data/vk83/configurations/inputs/access-om3/mom/surface_salt_restoring/global.25km/2025.10.24/salt_sfc_restore.nc
+- /g/data/vk83/configurations/inputs/access-om3/mom/tidal_external_files/global.25km/2025.09.03/bottom_roughness.nc
+- /g/data/vk83/configurations/inputs/access-om3/mom/tidal_external_files/global.25km/2025.09.03/tideamp.nc
+- /g/data/vk83/configurations/inputs/access-om3/share/grids/global.25km/2025.11.27/topog.nc
+- /g/data/vk83/configurations/inputs/access-om3/mom/chlorophyll/global.25km/2025.11.21/chl_globcolour_monthly_clim.nc
+- /g/data/vk83/configurations/inputs/access-om3/share/meshes/global.25km/2025.11.27/access-om3-25km-ESMFmesh.nc
+- /g/data/vk83/configurations/inputs/access-om3/share/meshes/global.25km/2025.11.27/access-om3-25km-nomask-ESMFmesh.nc
+- /g/data/vk83/configurations/inputs/access-om3/share/meshes/share/2024.09.16/JRA55do-datm-ESMFmesh.nc
+- /g/data/vk83/configurations/inputs/access-om3/share/meshes/share/2024.09.16/JRA55do-drof-ESMFmesh.nc
+- /g/data/vk83/configurations/inputs/access-om3/cmeps/remap_weights/global.25km/2025.11.27/access-om3-25km-rof-remap-weights.nc
+- /g/data/qv56/replicas/input4MIPs/CMIP6Plus/OMIP/MRI/MRI-JRA55-do-1-6-0/
+- /g/data/vk83/configurations/inputs/access-om3/share/grids/global.25km/2025.11.27/mask_table.1038.63x56
 
 runlog: true
-metadata: 
-    enable: true
+metadata:
+  enable: true
 manifest:
   reproduce:
-    exe: True
-    input: True
+    exe: false
+    input: true
 
 platform:
-    nodesize: 104
-    nodemem: 512
+  nodesize: 104
+  nodemem: 512
 
 collate:
   restart: true
@@ -71,7 +71,7 @@ collate:
   exe: mppnccombine-fast
 
 userscripts:
-    archive: /usr/bin/bash /g/data/vk83/apps/om3-scripts/payu_config/archive.sh
+  archive: /usr/bin/bash /g/data/vk83/apps/om3-scripts/payu_config/archive.sh
 
 postscript: -v PROJECT,SCRIPTS_DIR=/g/data/vk83/apps/om3-scripts -lstorage=${PBS_NCI_STORAGE}+gdata/xp65 /g/data/vk83/apps/om3-scripts/payu_config/postscript.sh
```

</details>

Without the whitespace changes:

```diff
@@ -18,10 +18,10 @@ sync:
 modules:
   use:
   - /g/data/vk83/modules
+  - /g/data/vk83/prerelease/modules
   load:
-  - access-om3/2025.08.001
+  - access-om3/prX-Y
   - model-tools/mppnccombine-fast
-
 queue: normalsr
 ncpus: 2704
 jobfs: 10GB
@@ -54,7 +54,7 @@ metadata:
   enable: true
 manifest:
   reproduce:
-    exe: true
+    exe: false
     input: true
 
 platform:
```

### Local testing of the workflow

The workflow was tested locally by desk-checking the commands run, to `access-nri/access-test-configs`, and worked successfully. 

---------------

Pinging @dougiesquire as he alerted me to these issues - thanks!
