### PR TITLE
Update Actions that use Node 20

### DIFF
--- a/.github/actions/get-spack-manifest/README.md
+++ b/.github/actions/get-spack-manifest/README.md
@@ -26,7 +26,7 @@ jobs:
   manifest:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - id: spec
         uses: access-nri/build-cd/.github/actions/get-spack-manifest@vX  # for some version `vX`

--- a/.github/actions/get-spack-manifest/action.yml
+++ b/.github/actions/get-spack-manifest/action.yml
@@ -19,7 +19,7 @@ runs:
   using: composite
   steps:
     - name: Clone build-cd script location
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         repository: access-nri/build-cd
         path: ${{ github.workspace }}/getter-script

--- a/.github/actions/get-target-matrix/action.yml
+++ b/.github/actions/get-target-matrix/action.yml
@@ -14,7 +14,7 @@ runs:
   using: composite
   steps:
     - name: Get deployment settings.json
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         repository: access-nri/build-cd
 

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -72,7 +72,7 @@ jobs:
       deployment-name: ${{ steps.manifest.outputs.deployment-name }}
       targets: ${{ steps.target.outputs.valid-targets }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Get manifest
         id: manifest
@@ -95,7 +95,7 @@ jobs:
       matrix:
         target: ${{ fromJson(needs.init.outputs.targets) }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           repository: access-nri/build-cd
 
@@ -113,7 +113,7 @@ jobs:
     outputs:
       version: ${{ steps.manifest.outputs.deployment-version }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Get Deployment Version
         id: manifest
@@ -130,7 +130,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Import Commit-Signing Key
         uses: crazy-max/ghaction-import-gpg@01dd5d3ca463c7f10f7f4f7b4f177225ac661ee4  # v6.1.0
@@ -198,7 +198,7 @@ jobs:
       TEMPLATED_RELEASE_BODY_PATH: /opt/release-body.md
     steps:
       - name: Checkout build-cd
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: access-nri/build-cd
 
@@ -282,7 +282,7 @@ jobs:
           cache: pip
 
       - name: Checkout Upload Script
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: access-nri/build-cd
 

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -217,7 +217,7 @@ jobs:
           merge-multiple: true
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: 3.12
           cache: pip
@@ -276,7 +276,7 @@ jobs:
           merge-multiple: true
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ vars.PYTHON_VERSION }}
           cache: pip

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -203,14 +203,14 @@ jobs:
           repository: access-nri/build-cd
 
       - name: Download Metadata Artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           pattern: ${{ needs.deploy-release.outputs.general-metadata-artifact-glob }}
           path: ${{ env.METADATA_PATH }}
           merge-multiple: true
 
       - name: Download Outputs Artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           pattern: ${{ needs.deploy-release.outputs.general-outputs-artifact-glob }}
           path: ${{ env.OUTPUTS_PATH }}
@@ -262,14 +262,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download Metadata Artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           pattern: ${{ needs.deploy-release.outputs.general-metadata-artifact-glob }}
           path: ${{ env.METADATA_PATH }}
           merge-multiple: true
 
       - name: Download Outputs Artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           pattern: ${{ needs.deploy-release.outputs.general-outputs-artifact-glob }}
           path: ${{ env.OUTPUTS_PATH }}

--- a/.github/workflows/ci-closed.yml
+++ b/.github/workflows/ci-closed.yml
@@ -32,7 +32,7 @@ jobs:
       targets: ${{ steps.target.outputs.valid-targets }}
     steps:
       - name: Get data from ${{ github.repository }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Get Deployment Name
         id: manifest

--- a/.github/workflows/ci-command-configs.yml
+++ b/.github/workflows/ci-command-configs.yml
@@ -107,7 +107,7 @@ jobs:
         run: echo "ref=$(gh pr view ${{ github.event.issue.number }} --repo ${{ github.repository }} --json headRefName --jq .headRefName)" >> $GITHUB_OUTPUT
 
       - name: Checkout caller repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ steps.pr.outputs.ref }}
 
