### PR TITLE
Updates for new `spack-config`

### DIFF
--- a/.github/workflows/create-deployment-spack.yml
+++ b/.github/workflows/create-deployment-spack.yml
@@ -57,9 +57,8 @@ jobs:
         run: |
           ssh ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }} -i ${{ steps.ssh.outputs.private-key-path }} /bin/bash <<'EOT'
           mkdir ${{ env.ROOT_VERSION_LOCATION }} || exit $?
-          git -C ${{ env.ROOT_VERSION_LOCATION }} clone -c feature.manyFiles=true ${{ inputs.spack-git-url }} --branch ${{ inputs.spack-version }}
+          git -C ${{ env.ROOT_VERSION_LOCATION }} clone ${{ inputs.spack-git-url }} --branch ${{ inputs.spack-version }}
           git -C ${{ env.ROOT_VERSION_LOCATION }} clone https://github.com/ACCESS-NRI/spack-config.git --branch ${{ inputs.spack-config-version }}
-          ln -s -r -v ${{ env.ROOT_VERSION_LOCATION }}/spack-config/v${{ steps.strip.outputs.version-dir }}/${{ vars.DEPLOYMENT_TARGET }}/* ${{ env.ROOT_VERSION_LOCATION }}/spack/etc/spack/
           mkdir ${{ env.ROOT_VERSION_LOCATION }}/release
           mkdir ${{ env.ROOT_VERSION_LOCATION }}/logs
 
@@ -72,3 +71,6 @@ jobs:
             "g:vk83_w:r-X,g:ki32_mosrs:r-X,g:vk83_um:r-X,g:df42:r-X,g::---,o::---,d:g:vk83_w:r-X,d:g:ki32_mosrs:r-X,d:g:vk83_um:r-X,d:g:df42:r-X,d:g::---,d:o::---" \
             ${{ env.ROOT_VERSION_LOCATION }}/restricted $TMPDIR/restricted
           EOT
+
+          . ${{ env.ROOT_VERSION_LOCATION }}/spack/share/spack/setup-env.sh
+          spack -d bootstrap now

--- a/.github/workflows/deploy-2-start.yml
+++ b/.github/workflows/deploy-2-start.yml
@@ -197,6 +197,10 @@ jobs:
           # Export vars.DEPLOYMENT_TARGET
           export DEPLOYMENT_TARGET="${{ vars.DEPLOYMENT_TARGET }}"
           echo "DEPLOYMENT_TARGET exported as $DEPLOYMENT_TARGET"
+
+          # This environment variable is used by our spack-config to delineate between a normal user
+          # and an admin or service user that has custom config.install_trees (among other things).
+          # See https://github.com/ACCESS-NRI/spack-config/blob/main/v1.1/include/defaults.yaml
           export ACCESS_SPACK_ADMIN=1
 
           # Enable spack
@@ -244,6 +248,10 @@ jobs:
           # Export vars.DEPLOYMENT_TARGET
           export DEPLOYMENT_TARGET="${{ vars.DEPLOYMENT_TARGET }}"
           echo "DEPLOYMENT_TARGET exported as $DEPLOYMENT_TARGET"
+
+          # This environment variable is used by our spack-config to delineate between a normal user
+          # and an admin or service user that has custom config.install_trees (among other things).
+          # See https://github.com/ACCESS-NRI/spack-config/blob/main/v1.1/include/defaults.yaml
           export ACCESS_SPACK_ADMIN=1
 
           . ${{ steps.path.outputs.spack }}/share/spack/setup-env.sh

--- a/.github/workflows/deploy-2-start.yml
+++ b/.github/workflows/deploy-2-start.yml
@@ -199,7 +199,7 @@ jobs:
           echo "DEPLOYMENT_TARGET exported as $DEPLOYMENT_TARGET"
 
           # Enable spack
-          . ${{ steps.path.outputs.spack-config }}/spack-enable.bash
+          . ${{ steps.path.outputs.spack }}/share/spack/setup-env.sh
 
           # Create and activate environment
           spack env activate ${{ inputs.env-name }} --create --envfile ${{ vars.SPACK_YAML_LOCATION }}/${{ inputs.expected-root-spec-name }}-${{ github.run_id }}.spack.yaml
@@ -244,7 +244,7 @@ jobs:
           export DEPLOYMENT_TARGET="${{ vars.DEPLOYMENT_TARGET }}"
           echo "DEPLOYMENT_TARGET exported as $DEPLOYMENT_TARGET"
 
-          . ${{ steps.path.outputs.spack-config }}/spack-enable.bash
+          . ${{ steps.path.outputs.spack }}/share/spack/setup-env.sh
           ${{ steps.path.outputs.spack-environment }}/get_data_from_deployment.py \
             --environment ${{ steps.path.outputs.spack-environment }} \
             --deployment-name ${{ inputs.expected-root-spec-name }} \

--- a/.github/workflows/deploy-2-start.yml
+++ b/.github/workflows/deploy-2-start.yml
@@ -156,15 +156,6 @@ jobs:
             --spack-packages-version-sha ${{ steps.packages-ref.outputs.sha }} \
             --output ../${{ inputs.spack-manifest-path }}
 
-      - name: Validate service user permissions
-        run: |
-          ssh ${{ secrets.USER }}@${{ secrets.HOST }} -i ${{ steps.ssh.outputs.private-key-path }} /bin/bash <<'EOT'
-            if [ -z "$ACCESS_SPACK_ADMIN" ]; then
-              echo "::error::Service user is not setup to deploy Pre/Releases. Please ensure the service user has the correct permissions and try again."
-              exit 1
-            fi
-          EOT
-
       - name: Copy ${{ inputs.spack-manifest-path }}
         run: |
           rsync -e 'ssh -i ${{ steps.ssh.outputs.private-key-path }}' \

--- a/.github/workflows/deploy-2-start.yml
+++ b/.github/workflows/deploy-2-start.yml
@@ -206,6 +206,7 @@ jobs:
           # Export vars.DEPLOYMENT_TARGET
           export DEPLOYMENT_TARGET="${{ vars.DEPLOYMENT_TARGET }}"
           echo "DEPLOYMENT_TARGET exported as $DEPLOYMENT_TARGET"
+          export ACCESS_SPACK_ADMIN=1
 
           # Enable spack
           . ${{ steps.path.outputs.spack }}/share/spack/setup-env.sh
@@ -252,6 +253,7 @@ jobs:
           # Export vars.DEPLOYMENT_TARGET
           export DEPLOYMENT_TARGET="${{ vars.DEPLOYMENT_TARGET }}"
           echo "DEPLOYMENT_TARGET exported as $DEPLOYMENT_TARGET"
+          export ACCESS_SPACK_ADMIN=1
 
           . ${{ steps.path.outputs.spack }}/share/spack/setup-env.sh
           ${{ steps.path.outputs.spack-environment }}/get_data_from_deployment.py \

--- a/.github/workflows/deploy-2-start.yml
+++ b/.github/workflows/deploy-2-start.yml
@@ -156,6 +156,15 @@ jobs:
             --spack-packages-version-sha ${{ steps.packages-ref.outputs.sha }} \
             --output ../${{ inputs.spack-manifest-path }}
 
+      - name: Validate service user permissions
+        run: |
+          ssh ${{ secrets.USER }}@${{ secrets.HOST }} -i ${{ steps.ssh.outputs.private-key-path }} /bin/bash <<'EOT'
+            if [ -z "$ACCESS_SPACK_ADMIN" ]; then
+              echo "::error::Service user is not setup to deploy Pre/Releases. Please ensure the service user has the correct permissions and try again."
+              exit 1
+            fi
+          EOT
+
       - name: Copy ${{ inputs.spack-manifest-path }}
         run: |
           rsync -e 'ssh -i ${{ steps.ssh.outputs.private-key-path }}' \

--- a/.github/workflows/settings-2-deploy.yml
+++ b/.github/workflows/settings-2-deploy.yml
@@ -120,6 +120,8 @@ jobs:
                 echo "::error::Error: ${{ inputs.deployment-environment }} ${{ inputs.spack-type }} $version spack-config failed checkout from $current_head_commit to $new_commit"
               else
                 echo "::notice::Changed: ${{ inputs.deployment-environment }} ${{ inputs.spack-type }} $version spack-config changed from $current_head_commit to $new_commit"
+                . ${{ secrets.SPACK_INSTALLS_ROOT_LOCATION }}/$version/spack/share/spack/setup-env.sh
+                spack repo update
               fi
 
             else

--- a/.github/workflows/settings-2-deploy.yml
+++ b/.github/workflows/settings-2-deploy.yml
@@ -55,23 +55,6 @@ jobs:
           echo "$updates" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
 
-      - name: Setup builtin spack-packages updates
-        id: builtin-spack-packages
-        # Notably, only the spack instances that are >=1.0 and have builtin-spack-packages entries will produce any output here
-        run: |
-          updates=$(jq --compact-output --raw-output \
-            --arg env "${{ inputs.deployment-environment }}" \
-            --arg type "${{ inputs.spack-type }}" \
-            '.deployment[$env][$type] | to_entries[] | select(.value."builtin-spack-packages" != null) | "\(.key) \(.value."builtin-spack-packages")"' \
-            ${{ env.CONFIG_SETTINGS_PATH }}
-          )
-
-          echo "$updates"
-          # For multiline output, use a heredoc. See https://github.com/orgs/community/discussions/116619#discussioncomment-8994849
-          echo "updates<<EOF" >> $GITHUB_OUTPUT
-          echo "$updates" >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
-
       - name: Setup SSH
         id: ssh
         uses: access-nri/actions/.github/actions/setup-ssh@main
@@ -136,10 +119,6 @@ jobs:
               if [ $? -ne 0 ]; then
                 echo "::error::Error: ${{ inputs.deployment-environment }} ${{ inputs.spack-type }} $version spack-config failed checkout from $current_head_commit to $new_commit"
               else
-                ln -s -r -v -f \
-                  ${{ secrets.SPACK_INSTALLS_ROOT_LOCATION }}/$version/spack-config/$version/* \
-                  ${{ secrets.SPACK_INSTALLS_ROOT_LOCATION }}/$version/spack/etc/spack/
-
                 echo "::notice::Changed: ${{ inputs.deployment-environment }} ${{ inputs.spack-type }} $version spack-config changed from $current_head_commit to $new_commit"
               fi
 
@@ -147,37 +126,4 @@ jobs:
               echo "::notice::Unchanged: ${{ inputs.deployment-environment }} ${{ inputs.spack-type }} $version spack-config left at $current_head_commit"
             fi
           done <<< "${{ steps.spack-config.outputs.updates }}"
-          EOT
-
-      - name: Update builtin spack-packages
-        # This will only run for instances that have builtin-spack-packages defined in their entries (i.e. instances at spack >=1.0)
-        continue-on-error: true
-        run: |
-          ssh ${{ secrets.USER}}@${{ secrets.HOST }} -i ${{ steps.ssh.outputs.private-key-path }} /bin/bash <<'EOT'
-          set +e
-
-          while read -ra update; do
-            version=${update[0]}
-            new_ref=${update[1]}
-
-            . ${{ secrets.SPACK_INSTALLS_ROOT_LOCATION }}/$version/spack/share/spack/setup-env.sh
-
-            builtin_repo_path=$(spack location --repo builtin)
-
-            current_head_commit=$(git -C $builtin_repo_path rev-parse HEAD)
-            new_commit=$(git -C $builtin_repo_path rev-parse "$new_ref")
-
-            if [[ "$current_head_commit" != "$new_commit" ]]; then
-
-              spack repo update builtin --commit $new_commit
-
-              if [ $? -ne 0 ]; then
-                echo "::error::Error: ${{ inputs.deployment-environment }} ${{ inputs.spack-type }} $version builtin-spack-packages failed checkout from $current_head_commit to $new_commit"
-              else
-                echo "::notice::Changed: ${{ inputs.deployment-environment }} ${{ inputs.spack-type }} $version builtin-spack-packages changed from $current_head_commit to $new_commit"
-              fi
-            else
-              echo "::notice::Unchanged: ${{ inputs.deployment-environment }} ${{ inputs.spack-type }} $version builtin-spack-packages left at $current_head_commit"
-            fi
-          done <<< "${{ steps.builtin-spack-packages.outputs.updates }}"
           EOT

--- a/.github/workflows/settings-2-deploy.yml
+++ b/.github/workflows/settings-2-deploy.yml
@@ -160,7 +160,7 @@ jobs:
             version=${update[0]}
             new_ref=${update[1]}
 
-            . ${{ secrets.SPACK_INSTALLS_ROOT_LOCATION }}/$version/spack-config/spack-enable.bash
+            . ${{ secrets.SPACK_INSTALLS_ROOT_LOCATION }}/$version/spack/share/spack/setup-env.sh
 
             builtin_repo_path=$(spack location --repo builtin)
 

--- a/.github/workflows/undeploy-1-start.yml
+++ b/.github/workflows/undeploy-1-start.yml
@@ -74,7 +74,7 @@ jobs:
           export DEPLOYMENT_TARGET="${{ vars.DEPLOYMENT_TARGET }}"
           echo "DEPLOYMENT_TARGET exported as $DEPLOYMENT_TARGET"
 
-          . ${{ steps.path.outputs.spack-config }}/spack-enable.bash
+          . ${{ steps.path.outputs.spack-config }}/share/spack/setup-env.sh
           envs=$(find ${{ steps.path.outputs.spack }}/../environments -type d -name '${{ inputs.version-pattern }}' -printf '%f ')
 
           for env in $envs; do

--- a/README.md
+++ b/README.md
@@ -154,6 +154,6 @@ This is most useful for models that are using `@git.BRANCH` references for versi
 !update-configs [profile=PROFILE]
 ```
 
-This Comment Command creates draft PRs to linked model configuration repositories, allowing quick testing of prerelease builds against different model configurations. 
+This Comment Command creates draft PRs to linked model configuration repositories, allowing quick testing of prerelease builds against different model configurations.
 
 This command is informed by the MDRs `config/auto-configs-pr.json` file.

--- a/config/README.md
+++ b/config/README.md
@@ -18,5 +18,4 @@ This schema enforces the structure shown in `settings.json`.
 
 Note:
 
-- For deployments using spack version keys >= `1.0` (for example `"1.0"`, `"1.1"`, `"2.0"`), each versioned entry under `deployment/<TARGET>/<Release|Prerelease>/<VERSION>` must include the field `builtin-spack-packages` in addition to `spack` and `spack-config`.
-- For version keys < `1.0` (for example `"0.22"`), only `spack` and `spack-config` are required. This is because historically `spack`s builtin `spack-packages` repository was versioned as part of the `spack` repository version.
+- Only `spack` and `spack-config` are required. `builtin` `spack-packages` is versioned solely by `spack-config`

--- a/config/settings.json
+++ b/config/settings.json
@@ -13,8 +13,7 @@
         },
         "1.1": {
           "spack": "2e2169d5282d166f63e3ee4db8d4446c43cefa8a",
-          "spack-config": "2026.02.003",
-          "builtin-spack-packages": "383e969358c951abe17623696083e6f862c4488e"
+          "spack-config": "2026.02.003"
         }
       },
       "Prerelease": {
@@ -24,8 +23,7 @@
         },
         "1.1": {
           "spack": "2e2169d5282d166f63e3ee4db8d4446c43cefa8a",
-          "spack-config": "2026.02.003",
-          "builtin-spack-packages": "383e969358c951abe17623696083e6f862c4488e"
+          "spack-config": "2026.02.003"
         }
       }
     }

--- a/config/settings.json
+++ b/config/settings.json
@@ -12,8 +12,8 @@
           "spack-config": "2026.02.000"
         },
         "1.1": {
-          "spack": "2e2169d5282d166f63e3ee4db8d4446c43cefa8a",
-          "spack-config": "2026.02.003"
+          "spack": "018ccf07963f6f4db4baff3b198ef3080cc58949",
+          "spack-config": "2026.04.000"
         }
       },
       "Prerelease": {
@@ -22,8 +22,8 @@
           "spack-config": "2026.02.000"
         },
         "1.1": {
-          "spack": "2e2169d5282d166f63e3ee4db8d4446c43cefa8a",
-          "spack-config": "2026.02.003"
+          "spack": "018ccf07963f6f4db4baff3b198ef3080cc58949",
+          "spack-config": "2026.04.000"
         }
       }
     }

--- a/config/settings.schema.json
+++ b/config/settings.schema.json
@@ -16,7 +16,7 @@
             "Release": {
               "type": "object",
               "patternProperties": {
-                "^0\\.\\d+$": {
+                "^\\d+\\.\\d+$": {
                   "type": "object",
                   "properties": {
                     "spack": {
@@ -28,22 +28,6 @@
                   },
                   "additionalProperties": false,
                   "required": ["spack", "spack-config"]
-                },
-                "^[1-9]\\d*\\.\\d+$": {
-                  "type": "object",
-                  "properties": {
-                    "spack": {
-                      "type": "string"
-                    },
-                    "builtin-spack-packages": {
-                      "type": "string"
-                    },
-                    "spack-config": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": ["spack", "builtin-spack-packages", "spack-config"]
                 }
               },
               "additionalProperties": false
@@ -51,7 +35,7 @@
             "Prerelease": {
               "type": "object",
               "patternProperties": {
-                "^0\\.\\d+$": {
+                "^\\d+\\.\\d+$": {
                   "type": "object",
                   "properties": {
                     "spack": {
@@ -63,22 +47,6 @@
                   },
                   "additionalProperties": false,
                   "required": ["spack", "spack-config"]
-                },
-                "^[1-9]\\d*\\.\\d+$": {
-                  "type": "object",
-                  "properties": {
-                    "spack": {
-                      "type": "string"
-                    },
-                    "builtin-spack-packages": {
-                      "type": "string"
-                    },
-                    "spack-config": {
-                      "type": "string"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "required": ["spack", "builtin-spack-packages", "spack-config"]
                 }
               },
               "additionalProperties": false

--- a/tools/service-user/README.md
+++ b/tools/service-user/README.md
@@ -1,0 +1,11 @@
+# Service User Setup Scripts
+
+## Overview
+
+This folder contains scripts that can be used to set up a service user on a HPC platform, ready to administer Pre/Release instances of spack via [a custom site scope defined here](https://github.com/ACCESS-NRI/spack-config/blob/main/v1.1/include/defaults.yaml).
+
+## Scripts
+
+### Setup
+
+Exports the `ACCESS_SPACK_ADMIN` environment variable to the service users `~/.bashrc`, which is used to enable admin-specific install trees and configuration.

--- a/tools/service-user/setup.sh
+++ b/tools/service-user/setup.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+### Spack-specific exports
+
+echo "export ACCESS_SPACK_ADMIN=1" >> ~/.bashrc


### PR DESCRIPTION
References ACCESS-NRI/spack-config#41
Closes https://github.com/ACCESS-NRI/build-cd/issues/349

## Background

There is an update to `spack-config` (see https://github.com/ACCESS-NRI/spack-config/pull/110), which makes use of the `includes.yaml`, and a move away from the `spack-enable.bash`. This PR updates the workflow to use `setup-env.sh`, and adds a new script to set up service users. 

Furthermore, we revert to essentially pre-`v8` behavior in which instead of `builtin-spack-packages` being a lever to pull in `config/settings.json`, it is informed solely by `spack-config`.

## The PR

- **Swap from spack-enable.bash to setup-env.sh**
- **Add tools/service-user for setup of service users, update README**
- **Remove updating of `builtin` via `settings.json`, now informed by `spack-config`**

## Testing

Tested in Prerelease via https://github.com/ACCESS-NRI/ACCESS-TEST/pull/65
