### PR TITLE
Set environment-level `access-spack-packages` update appropriately

### DIFF
--- a/.github/workflows/deploy-2-start.yml
+++ b/.github/workflows/deploy-2-start.yml
@@ -208,6 +208,7 @@ jobs:
           spack env activate ${{ inputs.env-name }} --create --envfile ${{ vars.SPACK_YAML_LOCATION }}/${{ inputs.expected-root-spec-name }}-${{ github.run_id }}.spack.yaml
 
           # Update access-spack-packages repository before installation
+          spack repo set access_spack_packages
           spack repo update access_spack_packages --commit ${{ steps.packages-ref.outputs.sha }}
 
           # Finally, install the spack manifest


### PR DESCRIPTION
See failing Release Deployment in https://github.com/ACCESS-NRI/ACCESS-OM2/actions/runs/26146764625/job/76904387515#step:15:119

## Background

Our `Release` deployments are failing because a bare `spack repo update access_spack_packages` at the environment scope leads to an inconsistent `repos` section. This is the same issue (just a different scope) as https://github.com/ACCESS-NRI/build-ci/pull/292, specifically https://github.com/ACCESS-NRI/build-ci/pull/292/changes#diff-5a225825f77ad0eceb5a0e01f60b70dd9cd92e8898b2800e85aca1836f1ffa63L54-R57).

Essentially, when we do a bare `spack repo update` when there is no corresponding section in the `spack.yaml`, we get:

```yaml
spack:
  # ...
  repos:
    'access_spack_packages:':
      commit: 8cedd8f2f4a0fb1b5017c9d3d6a246fd74148589

```

in which the `access_spack_packages::` overrides existing, lower-scope config (including required `git` attributes). This leads to the error: "Invalid configuration for repository 'access_spack_packages': ordereddict([('commit', '8cedd8f2f4a0fb1b5017c9d3d6a246fd74148589')]). A `git` attribute is required for remote repositories."

The fix is to do `spack repo set access_spack_packages` first, so the config doesn't use the `::` operator, which disregards the required `git` attribute:

```yaml
spack:
  # ...
  repos:
    access_spack_packages: {}
```

and then the `spack repo update` works as intended:

```yaml
spack:
  # ...
  repos:
    access_spack_packages:
      commit: 8cedd8f2f4a0fb1b5017c9d3d6a246fd74148589
```

Which leads to a valid `repos`:

```bash
$ spack config blame repos
---                                                                                            repos:
/g/data/vk83/prerelease/apps/spack/1.1/environments/test_access-om2-2026_05_000/spack.yaml:74    access_spack_packages:
/g/data/vk83/prerelease/apps/spack/1.1/environments/test_access-om2-2026_05_000/spack.yaml:75      commit: 8cedd8f2f4a0fb1b5017c9d3d6a246fd74148589
/g/data/vk83/prerelease/apps/spack/1.1/spack-config/v1.1/repos.yaml:4                              git: https://github.com/ACCESS-NRI/access-spack-packages.git
/g/data/vk83/prerelease/apps/spack/1.1/spack-config/v1.1/repos.yaml:5                              branch: api-v2
/g/data/vk83/prerelease/apps/spack/1.1/spack-config/v1.1/repos.yaml:6                              destination: $spack/../access-spack-packages
/g/data/vk83/prerelease/apps/spack/1.1/spack-config/v1.1/repos.yaml:7                            builtin:
/g/data/vk83/prerelease/apps/spack/1.1/spack-config/v1.1/repos.yaml:8                              git: https://github.com/ACCESS-NRI/upstream-spack-packages.git
/g/data/vk83/prerelease/apps/spack/1.1/spack-config/v1.1/repos.yaml:10                             commit: 2f02a99ec9dfd5dceb9bd91abc392edabd9ba963
/g/data/vk83/prerelease/apps/spack/1.1/spack-config/v1.1/repos.yaml:11                             destination: $spack/../spack-packages
```

## The PR

