### PR TITLE
Get repo information specially for `um`

### DIFF
--- a/scripts/release_provenance/get_data_from_deployment.py
+++ b/scripts/release_provenance/get_data_from_deployment.py
@@ -102,6 +102,8 @@ def generate_packages_metadata(package_names: List[str], root_spec: spack.spec.S
 
         package_hash: str  = package.format('{hash}')
         package_location: str = package.format('{prefix}')
+        package_repo_url: str
+        package_repo_version: str
         package_repo_url, package_repo_version = _get_package_repo_info(package)
 
         md5s_of_binaries = generate_md5s_for_package_binaries(package)

--- a/scripts/release_provenance/get_data_from_deployment.py
+++ b/scripts/release_provenance/get_data_from_deployment.py
@@ -129,7 +129,7 @@ def _get_package_repo_info(package: spack.spec.Spec) -> Tuple[str, str]:
     if package_name == "um":
         return (
             spack.repo.PATH.get_pkg_class(package_name)._resource_cfg.um_ref.git_url,
-            package.variants.get("um_sources_ref").value
+            package.variants.get("um_ref").value
         )
     else:
         return (

--- a/scripts/release_provenance/get_data_from_deployment.py
+++ b/scripts/release_provenance/get_data_from_deployment.py
@@ -127,9 +127,16 @@ def _get_package_repo_info(package: spack.spec.Spec) -> Tuple[str, str]:
     package_name = package.name
 
     if package_name == "um":
+        um_config: Dict[str, Any] = spack.repo.PATH.get_pkg_class(package_name)._resource_cfg
+        um_git_url = um_config.get("um_ref", {}).get("git_url")
+        um_git_ref = package.variants.get("um_ref")
+
+        if not um_git_url or not um_git_ref:
+            raise RuntimeError("The package 'um' needs to have a git url specified in _resource_cfg and the um_ref variant for provenance.")
+
         return (
-            spack.repo.PATH.get_pkg_class(package_name)._resource_cfg.um_ref.git_url,
-            package.variants.get("um_ref").value
+            um_git_url,
+            um_git_ref.value
         )
     else:
         return (

--- a/scripts/release_provenance/get_data_from_deployment.py
+++ b/scripts/release_provenance/get_data_from_deployment.py
@@ -6,7 +6,7 @@ import hashlib
 import os
 from pathlib import Path
 # Need to import these as spack python is on 3.6, before __future__ annotations or typing improvements
-from typing import Any, List, Dict
+from typing import Any, List, Dict, Tuple
 
 import spack.environment
 import spack.error
@@ -101,15 +101,14 @@ def generate_packages_metadata(package_names: List[str], root_spec: spack.spec.S
             raise
 
         package_hash: str  = package.format('{hash}')
-        package_version: str = package.format('{version}')
         package_location: str = package.format('{prefix}')
-        package_repo_url: str =  spack.repo.PATH.get_pkg_class(package_name).git
+        package_repo_url, package_repo_version = _get_package_repo_info(package)
 
         md5s_of_binaries = generate_md5s_for_package_binaries(package)
 
         metadata.append({
             "name": package_name,
-            "version": package_version,
+            "version": package_repo_version,
             "hash": package_hash,
             "location": package_location,
             "url": package_repo_url,
@@ -117,6 +116,26 @@ def generate_packages_metadata(package_names: List[str], root_spec: spack.spec.S
         })
 
     return metadata
+
+def _get_package_repo_info(package: spack.spec.Spec) -> Tuple[str, str]:
+    """
+    Get package repo information from the package.py file.
+    This is different for certain packages like the um, which have variants and structs in the
+    package.py file that have that information.
+    Returns: A pair composed of a git url and a git ref
+    """
+    package_name = package.name
+
+    if package_name == "um":
+        return (
+            spack.repo.PATH.get_pkg_class(package_name)._resource_cfg.um_ref.git_url,
+            package.variants.get("um_sources_ref").value
+        )
+    else:
+        return (
+            spack.repo.PATH.get_pkg_class(package_name).git,
+            package.format("{version}")
+        )
 
 
 def generate_md5s_for_package_binaries(package: spack.spec.Spec) -> List[Dict[str, str]]:


### PR DESCRIPTION
See #363

## Background

We can't get the url or ref information for the `um` spack package because it doesn't have a `git` attribute in the `package.py`. It has special variants and data within the file for that purpose. 

## The PR

* Update the `get_packages_metadata()` function to get the `um` data specially - as in, it gets the URL from the `_resource_cfg` attribute at https://github.com/ACCESS-NRI/access-spack-packages/blob/38fec2deecd505a244ea47416eb1def01e4b0aa2/spack_repo/access/nri/packages/um/package.py#L183; and it's version from the value of the `um_ref` variant at https://github.com/ACCESS-NRI/access-spack-packages/blob/38fec2deecd505a244ea47416eb1def01e4b0aa2/spack_repo/access/nri/packages/um/package.py#L78

## Testing

Tested via https://github.com/ACCESS-NRI/ACCESS-AM3/pull/30
