### PR TITLE
Get MD5 info for binaries under `bin` subdir

### DIFF
--- a/scripts/release_provenance/get_data_from_deployment.py
+++ b/scripts/release_provenance/get_data_from_deployment.py
@@ -150,13 +150,18 @@ def _get_package_repo_info(package: spack.spec.Spec) -> Tuple[str, str]:
 def generate_md5s_for_package_binaries(package: spack.spec.Spec) -> List[Dict[str, str]]:
     md5s: List[Dict[str, str]] = []
 
-    bin_path = Path(package.prefix) / "bin"
+    bin_paths = [
+        directory
+        for directory in Path(package.prefix).rglob("bin")
+        if directory.is_dir()
+    ]
 
-    if not bin_path.exists():
+    if not bin_paths:
         return md5s
 
     executables = [
         executable
+        for bin_path in bin_paths
         for executable in bin_path.rglob('*')
         if executable.is_file() and os.access(executable, os.X_OK)
     ]


### PR DESCRIPTION
## Background

Currently, we search for binaries under the `$PACKAGE_PREFIX/bin/**` directory. 
This works for every package except for the `um`, which has a `$PACKAGE_PREFIX/um_atmos/bin` and `$PACKAGE_PREFIX/um_recon/bin`. 
This PR enables search for binaries under `$PACKAGE_PREFIX/**/bin/**` instead. 

## The PR

* Search for binaries under a `bin` that might be a subdirectory.

## Testing

Tested updated python locally, works for both nested `bin`:

```py
[PosixPath('/g/data/vk83/prerelease/apps/spack/1.1/restricted/ukmo/release/linux-x86_64_v4/um-13.1-ado7saoc5sicjf53pyfybz6ope5ogwvb/build-atmos/bin/um_script_functions'), PosixPath('/g/data/vk83/prerelease/apps/spack/1.1/restricted/ukmo/release/linux-x86_64_v4/um-13.1-ado7saoc5sicjf53pyfybz6ope5ogwvb/build-atmos/bin/um-atmos.exe'), PosixPath('/g/data/vk83/prerelease/apps/spack/1.1/restricted/ukmo/release/linux-x86_64_v4/um-13.1-ado7saoc5sicjf53pyfybz6ope5ogwvb/build-atmos/bin/um-atmos'), PosixPath('/g/data/vk83/prerelease/apps/spack/1.1/restricted/ukmo/release/linux-x86_64_v4/um-13.1-ado7saoc5sicjf53pyfybz6ope5ogwvb/build-recon/bin/um_script_functions'), PosixPath('/g/data/vk83/prerelease/apps/spack/1.1/restricted/ukmo/release/linux-x86_64_v4/um-13.1-ado7saoc5sicjf53pyfybz6ope5ogwvb/build-recon/bin/um-recon'), PosixPath('/g/data/vk83/prerelease/apps/spack/1.1/restricted/ukmo/release/linux-x86_64_v4/um-13.1-ado7saoc5sicjf53pyfybz6ope5ogwvb/build-recon/bin/um-recon.exe')]
```

And non-nested `bin`:

```py
[PosixPath('/g/data/vk83/prerelease/apps/spack/1.1/restricted/ukmo/release/linux-x86_64/um7-git.2025.12.000_access-esm1.6-e2f65up2odqdgkd7uogmkockgwoqbdsn/bin')]
```
