### PR TITLE
Checkout actual `spack-config` ref supplied, update references to new `upstream-spack-packages` repository

### DIFF
--- a/.github/workflows/deploy-1-setup.yml
+++ b/.github/workflows/deploy-1-setup.yml
@@ -109,11 +109,11 @@ on:
     #   builtin-spack-packages-version:
     #     value: ${{ jobs.check-config.outputs.builtin-spack-packages-version }}
     #     description: |
-    #       Git ref of 'spack/spack-packages' that is used to reference builtin packages in spack.
+    #       Git ref of 'ACCESS-NRI/upstream-spack-packages' that is used to reference builtin packages in spack.
     #   builtin-spack-packages-git-hash:
     #     value: ${{ jobs.check-config.outputs.builtin-spack-packages-git-hash }}
     #     description: |
-    #       Git hash of the 'spack/spack-packages' repository at the specified version.
+    #       Git hash of the 'ACCESS-NRI/upstream-spack-packages' repository at the specified version.
     #   access-spack-packages-version:
     #     value: ${{ jobs.check-config.outputs.access-spack-packages-version }}
     #     description: |
@@ -250,7 +250,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           repository: ACCESS-NRI/spack-config
-          ref: ${{ steps.config-settings-refs.outputs.spack-config }}
+          ref: ${{ steps.config-settings-refs.outputs.spack-config-ref }}
           path: spack-config
 
       - name: 'build-cd: Get builtin spack-packages ref'
@@ -276,7 +276,7 @@ jobs:
         id: builtin-spack-packages-sha
         uses: access-nri/actions/.github/actions/get-git-ref-info@main
         with:
-          repository: spack/spack-packages
+          repository: ACCESS-NRI/upstream-spack-packages
           ref: ${{ steps.builtin-spack-packages.outputs.ref }}
 
   check-spack-yaml:

--- a/scripts/jinja_template/templates/deployment-comment-body.md.j2
+++ b/scripts/jinja_template/templates/deployment-comment-body.md.j2
@@ -32,7 +32,7 @@ Due to inode-saving measures, one will have to manually untar the environment me
 
 This Prerelease is deployed using:
 * `access-nri/spack` on branch [`{{ deployment.spack_version }}`](https://github.com/ACCESS-NRI/spack/tree/{{ deployment.spack_git_hash }})
-* `spack/spack-packages` version [`{{ deployment.builtin_spack_packages_version }}`](https://github.com/spack/spack-packages/tree/{{ deployment.builtin_spack_packages_git_hash }})
+* `ACCESS-NRI/upstream-spack-packages` version [`{{ deployment.builtin_spack_packages_version }}`](https://github.com/ACCESS-NRI/upstream-spack-packages/tree/{{ deployment.builtin_spack_packages_git_hash }})
 * `access-nri/access-spack-packages` version [`{{ deployment.access_spack_packages_version }}`](https://github.com/ACCESS-NRI/access-spack-packages/tree/{{ deployment.access_spack_packages_git_hash }})
 * `access-nri/spack-config` version [`{{ deployment.spack_config_version }}`](https://github.com/ACCESS-NRI/spack-config/tree/{{ deployment.spack_config_git_hash }})
 

--- a/scripts/jinja_template/templates/release-body.md.j2
+++ b/scripts/jinja_template/templates/release-body.md.j2
@@ -4,7 +4,7 @@ This is an official release of `{{ model }}` `{{ version }}` to the HPC(s) {% fo
 {% for deployment in deployments %}
 ### `{{ deployment.name }}`
 
-Deployed using [spack {{ deployment.spack_version }}](https://github.com/ACCESS-NRI/spack/tree/{{ deployment.spack_git_hash }}), [spack/spack-packages {{ deployment.builtin_spack_packages_version }}](https://github.com/spack/spack-packages/tree/{{ deployment.builtin_spack_packages_git_hash }}), [ACCESS-NRI/access-spack-packages {{ deployment.access_spack_packages_version }}](https://github.com/ACCESS-NRI/access-spack-packages/tree/{{ deployment.access_spack_packages_git_hash }})  and [spack-config {{ deployment.spack_config_version }}](https://github.com/ACCESS-NRI/spack-config/tree/{{ deployment.spack_config_git_hash }}).
+Deployed using [spack {{ deployment.spack_version }}](https://github.com/ACCESS-NRI/spack/tree/{{ deployment.spack_git_hash }}), [ACCESS-NRI/upstream-spack-packages {{ deployment.builtin_spack_packages_version }}](https://github.com/ACCESS-NRI/upstream-spack-packages/tree/{{ deployment.builtin_spack_packages_git_hash }}), [ACCESS-NRI/access-spack-packages {{ deployment.access_spack_packages_version }}](https://github.com/ACCESS-NRI/access-spack-packages/tree/{{ deployment.access_spack_packages_git_hash }})  and [spack-config {{ deployment.spack_config_version }}](https://github.com/ACCESS-NRI/spack-config/tree/{{ deployment.spack_config_git_hash }}).
 
 Deployed as a module accessible using:
 


### PR DESCRIPTION
See failing workflow https://github.com/ACCESS-NRI/ACCESS-OM2/actions/runs/26136102887/job/76871574166?pr=148

## Background

The above workflow actually demonstrates two bugs:

### Bug 1: Using a non-existent step output

In `deploy-1-setup.yml`s `Checkout spack-config to get builtin spack-packages ref` step, we mistakenly template `actions/checkout`s `ref` with `steps.config-settings-refs.outputs.spack-config` (which doesn't exist - should be `steps.config-settings-refs.outputs.spack-config-ref`). This means that it has been using the current `main` of `spack-config` for validation of configuration, rather than the version that the spack instance is currently using. 

Due to a recent change (https://github.com/ACCESS-NRI/spack-config/pull/113) to `spack-config`, it led to us attempting to validate a `ACCESS-NRI/upstream-spack-packages` branch against the `spack/spack-packages` repository. Which leads to the second bug...

### Bug 2: Not updating references to `upstream-spack-packages`

We have moved to `ACCESS-NRI/upstream-spack-packages`. But the CI is still validating against the original `spack/spack-packages`. Even if the first bug hadn't happened, this would show up when we updated the spack instances `spack-config` to the current `main`. 

## The PR

* Checkout the actual `spack-config` ref, rather than `main`, by using the proper template variable
* Update all references of `spack/spack-packages` to `ACCESS-NRI/upstream-spack-packages`. 