@@ -165,13 +165,13 @@ jobs:
       # pr-url: ${{ steps.open-pr.outputs.pr-url }}
     steps:
       - name: Checkout caller repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           path: caller
           ref: ${{ needs.setup.outputs.pr-branch }}
 
       - name: Checkout caller configs repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: ${{ needs.setup.outputs.configs-repo }}
           path: caller-configs
@@ -179,7 +179,7 @@ jobs:
           token: ${{ secrets.configs-repo-token }}
 
       - name: Checkout build-cd
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: access-nri/build-cd
           path: build-cd
@@ -307,7 +307,7 @@ jobs:
       ARTIFACT_PATH: ./pr-urls
     steps:
       - name: Checkout build-cd
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: access-nri/build-cd
           path: build-cd

--- a/.github/workflows/ci-command-configs.yml
+++ b/.github/workflows/ci-command-configs.yml
@@ -290,7 +290,7 @@ jobs:
           jq --null-input --arg pr_url "${{ steps.open-pr.outputs.pr_url }}" '{pr_url: $pr_url}' > ./${{ env.PR_URL_ARTIFACT_NAME }}
 
       - name: Upload PR URL Artifact
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ env.PR_URL_ARTIFACT_NAME }}
           path: ./${{ env.PR_URL_ARTIFACT_NAME }}
@@ -313,7 +313,7 @@ jobs:
           path: build-cd
 
       - name: Download PR URL Artifacts
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v7
         with:
           pattern: ${{ needs.update-configs.outputs.pr-url-artifact-glob }}
           merge-multiple: true

--- a/.github/workflows/ci-command-configs.yml
+++ b/.github/workflows/ci-command-configs.yml
@@ -186,7 +186,7 @@ jobs:
           ref: v7
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           cache: pip
@@ -320,7 +320,7 @@ jobs:
           path: ${{ env.ARTIFACT_PATH }}
 
       - name: Setup python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           cache: pip

--- a/.github/workflows/ci-comment.yml
+++ b/.github/workflows/ci-comment.yml
@@ -40,7 +40,7 @@ jobs:
         # We have to do a bit more interrogation of the issue number to get the branch name to check out
         run: echo "branch=$(gh pr view ${{ github.event.issue.number }} --repo ${{ github.repository }} --json headRefName --jq .headRefName)" >> $GITHUB_OUTPUT
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ steps.issue.outputs.branch }}
           fetch-depth: 0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,7 +128,7 @@ jobs:
         with:
           targets: ${{ vars.PRERELEASE_DEPLOYMENT_TARGETS }}
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ steps.pr.outputs.head }}
 
@@ -260,7 +260,7 @@ jobs:
       TEMPLATED_COMMENT_BODY_PATH: /opt/comment-body.md
     steps:
       - name: Checkout build-cd for scripts
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: access-nri/build-cd
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -285,7 +285,7 @@ jobs:
           echo "errors=$(jq --slurp 'map(.deployment_result == "success") | all | not' ${{ env.OUTPUT_ARTIFACT_PATH }}/*)" >> $GITHUB_OUTPUT
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: 3.12
           cache: pip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -265,7 +265,7 @@ jobs:
           repository: access-nri/build-cd
 
       - name: Download matrix deployment outputs
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           pattern: ${{ needs.deploy.outputs.general-outputs-artifact-glob }}
           path: ${{ env.OUTPUT_ARTIFACT_PATH }}

--- a/.github/workflows/deploy-1-setup.yml
+++ b/.github/workflows/deploy-1-setup.yml
@@ -179,7 +179,7 @@ jobs:
     steps:
       # Validate the caller repository's config files and versions
       - name: '${{ github.repository }}: Checkout ${{ github.repository }} Config'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           path: model
           ref: ${{ inputs.deployment-ref }}
@@ -220,7 +220,7 @@ jobs:
 
       # Validate the build-cd repository's config/settings.json for the deployment target
       - name: 'build-cd: Checkout build-cd Config'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: access-nri/build-cd
           path: build-cd
