### PR TITLE
Simplify pre/release module generation to replace `{version}`, focus less on `{name}`

### DIFF
--- a/scripts/spack_manifest/injection/modules.py
+++ b/scripts/spack_manifest/injection/modules.py
@@ -64,7 +64,7 @@ def main():
             output_file.write(dumped_manifest)
 
 def inject_projections(
-    manifest: str, root_spec: str, packages: set[str]
+    manifest: dict[str, Any], root_spec: str, packages: set[str]
 ) -> dict[str, Any]:
 
     # Get projections that are already defined in the manifest - we don't want to redefine these
@@ -140,7 +140,6 @@ def generate_projection_for_root_spec_or_raise(
     root_spec_projection: str = ''
 ) -> dict[str, str]:
     reserved_definitions_getter = ReservedDefinitions(manifest)
-    specs_getter = Specs(manifest)
 
     version = reserved_definitions_getter.get("version")
 
@@ -148,39 +147,18 @@ def generate_projection_for_root_spec_or_raise(
         f"Extracted version '{version}' from _version definition'"
     )
 
-    # Essentially we're looking to infix the version between {name} and what comes after, if there exists a projection.
-    module_projection_pattern = re.compile(
-        r"""
-        ^(.*\{name\}[^\/]*?)  # First group - Either '{name}' (most common) or a prefix like 'system-tools/{name}' (for SDRs)
-        (?:\/(.+))?$          # Optional second group - Rest of the projection after '{name}/', if given. Used for variants/descriptors in modulefile names
-        """,
-        re.VERBOSE
-    )
+    if not root_spec_projection:  # we need to make a projection from scratch...
+        root_specs_in_speclist = len(Specs(manifest).get_specs_with_name(root_spec_name))
 
-    projection_components: re.Match | None = re.match(module_projection_pattern, root_spec_projection)
+        if root_specs_in_speclist == 0:
+            raise ValueError(f"No specs with name {root_spec_name} in speclist")
+        elif root_specs_in_speclist == 1:
+            return {root_spec_name: f"{{name}}/{version}"}
+        else:
+            # If there are multiple of the same root spec (for example, different variants housed under the same environment), we need to demarcate the modulefile with a spack package hash
+            return {root_spec_name: f"{{name}}/{version}/{{hash:7}}"}
 
