### PR TITLE
Instance Update for 1.1: spack-config to 2026.02.003, builtin-spack-packages update

### DIFF
--- a/config/settings.json
+++ b/config/settings.json
@@ -13,8 +13,8 @@
         },
         "1.1": {
           "spack": "2e2169d5282d166f63e3ee4db8d4446c43cefa8a",
-          "spack-config": "2026.02.001",
-          "builtin-spack-packages": "39aeb9dbcc13b6a53e40c77b672c397e1f4c93ec"
+          "spack-config": "2026.02.003",
+          "builtin-spack-packages": "383e969358c951abe17623696083e6f862c4488e"
         }
       },
       "Prerelease": {
@@ -24,8 +24,8 @@
         },
         "1.1": {
           "spack": "2e2169d5282d166f63e3ee4db8d4446c43cefa8a",
-          "spack-config": "2026.02.001",
-          "builtin-spack-packages": "39aeb9dbcc13b6a53e40c77b672c397e1f4c93ec"
+          "spack-config": "2026.02.003",
+          "builtin-spack-packages": "383e969358c951abe17623696083e6f862c4488e"
         }
       }
     }


### PR DESCRIPTION
## Background

We need some commits from the upstream spack-packages that are in `develop` (updated `parallelio` version and updated version of `libtool`).

## The PR

* Update `spack-config` to `2026.02.003` (which updates the `repos.yaml` builtin spack-packages commit
* Update `builtin-spack-packages` to the appropriate builtin commit of https://github.com/spack/spack-packages/commit/383e969358c951abe17623696083e6f862c4488e

> [!NOTE]
> In the future, the `builtin-spack-packages` commit will be solely informed by `spack-config`, so we don't have to update both. See https://github.com/ACCESS-NRI/build-cd/issues/349