@@ -247,7 +247,7 @@ jobs:
           echo "spack-config-ref=$(jq --compact-output --raw-output '."spack-config"' <<< "$refs_for_deployment")" >> $GITHUB_OUTPUT
 
       - name: 'build-cd: Checkout spack-config to get builtin spack-packages ref'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: ACCESS-NRI/spack-config
           ref: ${{ steps.config-settings-refs.outputs.spack-config }}
@@ -294,7 +294,7 @@ jobs:
       # Spack env name in form <model>-<version>
       spack-env-name: ${{ steps.get-env-name.outputs.env-name }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
           ref: ${{ inputs.deployment-ref }}

--- a/.github/workflows/deploy-1-setup.yml
+++ b/.github/workflows/deploy-1-setup.yml
@@ -440,7 +440,7 @@ jobs:
           }' > ./${{ env.UPLOAD_FILE_NAME }}
 
       - name: Upload
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ env.UPLOAD_FILE_NAME }}
           path: ./${{ env.UPLOAD_FILE_NAME }}

--- a/.github/workflows/deploy-2-start.yml
+++ b/.github/workflows/deploy-2-start.yml
@@ -106,7 +106,7 @@ jobs:
             ${{ secrets.HOST_DATA }}
 
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
           cache: 'pip'

--- a/.github/workflows/deploy-2-start.yml
+++ b/.github/workflows/deploy-2-start.yml
@@ -67,12 +67,12 @@ jobs:
       metadata-artifact-name: ${{ env.ARTIFACT_NAME }}
     steps:
       - name: Checkout ${{ github.repository }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ inputs.ref }}
 
       - name: Checkout build-cd
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: access-nri/build-cd
           path: build-cd

--- a/.github/workflows/deploy-2-start.yml
+++ b/.github/workflows/deploy-2-start.yml
@@ -302,7 +302,7 @@ jobs:
           cd -
 
       - name: Upload Metadata Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ env.ARTIFACT_NAME }}
           path: ./${{ env.ARTIFACT_NAME }}/*

--- a/.github/workflows/settings-1-update.yml
+++ b/.github/workflows/settings-1-update.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Checkout settings.json
         uses: actions/checkout@v6
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: ${{ vars.PYTHON_VERSION }}
 

--- a/.github/workflows/settings-1-update.yml
+++ b/.github/workflows/settings-1-update.yml
@@ -1,7 +1,7 @@
 name: Config Settings Update
 on:
   push:
-    # Below condition is enforced by the `if` condition in 
+    # Below condition is enforced by the `if` condition in
     # the `setup-settings-update` job:
     # branches:
     #   - $default_branch
@@ -21,7 +21,7 @@ jobs:
       targets: ${{ steps.target.outputs.targets }}
     steps:
       - name: Get deployment settings.json
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: access-nri/build-cd
 
@@ -42,7 +42,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout settings.json
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - uses: actions/setup-python@v5
         with:
@@ -75,7 +75,7 @@ jobs:
     outputs:
       updates: ${{ steps.info.outputs.updates }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Collect Deployment Information
         id: info
@@ -107,7 +107,7 @@ jobs:
     env:
       GH_TOKEN: ${{ github.token }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Get merged PR number
         id: pr

--- a/.github/workflows/settings-2-deploy.yml
+++ b/.github/workflows/settings-2-deploy.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: ${{ inputs.deployment-environment }} ${{ inputs.spack-type }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup spack updates
         id: spack

--- a/.github/workflows/undeploy-1-start.yml
+++ b/.github/workflows/undeploy-1-start.yml
@@ -40,7 +40,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: ${{ inputs.target }} ${{ inputs.type }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Get Spack Version From config/versions.json
         id: versions


### PR DESCRIPTION
See https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

## Background

Node 20 Actions will be forced to run on Node 24 in June. This PR updates all actions that use Node 20 to versions that use Node 24. Since they are `actions/*` actions, the major branch version is updated. 

## The PR

- **Update actions/checkout to v6**
- **Update actions/setup-python to v6**
- **Update actions/*-artifact to v7**