-    # If there is a root spec projection and it is well-formed, we need to infix the version
-    if projection_components:
-        # We have a custom projection defined for the root spec, so we need to respect that
-        projection_groups: tuple[str] = projection_components.groups()
-
-        updated_version: str = f"{projection_groups[0]}/{version}" + (f"/{projection_groups[1]}" if projection_groups[1] else "")
-
-        print(f"Root spec already had a projection ({root_spec_projection}) so we infix the the version ({version}) to give: {updated_version}")
-
-        return {root_spec_name: updated_version}
-
-    # Otherwise, we need to construct a projection from scratch
-    root_specs_in_speclist = len(specs_getter.get_specs_with_name(root_spec_name))
-
-    if root_specs_in_speclist == 0:
-        raise ValueError(f"No specs with name {root_spec_name} in speclist")
-    elif root_specs_in_speclist == 1:
-        return {root_spec_name: f"{{name}}/{version}"}
-    else:
-        # If there are multiple of the same root spec (for example, different variants housed under the same environment), we need to demarcate the modulefile with a spack package hash
-        return {root_spec_name: f"{{name}}/{version}/{{hash:7}}"}
-
+    return {root_spec_name: root_spec_projection.replace("{version}", version)}
 
 def generate_projection_for_package_or_raise(
     manifest: dict[str, Any], package_name: str

--- a/scripts/spack_manifest/injection/prerelease.py
+++ b/scripts/spack_manifest/injection/prerelease.py
@@ -86,11 +86,9 @@ def add_namespace_to_other_projection_versions(
         projections.pop(root_spec_name)
 
     for projection_name, projection_value in projections.items():
-        # Non-root-spec projections will be of the form ROOT_SPEC_NAME/prX-Y/{name}/VERSION, where VERSION is previously defined.
-        # For example, access-om2/pr12-13/mom5/main-{hash:7}
-        new_projection_value = re.sub(
-            r"{name}/(.+)", rf"{root_spec_name}/dependencies/{version}/{{name}}/\1", projection_value
-        )
+        # Non-root-spec projections are namespaced under ROOT_SPEC_NAME/dependencies/prX-Y,
+        # while preserving the original projection structure (with or without a {name} token).
+        new_projection_value = f"{root_spec_name}/dependencies/{version}/{projection_value.lstrip('/')}"
 
         print(
             f"Updating projection '{projection_name}' from '{projection_value}' to '{new_projection_value}'"
@@ -111,19 +109,9 @@ def update_root_spec_projection_version(
     number_of_root_specs_in_speclist = len(Specs(manifest).get_specs_with_name(root_spec_name))
 
     if current_root_projection:
-        # Essentially - replace the original version infix with the prX-Y style, and add back the custom suffix if there was one.
-        # For example:
-        #   {name}/2025.12.000 -> {name}/prX-Y
-        #   system-tools/{name}/2025.12.000 -> system-tools/{name}/prX-Y
-        #   {name}/2025.12.000/{variant.x} -> {name}/prX-Y/{variant.x}
-        new_root_projection_pattern = re.compile(
-            r"""
-            ^(.*\{name\}/)[^/]+  # Pre-infix section - like {name} or system-tools/{name}
-            (/.+)?$              # Post-infix section - like /{variants.x}
-            """,
-            re.VERBOSE
-        )
-        new_root_projection = re.sub(new_root_projection_pattern, fr"\1{deployment_version}\2", current_root_projection)
+        # Replace the manifest version wherever it appears as a path segment in the projection.
+        current_version = ReservedDefinitions(manifest).get("version")
+        new_root_projection = current_root_projection.replace(current_version, deployment_version)
 
         if number_of_root_specs_in_speclist > 1 and re.match(fr"^.+/{deployment_version}$", new_root_projection):
             # If there are multiple of the same root spec, we need to demarcate them somehow if there was no custom suffix given.

--- a/tests/scripts/spack_manifest/injection/test_modules.py
+++ b/tests/scripts/spack_manifest/injection/test_modules.py
@@ -144,6 +144,34 @@ class TestGenerateProjectionForRootSpecOrRaise:
         with pytest.raises(ValueError):
             generate_projection_for_root_spec_or_raise(manifest, projection)
 
+    def test_generate_projection_for_root_spec_or_raise__projection_without_default_name(self):
+        root_spec_name="access-issm"
+        root_spec_version="2025.12.000"
+        root_spec_projection="ISSM{variants.ad}/{version}"
+
+        partial_manifest = {
+            "spack": {
+                "definitions": [
+                    {"_name": [root_spec_name]},
+                    {"_version": [root_spec_version]},
+                ],
+                "specs": [root_spec_name],
+                "modules": {
+                    "default": {
+                        "tcl": {
+                            "projections": {
+                                root_spec_name: root_spec_projection
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        result_projections = generate_projection_for_root_spec_or_raise(partial_manifest, root_spec_name, root_spec_projection)
+
+        assert result_projections == {root_spec_name: f"ISSM{{variants.ad}}/{root_spec_version}"}
+
 
 class TestGenerateProjectionForPackageOrRaise:
     def test_generate_projection_for_package_or_raise__valid_at_git(self):

--- a/tests/scripts/spack_manifest/injection/test_prerelease.py
+++ b/tests/scripts/spack_manifest/injection/test_prerelease.py
@@ -12,6 +12,10 @@ class TestUpdateRootSpecProjectionVersion:
     def test_update_root_spec_projection_version__valid_existing_single_spec(self):
         manifest = {
             "spack": {
+                "definitions": [
+                    {"_name": ["access-om2"]},
+                    {"_version": ["2025.12.000"]},
+                ],
                 "specs": [
                     "access-om2",
                 ],
@@ -37,6 +41,10 @@ class TestUpdateRootSpecProjectionVersion:
     def test_update_root_spec_projection_version__valid_existing_multi_spec(self):
         manifest = {
             "spack": {
+                "definitions": [
+                    {"_name": ["access-om2"]},
+                    {"_version": ["2025.12.000"]},
+                ],
                 "specs": [
                     "access-om2 +var",
                     "access-om2 ~var"


### PR DESCRIPTION
## Background

Currently, modulefile generation is still quite inflexible:
* we have a lot of convoluted logic regarding infixing the reserved definition `spack.defintions._version` into existing projections, etc. that can be quite confusing.
* We make a lot of assumptions on the structure of existing root spec projections (for example, `{name}` must come before the `{version}`), but we may not need `{name}` at all - for example, `access-issm: ISSM{variants.ad}/{version}`.

## The PR

* Simplify version infixing for root specs - now, just replace `{version}` with `spack.definitions._version` if the projection exists. 
* Simplify all the complex regex - we don't need to make assumptions on projection `{name}`s. 

## Testing

### Unit Tests

All existing unit tests passed.

### Test projection-less manifests (common case)

<details>
<summary>ACCESS-OM3</summary>

#### Manifest

No projections!

#### Release

```yaml
spack:
  definitions:
  - _name: [access-om3]
  - _version: [2025.08.002]
  specs:
  - access-om3
  # packages, concretizer, etc...
  modules:
    default:
      tcl:
        projections:
          access-om3: '{name}/2025.08.002'
          access-cice: '{name}/CICE6.6.1-0-{hash:7}'
          access-generic-tracers: '{name}/2025.08.000-{hash:7}'
          access-mocsy: '{name}/2025.07.002-{hash:7}'
          access-mom6: '{name}/2025.07.000-{hash:7}'
          access-ww3: '{name}/2025.08.000-{hash:7}'
          access3: '{name}/2025.08.000-{hash:7}'
          access3-share: '{name}/2025.08.000-{hash:7}'
        include:
        - access-om3
        - access-cice
        - access-generic-tracers
        - access-mocsy
        - access-mom6
        - access-ww3
        - access3
        - access3-share
```

Prerelease:

```
spack:
  # ...
  modules:
    default:
      tcl:
        projections:
          access-om3: '{name}/prX-Y'
          access-cice: 'access-om3/dependencies/prX-Y/{name}/CICE6.6.1-0-{hash:7}'
          access-generic-tracers: 'access-om3/dependencies/prX-Y/{name}/2025.08.000-{hash:7}'
          access-mocsy: 'access-om3/dependencies/prX-Y/{name}/2025.07.002-{hash:7}'
          access-mom6: 'access-om3/dependencies/prX-Y/{name}/2025.07.000-{hash:7}'
          access-ww3: 'access-om3/dependencies/prX-Y/{name}/2025.08.000-{hash:7}'
          access3: 'access-om3/dependencies/prX-Y/{name}/2025.08.000-{hash:7}'
          access3-share: 'access-om3/dependencies/prX-Y/{name}/2025.08.000-{hash:7}'
        include:
        - access-om3
        - access-cice
        - access-generic-tracers
        - access-mocsy
        - access-mom6
        - access-ww3
        - access3
        - access3-share
```

</details>

### Test manifests with projections (`system-tools`, etc.)

<details>
<summary>system-tools/gh</summary>

#### Manifest

```yaml
spack:
  definitions:
  # _name and _version are reserved definitions that inform build-cd deployments, and have no effect otherwise
  - _name: [gh]
  - _version: [2.49.2-1]
  specs:
  - gh@2.49.2
  # package, concretizer...
  # Note the existing projections
  modules:
    default:
      tcl:
        include:
        - gh
        projections:
          gh: 'system-tools/{name}/{version}'
```

#### Release

```yaml
spack:
  definitions:
  - _name: [gh]
  - _version: [2.49.2-1]
  specs:
  - gh@2.49.2
  # packages, concretizer...
  modules:
    default:
      tcl:
        include:
        - gh
        projections:
          gh: system-tools/{name}/2.49.2-1
```

Prerelease:

```
spack:
  definitions:
  - _name: [gh]
  - _version: [2.49.2-1]
  specs:
  - gh@2.49.2
  # packages, concretizer...
  modules:
    default:
      tcl:
        include:
        - gh
        projections:
          gh: system-tools/{name}/prX-Y

```

</details>

### Test manifests with non-`{name}` projections (`ACCESS-ISSM`s `access-issm: ISSM{variants.ad}/{version}`)

<details>
<summary>ACCESS-ISSM (with no `{name}`)</summary>

#### Manifest

```yaml
spack:
  definitions:
  - _name: [access-issm]
  - _version: [2025.11.0]
  specs:
  - access-issm
  # package, concretizer...
  modules:
    default:
      tcl:
        projections:
          access-issm: "ISSM{variants.ad}/{version}"
```

#### Release

```yaml
spack:
  definitions:
  - _name: [access-issm]
  - _version: [2025.11.0]
  specs:
  - access-issm
  # package, concretizers...
  modules:
    default:
      tcl:
        projections:
          access-issm: ISSM{variants.ad}/2025.11.0
          access-triangle: '{name}/1.6.1-{hash:7}'
          issm: '{name}/2025.11.24-{hash:7}'
          openmpi: '{name}/4.1.5-{hash:7}'
        include:
        - access-issm
        - access-triangle
        - issm
        - openmpi
```

#### Prerelease

```yaml
spack:
  definitions:
  - _name: [access-issm]
  - _version: [2025.11.0]
  specs:
  - access-issm
  # package, concretizer...
  modules:
    default:
      tcl:
        projections:
          access-issm: ISSM{variants.ad}/prX-Y
          access-triangle: 'access-issm/dependencies/prX-Y/{name}/1.6.1-{hash:7}'
          issm: 'access-issm/dependencies/prX-Y/{name}/2025.11.24-{hash:7}'
          openmpi: 'access-issm/dependencies/prX-Y/{name}/4.1.5-{hash:7}'
        include:
        - access-issm
        - access-triangle
        - issm
        - openmpi
```

</details>