### PR TITLE
`!update-configs` Comment Command Fixes - `v7` Backport

### DIFF
--- a/.github/workflows/ci-command-configs.yml
+++ b/.github/workflows/ci-command-configs.yml
@@ -230,7 +230,7 @@ jobs:
           echo "Checking PR branch $pr_branch_name from ${{ env.CONFIG }}..."
           git -C caller-configs checkout ${{ env.CONFIG }}
 
-          if git -C caller-configs ls-remote --exit-code --heads origin $pr_branch_name; then
+          if git -C caller-configs ls-remote --exit-code --heads origin $pr_branch_name &> /dev/null; then
             git -C caller-configs checkout $pr_branch_name
           else
             git -C caller-configs checkout -b $pr_branch_name
@@ -257,7 +257,7 @@ jobs:
           git -C caller-configs commit -am "auto: use ${{ env.DEPLOYMENT_IDENTIFIER }} from ${{ env.RUN_URL }}"
           git -C caller-configs push
 
-          if ! gh pr view; then
+          if ! pr_url=$(gh pr view --json url --jq .url 2>/dev/null); then
             echo "Opening PR for branch $pr_branch_name in repo ${{ needs.setup.outputs.configs-repo }}..."
             pr_url=$(gh pr create \
               --draft \
@@ -270,7 +270,6 @@ jobs:
             echo "pr_url=$pr_url" >> $GITHUB_OUTPUT
             echo "::notice:: Opened $pr_url"
           else
-            pr_url=$(gh pr view --json url --jq .url)
             echo "pr_url=$pr_url" >> $GITHUB_OUTPUT
             echo "::notice:: Updated $pr_url"
           fi

--- a/.github/workflows/ci-command-configs.yml
+++ b/.github/workflows/ci-command-configs.yml
@@ -225,18 +225,17 @@ jobs:
         env:
           DEPLOYMENT_IDENTIFIER: ${{ needs.setup.outputs.root-sbd }}/pr${{ github.event.issue.number }}-${{ steps.previous-deployments.outputs.deployments }}
         run: |
-          pr_branch_name="auto/pr${{ github.event.issue.number }}-${{ steps.previous-deployments.outputs.deployments }}/${{ env.CONFIG }}"
+          pr_branch_name="auto/pr${{ github.event.issue.number }}/${{ env.CONFIG }}"
 
-          echo "Creating PR branch $pr_branch_name from ${{ env.CONFIG }}..."
+          echo "Checking PR branch $pr_branch_name from ${{ env.CONFIG }}..."
           git -C caller-configs checkout ${{ env.CONFIG }}
 
           if git -C caller-configs ls-remote --exit-code --heads origin $pr_branch_name; then
-            # TODO: Feature: Append to the existing PR instead of continuing
-            echo "::error::Branch $pr_branch_name already exists for ${{ env.CONFIG }}, so a gh PR can't be created from it"
-            exit 1
+            git -C caller-configs checkout $pr_branch_name
+          else
+            git -C caller-configs checkout -b $pr_branch_name
+            git -C caller-configs push --set-upstream origin $pr_branch_name
           fi
-
-          git -C caller-configs checkout -b $pr_branch_name
 
           if [ ! -f caller-configs/config.yaml ]; then
             echo "::error::File config.yaml not found in ${{ needs.setup.outputs.configs-repo }} on branch ${{ env.CONFIG }}, cannot automatically open configs PRs"
@@ -255,21 +254,26 @@ jobs:
 
           echo "Committing and pushing changes..."
           git -C caller-configs diff
-          git -C caller-configs commit -am "Auto update to use ${{ env.DEPLOYMENT_IDENTIFIER }} as part of ${{ env.RUN_URL }}"
-          git -C caller-configs push --set-upstream origin $pr_branch_name
+          git -C caller-configs commit -am "auto: use ${{ env.DEPLOYMENT_IDENTIFIER }} from ${{ env.RUN_URL }}"
+          git -C caller-configs push
 
-          echo "Opening PR for branch $pr_branch_name in repo ${{ needs.setup.outputs.configs-repo }}..."
-          pr_url=$(gh pr create \
-            --draft \
-            --repo "${{ needs.setup.outputs.configs-repo }}" \
-            --title "Auto update ${{ env.CONFIG }} to use ${{ env.DEPLOYMENT_IDENTIFIER }}" \
-            --body "Auto-generated PR to update ${{ env.CONFIG }} to use ${{ env.DEPLOYMENT_IDENTIFIER }} from ${{ github.repository }}#${{ github.event.issue.number }}, see ${{ env.RUN_URL }}" \
-            --head "$pr_branch_name" \
-            --base "${{ env.CONFIG }}"
-          )
-
-          echo "::notice::Opened PR: $pr_url"
-          echo "pr_url=$pr_url" >> $GITHUB_OUTPUT
+          if ! gh pr view; then
+            echo "Opening PR for branch $pr_branch_name in repo ${{ needs.setup.outputs.configs-repo }}..."
+            pr_url=$(gh pr create \
+              --draft \
+              --repo "${{ needs.setup.outputs.configs-repo }}" \
+              --title "Auto update ${{ env.CONFIG }} to use ${{ env.DEPLOYMENT_IDENTIFIER }}" \
+              --body "Auto-generated PR to update ${{ env.CONFIG }} to use ${{ env.DEPLOYMENT_IDENTIFIER }} from ${{ github.repository }}#${{ github.event.issue.number }}, see ${{ env.RUN_URL }}" \
+              --head "$pr_branch_name" \
+              --base "${{ env.CONFIG }}"
+            )
+            echo "pr_url=$pr_url" >> $GITHUB_OUTPUT
+            echo "::notice:: Opened $pr_url"
+          else
+            pr_url=$(gh pr view --json url --jq .url)
+            echo "pr_url=$pr_url" >> $GITHUB_OUTPUT
+            echo "::notice:: Updated $pr_url"
+          fi
 
       - name: Determine if repro check required
         id: repro-check

--- a/scripts/jinja_template/templates/auto-prs-comment-body.md.j2
+++ b/scripts/jinja_template/templates/auto-prs-comment-body.md.j2
@@ -1,4 +1,4 @@
-:wrench: Opening Model Configuration PRs in `{{ model_configs_repo if model_configs_repo != '' else 'an unknown configs repository' }}`
+:wrench: Opening/Updating Model Configuration PRs in `{{ model_configs_repo if model_configs_repo != '' else 'an unknown configs repository' }}`
 
 {% if error == 'true' %}
 :x: One or more errors occurred with the workflow
@@ -19,15 +19,15 @@ No configs were requested.
 </details>
 
 <details>
-<summary>Pull Requests Opened</summary>
+<summary>Pull Requests Opened/Updated</summary>
 
 {% if pr_urls %}
-The following PRs were opened:
+The following PRs were opened/updated:
 {% for pr_url in pr_urls.split() %}
 - {{ pr_url }}
 {% endfor %}
 {% else %}
-No PRs were opened
+No PRs were opened/updated
 {% endif %}
 
 </details>

--- a/scripts/model_config_manifest/prerelease_update.py
+++ b/scripts/model_config_manifest/prerelease_update.py
@@ -1,7 +1,7 @@
 import argparse
-import re
 import sys
-import yaml
+
+import ruamel.yaml
 
 # Essentially we are looking to do the following substitutions in yq:
 # yq -i '.modules.use += ["/g/data/vk83/prerelease/modules"]' config.yaml
@@ -124,9 +124,12 @@ def parse_args(args: list[str]) -> argparse.Namespace:
 
 def main():
     args = parse_args(sys.argv[1:])
+    
+    yaml=ruamel.yaml.YAML()
+    yaml.preserve_quotes = True
 
     with open(args.manifest, "r") as f:
-        manifest = yaml.safe_load(f)
+        manifest = yaml.load(f)
 
     updated_manifest = update_model_config_manifest(
         manifest,
@@ -136,7 +139,7 @@ def main():
     )
 
     with open(args.manifest, "w") as f:
-        yaml.safe_dump(updated_manifest, f)
+        yaml.dump(updated_manifest, f)
 
 
 if __name__ == "__main__":

--- a/scripts/model_config_manifest/prerelease_update.py
+++ b/scripts/model_config_manifest/prerelease_update.py
@@ -124,9 +124,19 @@ def parse_args(args: list[str]) -> argparse.Namespace:
 
 def main():
     args = parse_args(sys.argv[1:])
-    
+
+    # Setting up the YAML parser...
     yaml=ruamel.yaml.YAML()
+    # To cut down on large diffs, keep the original quoting of config.yaml
     yaml.preserve_quotes = True
+    # Some files have 'foo: null' being updated to 'foo: ' - this will ensure that
+    # original 'null' values are still represented as 'null'
+    yaml.representer.add_representer(
+        type(None), lambda self, _: self.represent_scalar("tag:yaml.org,2002:null", "null")
+    )
+    # Some extra-long values are being wrapped, which increases the diff size.
+    # This ensures that wrapping only occurs at the extreme end of file width...
+    yaml.width = 1000
 
     with open(args.manifest, "r") as f:
         manifest = yaml.load(f)

--- a/scripts/model_config_manifest/requirements.txt
+++ b/scripts/model_config_manifest/requirements.txt
@@ -1,1 +1,1 @@
-PyYAML==6.0.2
+ruamel.yaml==0.19.1


### PR DESCRIPTION
References #354
References #341
Backported from #359

## Background

The `!update-configs` comment command has been pretty useful so far, but there are a couple of issues aluded to in the above issues. Namely:

* The updated `config.yaml` has it's keys sorted, and removes comments, leading to a large diff
* New branches are created for every invocation of `!update-configs`, of the form `auto/prX-Y/CONFIG`, for each prerelease build

The fixes in this PR address both of these, respectively:

* We now use `ruamel` over `PyYaml`, which preserves comments and doesn't sort keys by default
* We now append commits to the `auto/prX/CONFIG` branch if a PR already exists. Note the lack of a `-Y` in `prX-Y` - we now create branches based on MDR PRs, not individual builds

## The PR

- **Use ruamel instead of PyYaml to preserve order/comments**
- **Append commits to existing auto/prX/CONFIG PR if they are from the same MDR PR**

## Testing

See https://github.com/ACCESS-NRI/build-cd/pull/359
