### PR TITLE
Make service user cache a sibling of spack

### DIFF
--- a/.github/workflows/deploy-2-start.yml
+++ b/.github/workflows/deploy-2-start.yml
@@ -202,6 +202,8 @@ jobs:
           # and an admin or service user that has custom config.install_trees (among other things).
           # See https://github.com/ACCESS-NRI/spack-config/blob/main/v1.1/include/defaults.yaml
           export ACCESS_SPACK_ADMIN=1
+          # User cache path is not yet easily settable in spack-config, so we need to export it here as a sibling of the spack directory.
+          export SPACK_USER_CACHE_PATH="${{ steps.path.outputs.root }}/user_cache"
 
           # Enable spack
           . ${{ steps.path.outputs.spack }}/share/spack/setup-env.sh
@@ -253,6 +255,8 @@ jobs:
           # and an admin or service user that has custom config.install_trees (among other things).
           # See https://github.com/ACCESS-NRI/spack-config/blob/main/v1.1/include/defaults.yaml
           export ACCESS_SPACK_ADMIN=1
+          # User cache path is not yet easily settable in spack-config, so we need to export it here as a sibling of the spack directory.
+          export SPACK_USER_CACHE_PATH="${{ steps.path.outputs.root }}/user_cache"
 
           . ${{ steps.path.outputs.spack }}/share/spack/setup-env.sh
           ${{ steps.path.outputs.spack-environment }}/get_data_from_deployment.py \


### PR DESCRIPTION
References https://github.com/ACCESS-NRI/spack-config/issues/41

## Background

The user cache path defaults to `~/.spack`. This is probably fine for regular users, but for service users, who manage multiple spack instances, we don't want to mix configuration of any kind between Pre/Release instances, or different versions of `spack`. 

Therefore, we should explicitly set `SPACK_USER_CACHE_PATH` (similar to what the old `spack-enable.bash` did) in the workflow, based on the spack instance path. In the future, if there is an easy way to set it in `spack-config`, we will move to that. 

## The PR

* Export `SPACK_USER_CACHE_PATH` as a sibling of the `spack` instance for steps where we use `spack`. 