* Add `spack repo set` before `spack repo update` so the config doesn't override required, lower scope attributes like `git`.

## Testing

Tested manually in the Gadi Pre/Release instances:

### Release

The Background section explaining the fix was done in a `test_access-om2-2026_05_000` environment, and it worked! 

### Prerelease

Tested the same commands in a `test` Prerelease environment, and it worked - even though we inject that manually in the prerelease injection stage - making it essentially a no-op:

```bash
$ spack env activate test --create --envfile /g/data/vk83/prerelease/apps/spack/1.1/environments/access-om2-pr138-9/spack.yaml 

[tm70_ci@gadi-login-05 ~]$ spack config blame repos
---                                                                      repos:
/g/data/vk83/prerelease/apps/spack/1.1/environments/test/spack.yaml:104    access_spack_packages:
/g/data/vk83/prerelease/apps/spack/1.1/environments/test/spack.yaml:105      git: https://github.com/ACCESS-NRI/access-spack-packages.git
/g/data/vk83/prerelease/apps/spack/1.1/environments/test/spack.yaml:106      destination: /g/data/vk83/prerelease/apps/spack/1.1/environments/access-om2-pr138-9/access-spack-packages
/g/data/vk83/prerelease/apps/spack/1.1/environments/test/spack.yaml:107      commit: 900bb5e689803a4bfa7302500afb395b8e53beaa
/g/data/vk83/prerelease/apps/spack/1.1/spack-config/v1.1/repos.yaml:5        branch: api-v2
/g/data/vk83/prerelease/apps/spack/1.1/spack-config/v1.1/repos.yaml:7      builtin:
/g/data/vk83/prerelease/apps/spack/1.1/spack-config/v1.1/repos.yaml:8        git: https://github.com/ACCESS-NRI/upstream-spack-packages.git
/g/data/vk83/prerelease/apps/spack/1.1/spack-config/v1.1/repos.yaml:10       commit: 2f02a99ec9dfd5dceb9bd91abc392edabd9ba963
/g/data/vk83/prerelease/apps/spack/1.1/spack-config/v1.1/repos.yaml:11       destination: $spack/../spack-packages

[tm70_ci@gadi-login-05 ~]$ spack repo set access_spack_packages
==> Updated repo 'access_spack_packages'

[tm70_ci@gadi-login-05 ~]$ spack repo update access_spack_packages --commit 900bb5e689803a4bfa7302500afb395b8e53beaa
==> access_spack_packages: Already up to date.

[tm70_ci@gadi-login-05 ~]$ spack config blame repos
---                                                                      repos:
/g/data/vk83/prerelease/apps/spack/1.1/environments/test/spack.yaml:104    access_spack_packages:
/g/data/vk83/prerelease/apps/spack/1.1/environments/test/spack.yaml:105      git: https://github.com/ACCESS-NRI/access-spack-packages.git
/g/data/vk83/prerelease/apps/spack/1.1/environments/test/spack.yaml:106      destination: /g/data/vk83/prerelease/apps/spack/1.1/environments/access-om2-pr138-9/access-spack-packages
/g/data/vk83/prerelease/apps/spack/1.1/environments/test/spack.yaml:107      commit: 900bb5e689803a4bfa7302500afb395b8e53beaa
/g/data/vk83/prerelease/apps/spack/1.1/spack-config/v1.1/repos.yaml:5        branch: api-v2
/g/data/vk83/prerelease/apps/spack/1.1/spack-config/v1.1/repos.yaml:7      builtin:
/g/data/vk83/prerelease/apps/spack/1.1/spack-config/v1.1/repos.yaml:8        git: https://github.com/ACCESS-NRI/upstream-spack-packages.git
/g/data/vk83/prerelease/apps/spack/1.1/spack-config/v1.1/repos.yaml:10       commit: 2f02a99ec9dfd5dceb9bd91abc392edabd9ba963
/g/data/vk83/prerelease/apps/spack/1.1/spack-config/v1.1/repos.yaml:11       destination: $spack/../spack-packages
```