### PR TITLE
Regenerate Modules Without Custom Scopes

### DIFF
--- a/.github/workflows/deploy-2-start.yml
+++ b/.github/workflows/deploy-2-start.yml
@@ -212,9 +212,7 @@ jobs:
             $(for s in ${{ env.SCOPES }}; do echo -n "--config-scope=${{ env.SCOPES_PATH }}/$s "; done) \
             install --fail-fast --fresh ${{ vars.SPACK_INSTALL_ADDITIONAL_ARGS }} || exit $?
 
-          spack \
-            $(for s in ${{ env.SCOPES }}; do echo -n "--config-scope=${{ env.SCOPES_PATH }}/$s "; done) \
-            module tcl refresh -y
+          spack module tcl refresh -y
           EOT
 
       - name: Move spack logs


### PR DESCRIPTION
References #369.

## Background

For models with restricted scopes, we both `spack install` and `spack module tcl refresh` using thoes scopes. This doesn't work for the module refresh bit.

This PR reverts changing the scope of `spack module tcl refresh`, allowing modules to be successfully loaded again.

## The PR

* Remove loading of custom scopes during `spack module tcl refresh`

## Testing

Tested locally by regenerating the modulefiles of a Prerelease using `spack -e access-am3-pr34-1 module tcl refresh -y`. It worked!
