### PR TITLE
export SPACK_PYTHON to version `3.12`

### DIFF
--- a/.github/workflows/deploy-2-start.yml
+++ b/.github/workflows/deploy-2-start.yml
@@ -198,8 +198,9 @@ jobs:
           export DEPLOYMENT_TARGET="${{ vars.DEPLOYMENT_TARGET }}"
           echo "DEPLOYMENT_TARGET exported as $DEPLOYMENT_TARGET"
 
-          #FIXME: Remove this once spack modules are deployed
+          #FIXME: Remove this once spack modules are deployed for admins
           export SPACK_USER_CACHE_PATH=${{ steps.path.outputs.spack }}/../spack-admin-cache
+          export SPACK_PYTHON=/usr/bin/python3.12
 
           # Enable spack
           . ${{ steps.path.outputs.spack }}/share/spack/setup-env.sh


### PR DESCRIPTION
References #394

## Background

There are significant performance improvements if we move to a later version of `python` - specifically `3.12`. 

> [!NOTE]
> When we have a admin set of modulefiles in https://github.com/ACCESS-NRI/build-cd/pull/367, we can move to that

## The PR

* export `SPACK_PYTHON` to `/usr/bin/python3.12`
