### PR TITLE
deploy-2-start: Add --upstream-modules to module refresh code

### DIFF
--- a/.github/workflows/deploy-2-start.yml
+++ b/.github/workflows/deploy-2-start.yml
@@ -214,7 +214,7 @@ jobs:
 
           spack \
             $(for s in ${{ env.SCOPES }}; do echo -n "--config-scope=${{ env.SCOPES_PATH }}/$s "; done) \
-            module tcl refresh -y
+            module tcl refresh --upstream-modules -y
           EOT
 
       - name: Move spack logs


### PR DESCRIPTION
## Background

Spack added a `--upstream-modules` flag to `spack module tcl refresh` that refreshes modules defined in an upstream - this is the case in our `ukmo-restricted` scope, which makes `$spack/../release` an upstream of our `$spack/../restricted/ukmo/release` dir. This means that we can now generate modulefiles for externals defined in an upstream (like `openmpi`).
 
## The PR

* Add `--upstream-modules` flag. 
