### PR TITLE
Support Multiple Partial Root Specs In Projections

### DIFF
--- a/scripts/spack_manifest/getter.py
+++ b/scripts/spack_manifest/getter.py
@@ -352,6 +352,13 @@ class Includes:
 class Projections:
     def __init__(self, manifest: dict[str, Any]):
         self.manifest: dict[str, Any] = manifest
+        self.projections: dict[str, str] = (
+            manifest.get("spack", {})
+            .get("modules", {})
+            .get("default", {})
+            .get("tcl", {})
+            .get("projections", {})
+        )
 
     # Can also pass in a path to a yaml manifest instead of a python object
     @classmethod
@@ -364,20 +371,14 @@ class Projections:
         return cls(manifest)
 
     def get(self) -> dict[str, str]:
-        return (
-            self.manifest.get("spack", {})
-            .get("modules", {})
-            .get("default", {})
-            .get("tcl", {})
-            .get("projections", {})
-        )
+        return self.projections
 
     def get_projection_with_name(self, name: str) -> str | None:
-        return (
-            self.manifest.get("spack", {})
-            .get("modules", {})
-            .get("default", {})
-            .get("tcl", {})
-            .get("projections", {})
-            .get(name, None)
-        )
+        return self.projections.get(name, None)
+
+    def get_partial_specs_of(self, name: str) -> dict[str, str]:
+        return {
+            partial: projection
+            for partial, projection in self.projections.items()
+            if partial.startswith(name)
+        }

--- a/scripts/spack_manifest/getter.py
+++ b/scripts/spack_manifest/getter.py
@@ -377,8 +377,10 @@ class Projections:
         return self.projections.get(name, None)
 
     def get_partial_specs_of(self, name: str) -> dict[str, str]:
+        # Match exact root spec or root spec followed by a valid spec continuation.
+        pattern = re.compile(rf"^{re.escape(name)}($|[+~@% ])")
         return {
             partial: projection
             for partial, projection in self.projections.items()
-            if partial.startswith(name)
+            if pattern.match(partial)
         }

--- a/scripts/spack_manifest/injection/modules.py
+++ b/scripts/spack_manifest/injection/modules.py
@@ -88,7 +88,7 @@ def inject_projections(
 
     # This matches projection keys that are more complex partial specs, like model~variant
     projections_like_root_spec = projections_getter.get_partial_specs_of(root_spec)
-    list_of_projections_like_root_spec: list[str] = [root_spec] + list(projections_like_root_spec.keys())
+    projections_like_root_spec_set: set[str] = {root_spec} | set(projections_like_root_spec.keys())
 
     if not projections_like_root_spec:
         new_projections.update(generate_projection_for_root_spec_from_scratch(manifest, root_spec))
@@ -102,7 +102,7 @@ def inject_projections(
         )
 
     # Sort the projections by name to ensure a consistent order...
-    ordered_new_projections: dict[str, str] = order_projections(projections=new_projections, root_spec_like_specs=list_of_projections_like_root_spec)
+    ordered_new_projections: dict[str, str] = order_projections(projections=new_projections, root_spec_like_specs=projections_like_root_spec_set)
 
     # Finally, add the new projections to the manifest
     injected_manifest: dict[str, Any] = dict(manifest)
@@ -135,14 +135,14 @@ def inject_includes(
 # Lower-level functions to generate manifest sections #
 #######################################################
 
-def order_projections(projections: dict[str, str], root_spec_like_specs: list[str]) -> dict[str, str]:
-    root_specs: dict[str, str] = {spec: projection for spec, projection in projections.items() if spec in root_spec_like_specs}
-    other_specs: dict[str, str] = {spec: projection for spec, projection in projections.items() if spec not in root_spec_like_specs}
-
-    ordered_root_specs = dict(sorted(root_specs.items()))
-    ordered_other_specs = dict(sorted(other_specs.items()))
-
-    return {**ordered_root_specs, **ordered_other_specs}
+def order_projections(projections: dict[str, str], root_spec_like_specs: set[str]) -> dict[str, str]:
+    return dict(
+        sorted(
+            projections.items(),
+            # Sort first by root_spec_like_specs membership, then alphabetically
+            key=lambda item: (item[0] not in root_spec_like_specs, item[0]),
+        )
+    )
 
 def generate_projection_for_root_spec_from_scratch(manifest: dict[str, Any], root_spec_name: str) -> dict[str, str]:
     version = ReservedDefinitions(manifest).get("version")

--- a/scripts/spack_manifest/injection/modules.py
+++ b/scripts/spack_manifest/injection/modules.py
@@ -87,7 +87,7 @@ def inject_projections(
     new_projections: dict[str, str] = dict(defined_projections_dict)
 
     # This matches projection keys that are more complex partial specs, like model~variant
-    projections_like_root_spec = {partial_spec: projection for partial_spec, projection in defined_projections_dict.items() if partial_spec.startswith(root_spec)}
+    projections_like_root_spec = projections_getter.get_partial_specs_of(root_spec)
     list_of_projections_like_root_spec: list[str] = [root_spec] + list(projections_like_root_spec.keys())
 
     if not projections_like_root_spec:

--- a/scripts/spack_manifest/injection/modules.py
+++ b/scripts/spack_manifest/injection/modules.py
@@ -86,9 +86,15 @@ def inject_projections(
     # To start with, add the projections that are already defined in the manifest
     new_projections: dict[str, str] = dict(defined_projections_dict)
 
-    new_projections.update(
-        generate_projection_for_root_spec_or_raise(manifest, root_spec, defined_projections_dict.get(root_spec, ''))
-    )
+    # This matches projection keys that are more complex partial specs, like model~variant
+    projections_like_root_spec = {partial_spec: projection for partial_spec, projection in defined_projections_dict.items() if partial_spec.startswith(root_spec)}
+    list_of_projections_like_root_spec: list[str] = [root_spec] + list(projections_like_root_spec.keys())
+
+    if not projections_like_root_spec:
+        new_projections.update(generate_projection_for_root_spec_from_scratch(manifest, root_spec))
+    else:
+        for partial, projection in projections_like_root_spec.items():
+            new_projections.update(update_projection_for_root_spec_or_raise(manifest, partial, projection))
 
     for projection in projections_to_generate:
         new_projections.update(
@@ -96,11 +102,7 @@ def inject_projections(
         )
 
     # Sort the projections by name to ensure a consistent order...
-    ordered_new_projections = dict(sorted(new_projections.items()))
-
-    # But, we want to ensure that the root spec projection is always first in the list because it's special
-    root_spec_version = ordered_new_projections.pop(root_spec)
-    ordered_new_projections = {root_spec: root_spec_version, **ordered_new_projections}
+    ordered_new_projections: dict[str, str] = order_projections(projections=new_projections, root_spec_like_specs=list_of_projections_like_root_spec)
 
     # Finally, add the new projections to the manifest
     injected_manifest: dict[str, Any] = dict(manifest)
@@ -133,32 +135,46 @@ def inject_includes(
 # Lower-level functions to generate manifest sections #
 #######################################################
 
+def order_projections(projections: dict[str, str], root_spec_like_specs: list[str]) -> dict[str, str]:
+    root_specs: dict[str, str] = {spec: projection for spec, projection in projections.items() if spec in root_spec_like_specs}
+    other_specs: dict[str, str] = {spec: projection for spec, projection in projections.items() if spec not in root_spec_like_specs}
 
-def generate_projection_for_root_spec_or_raise(
-    manifest: dict[str, Any],
-    root_spec_name: str,
-    root_spec_projection: str = ''
-) -> dict[str, str]:
-    reserved_definitions_getter = ReservedDefinitions(manifest)
+    ordered_root_specs = dict(sorted(root_specs.items()))
+    ordered_other_specs = dict(sorted(other_specs.items()))
 
-    version = reserved_definitions_getter.get("version")
+    return {**ordered_root_specs, **ordered_other_specs}
+
+def generate_projection_for_root_spec_from_scratch(manifest: dict[str, Any], root_spec_name: str) -> dict[str, str]:
+    version = ReservedDefinitions(manifest).get("version")
 
     print(
         f"Extracted version '{version}' from _version definition'"
     )
 
-    if not root_spec_projection:  # we need to make a projection from scratch...
-        root_specs_in_speclist = len(Specs(manifest).get_specs_with_name(root_spec_name))
+    root_specs_in_speclist = len(Specs(manifest).get_specs_with_name(root_spec_name))
 
-        if root_specs_in_speclist == 0:
-            raise ValueError(f"No specs with name {root_spec_name} in speclist")
-        elif root_specs_in_speclist == 1:
-            return {root_spec_name: f"{{name}}/{version}"}
-        else:
-            # If there are multiple of the same root spec (for example, different variants housed under the same environment), we need to demarcate the modulefile with a spack package hash
-            return {root_spec_name: f"{{name}}/{version}/{{hash:7}}"}
+    if root_specs_in_speclist == 0:
+        raise ValueError(f"No specs with name {root_spec_name} in speclist")
+    elif root_specs_in_speclist == 1:
+        return {root_spec_name: f"{{name}}/{version}"}
+    else:
+        # If there are multiple of the same root spec (for example, different variants housed under the same environment), we need to demarcate the modulefile with a spack package hash
+        return {root_spec_name: f"{{name}}/{version}/{{hash:7}}"}
+
+
+def update_projection_for_root_spec_or_raise(
+    manifest: dict[str, Any],
+    root_spec_name: str,
+    root_spec_projection: str = ''
+) -> dict[str, str]:
+    version = ReservedDefinitions(manifest).get("version")
+
+    print(
+        f"Extracted version '{version}' from _version definition'"
+    )
 
     return {root_spec_name: root_spec_projection.replace("{version}", version)}
+
 
 def generate_projection_for_package_or_raise(
     manifest: dict[str, Any], package_name: str

--- a/scripts/spack_manifest/injection/prerelease.py
+++ b/scripts/spack_manifest/injection/prerelease.py
@@ -98,9 +98,9 @@ def add_namespace_to_other_projection_versions(
         )
 
         # Ensures that the new projection is a quoted string when dumped so spack does projected modules correctly, see top of file.
-        manifest["spack"]["modules"]["default"]["tcl"]["projections"][projection_name] = YamlExplicitQuotedString(new_projection_value)
+        mutable_manifest["spack"]["modules"]["default"]["tcl"]["projections"][projection_name] = YamlExplicitQuotedString(new_projection_value)
 
-    return manifest
+    return mutable_manifest
 
 
 def update_root_spec_projections_version(

--- a/scripts/spack_manifest/injection/prerelease.py
+++ b/scripts/spack_manifest/injection/prerelease.py
@@ -85,10 +85,9 @@ def add_namespace_to_other_projection_versions(
     root_spec_like_projections: dict[str, str] = projections_getter.get_partial_specs_of(root_spec_name)
 
     # We only want to modify projections that are not root-spec-like, since they already have their version set
-    for root_spec_like_projection in root_spec_like_projections:
-        projections.pop(root_spec_like_projection, None)
-
     for projection_name, projection_value in projections.items():
+        if projection_name in root_spec_like_projections:
+            continue
         # Non-root-spec projections are namespaced under ROOT_SPEC_NAME/dependencies/prX-Y,
         # while preserving the original projection structure (with or without a {name} token).
         new_projection_value = f"{root_spec_name}/dependencies/{version}/{projection_value.lstrip('/')}"

--- a/scripts/spack_manifest/injection/prerelease.py
+++ b/scripts/spack_manifest/injection/prerelease.py
@@ -48,7 +48,7 @@ def inject_prerelease_information(
     # We want the root spec projection to be of the form {name}/prX-Y for single specs, and
     # {name}/prX-Y/DEMARCATOR for multiple specs, so we don't have modulefile clashes.
     # The DEMARCATOR can be a custom projection, or {hash:7} if not supplied.
-    updated_manifest = update_root_spec_projection_version(
+    updated_manifest = update_root_spec_projections_version(
         updated_manifest, root_spec_name, version
     )
 
@@ -78,12 +78,15 @@ def add_namespace_to_other_projection_versions(
 ) -> dict[str, Any]:
     # We don't want to modify the linked manifest dict, so we create a mutable copy.
     mutable_manifest: dict[str, Any] = deepcopy(manifest)
-    projections_from_manifest = Projections(mutable_manifest)
-    projections = projections_from_manifest.get()
 
-    # We only want to modify projections that are not the root spec, since that already has its version set
-    if root_spec_name in projections:
-        projections.pop(root_spec_name)
+
+    projections_getter = Projections(mutable_manifest)
+    projections: dict[str, str] = projections_getter.get()
+    root_spec_like_projections: dict[str, str] = projections_getter.get_partial_specs_of(root_spec_name)
+
+    # We only want to modify projections that are not root-spec-like, since they already have their version set
+    for root_spec_like_projection in root_spec_like_projections:
+        projections.pop(root_spec_like_projection, None)
 
     for projection_name, projection_value in projections.items():
         # Non-root-spec projections are namespaced under ROOT_SPEC_NAME/dependencies/prX-Y,
@@ -100,30 +103,33 @@ def add_namespace_to_other_projection_versions(
     return manifest
 
 
-def update_root_spec_projection_version(
+def update_root_spec_projections_version(
     manifest: dict[str, Any], root_spec_name: str, deployment_version: str
 ) -> dict[str, Any]:
     manifest.setdefault("spack", {}).setdefault("modules", {}).setdefault("default", {}).setdefault("tcl", {}).setdefault("projections", {})
 
-    current_root_projection = Projections(manifest).get_projection_with_name(root_spec_name)
+    projections_like_root_spec: dict[str, str] | None = Projections(manifest).get_partial_specs_of(root_spec_name)
     number_of_root_specs_in_speclist = len(Specs(manifest).get_specs_with_name(root_spec_name))
 
-    if current_root_projection:
+    if projections_like_root_spec:
         # Replace the manifest version wherever it appears as a path segment in the projection.
         current_version = ReservedDefinitions(manifest).get("version")
-        new_root_projection = current_root_projection.replace(current_version, deployment_version)
+        for root_spec_partial, current_root_projection in projections_like_root_spec.items():
+            new_root_projection = current_root_projection.replace(current_version, deployment_version)
 
-        if number_of_root_specs_in_speclist > 1 and re.match(fr"^.+/{deployment_version}$", new_root_projection):
-            # If there are multiple of the same root spec, we need to demarcate them somehow if there was no custom suffix given.
-            # We use a short package hash as the demarcator if no custom suffix was given.
-            new_root_projection += "/{hash:7}"
+            if number_of_root_specs_in_speclist > 1 and re.match(fr"^.+/{deployment_version}$", new_root_projection):
+                # If there are multiple of the same root spec, we need to demarcate them somehow if there was no custom suffix given.
+                # We use a short package hash as the demarcator if no custom suffix was given.
+                new_root_projection += "/{hash:7}"
+
+            manifest["spack"]["modules"]["default"]["tcl"]["projections"][root_spec_partial] = new_root_projection
     else:
         if number_of_root_specs_in_speclist == 1:
             new_root_projection = f'{{name}}/{deployment_version}'
         else:
             new_root_projection = f'{{name}}/{deployment_version}/{{hash:7}}'
 
-    manifest["spack"]["modules"]["default"]["tcl"]["projections"][root_spec_name] = new_root_projection
+        manifest["spack"]["modules"]["default"]["tcl"]["projections"][root_spec_name] = new_root_projection
 
     return manifest
 

--- a/tests/scripts/spack_manifest/injection/test_modules.py
+++ b/tests/scripts/spack_manifest/injection/test_modules.py
@@ -6,6 +6,7 @@ from scripts.spack_manifest.injection.modules import (
     inject_includes,
 
     generate_projection_for_root_spec_from_scratch,
+    order_projections,
     update_projection_for_root_spec_or_raise,
     generate_projection_for_package_or_raise,
 
@@ -242,8 +243,78 @@ class TestGenerateProjectionForPackageOrRaise:
         with pytest.raises(NoSectionComponentError):
             generate_projection_for_package_or_raise(manifest, projection)
 
+class TestOrderProjections:
+    def test_order_projections__single_root_spec(self):
+        projections: dict[str, str] = {
+            "cice5": "{name}/2023.10.19-{hash:7}",
+            "libaccessom2": "{name}/2023.10.26-{hash:7}",
+            "mom5": "{name}/2023.11.09-{hash:7}",
+            "oasis3-mct": "{name}/2023.11.09-{hash:7}",
+            "access-om2": "{name}/2024.03.0",
+        }
 
-###############
+        root_spec_like_specs: set[str] = {"access-om2"}
+
+        result = order_projections(projections, root_spec_like_specs)
+
+        expected = {
+            "access-om2": "{name}/2024.03.0",
+            "cice5": "{name}/2023.10.19-{hash:7}",
+            "libaccessom2": "{name}/2023.10.26-{hash:7}",
+            "mom5": "{name}/2023.11.09-{hash:7}",
+            "oasis3-mct": "{name}/2023.11.09-{hash:7}",
+        }
+
+        assert result == expected, "Projections should be ordered with root spec first, followed by others alphabetically."
+
+    def test_order_projections__multiple_root_like_specs(self):
+        projections: dict[str, str] = {
+            "cice5": "{name}/2023.10.19-{hash:7}",
+            "libaccessom2": "{name}/2023.10.26-{hash:7}",
+            "mom5": "{name}/2023.11.09-{hash:7}",
+            "oasis3-mct": "{name}/2023.11.09-{hash:7}",
+            "access-om2+variant": "{name}/2024.03.0",
+            "access-om2~variant": "{name}-variant/2024.03.0",
+        }
+
+        root_spec_like_specs: set[str] = {"access-om2+variant", "access-om2~variant"}
+
+        result = order_projections(projections, root_spec_like_specs)
+
+        expected = {
+            "access-om2+variant": "{name}/2024.03.0",
+            "access-om2~variant": "{name}-variant/2024.03.0",
+            "cice5": "{name}/2023.10.19-{hash:7}",
+            "libaccessom2": "{name}/2023.10.26-{hash:7}",
+            "mom5": "{name}/2023.11.09-{hash:7}",
+            "oasis3-mct": "{name}/2023.11.09-{hash:7}",
+        }
+
+        assert result == expected, "Projections should be ordered with root spec like entries first, followed by others alphabetically."
+
+    def test_order_projections__alphabetically_lower_root_spec(self):
+        projections: dict[str, str] = {
+            "cice5": "{name}/2023.10.19-{hash:7}",
+            "libaccessom2": "{name}/2023.10.26-{hash:7}",
+            "mom5": "{name}/2023.11.09-{hash:7}",
+            "oasis3-mct": "{name}/2023.11.09-{hash:7}",
+            "z-access-om2": "{name}/2024.03.0",
+        }
+
+        root_spec_like_specs: set[str] = {"z-access-om2"}
+
+        result = order_projections(projections, root_spec_like_specs)
+
+        expected = {
+            "z-access-om2": "{name}/2024.03.0",
+            "cice5": "{name}/2023.10.19-{hash:7}",
+            "libaccessom2": "{name}/2023.10.26-{hash:7}",
+            "mom5": "{name}/2023.11.09-{hash:7}",
+            "oasis3-mct": "{name}/2023.11.09-{hash:7}",
+        }
+
+        assert result == expected, "Projections should be ordered with root spec first, followed by others alphabetically."
+
 
 class TestInjectProjections:
     def test_inject_projections__valid(self):

--- a/tests/scripts/spack_manifest/injection/test_modules.py
+++ b/tests/scripts/spack_manifest/injection/test_modules.py
@@ -5,7 +5,8 @@ from scripts.spack_manifest.injection.modules import (
     inject_projections,
     inject_includes,
 
-    generate_projection_for_root_spec_or_raise,
+    generate_projection_for_root_spec_from_scratch,
+    update_projection_for_root_spec_or_raise,
     generate_projection_for_package_or_raise,
 
     parse_args
@@ -64,20 +65,20 @@ class TestParseArgs:
         assert parsed_args.packages == "mom5,cice5,libaccessom2"
 
 
-class TestGenerateProjectionForRootSpecOrRaise:
+class TestGenerateProjectionForRootSpecFromScratch:
 
-    def test_generate_projection_for_root_spec_or_raise__valid_single_target(self):
+    def test_generate_projection_for_root_spec_from_scratch__valid_single_target(self):
         manifest = {"spack": {"definitions": [{"_name": ["access-om2"]}, {"_version": ["2025.05.000"]}],"specs": ["access-om2 +debug ~mpi"]}}
 
         projection = "access-om2"
         expected_version = {"access-om2": "{name}/2025.05.000"}
-        result = generate_projection_for_root_spec_or_raise(manifest, projection)
+        result = generate_projection_for_root_spec_from_scratch(manifest, projection)
 
         assert (
             result == expected_version
         ), f"Expected version {expected_version} for spec {projection}."
 
-    def test_generate_projection_for_root_spec_or_raise__valid_multi_target(self):
+    def test_generate_projection_for_root_spec_from_scratch__valid_multi_target(self):
         manifest = {
             "spack": {
                 "definitions": [
@@ -90,13 +91,13 @@ class TestGenerateProjectionForRootSpecOrRaise:
 
         projection = "access-om2"
         expected_version = {"access-om2": "{name}/2025.05.000"}
-        result = generate_projection_for_root_spec_or_raise(manifest, projection)
+        result = generate_projection_for_root_spec_from_scratch(manifest, projection)
 
         assert (
             result == expected_version
         ), f"Expected version {expected_version} for spec {projection}."
 
-    def test_generate_projection_for_root_spec_or_raise__single_target_no_version_defined(
+    def test_generate_projection_for_root_spec_from_scratch__single_target_no_version_defined(
         self,
     ):
         manifest = {"spack": {"definitions": [{"_name": ["access-om2"]}],"specs": ["access-om2"]}}
@@ -104,9 +105,9 @@ class TestGenerateProjectionForRootSpecOrRaise:
         projection = "access-om2"
 
         with pytest.raises(NoSectionComponentError):
-            generate_projection_for_root_spec_or_raise(manifest, projection)
+            generate_projection_for_root_spec_from_scratch(manifest, projection)
 
-    def test_generate_projection_for_root_spec_or_raise__multi_target_no_version_defined(
+    def test_generate_projection_for_root_spec_from_scratch__multi_target_no_version_defined(
         self,
     ):
         manifest = {"spack": {"definitions": [{"ROOT_PACKAGE": ["access-om2"]}]}}
@@ -114,9 +115,9 @@ class TestGenerateProjectionForRootSpecOrRaise:
         projection = "access-om2"
 
         with pytest.raises(NoSectionComponentError):
-            generate_projection_for_root_spec_or_raise(manifest, projection)
+            generate_projection_for_root_spec_from_scratch(manifest, projection)
 
-    def test_generate_projection_for_root_spec_or_raise__single_target_wrong_projection(
+    def test_generate_projection_for_root_spec_from_scratch__single_target_wrong_projection(
         self,
     ):
         manifest = {"spack": {"definitions": [{"_name": ["access-om2"]}, {"_version": ["2025.05.000"]}],"specs": ["access-om2 +debug ~mpi"]}}
@@ -124,9 +125,9 @@ class TestGenerateProjectionForRootSpecOrRaise:
         projection = "wrong-projection"
 
         with pytest.raises(ValueError):
-            generate_projection_for_root_spec_or_raise(manifest, projection)
+            generate_projection_for_root_spec_from_scratch(manifest, projection)
 
-    def test_generate_projection_for_root_spec_or_raise__multi_target_wrong_projection(
+    def test_generate_projection_for_root_spec_from_scratch__multi_target_wrong_projection(
         self,
     ):
         manifest = {
@@ -142,9 +143,39 @@ class TestGenerateProjectionForRootSpecOrRaise:
         projection = "wrong-projection"
 
         with pytest.raises(ValueError):
-            generate_projection_for_root_spec_or_raise(manifest, projection)
+            generate_projection_for_root_spec_from_scratch(manifest, projection)
 
-    def test_generate_projection_for_root_spec_or_raise__projection_without_default_name(self):
+class TestUpdateProjectionForRootSpecOrRaise:
+
+    def test_update_projection_for_root_spec_or_raise__projection_default_name(self):
+        root_spec_name="access-issm"
+        root_spec_version="2025.12.000"
+        root_spec_projection="{name}{variants.ad}/{version}"
+
+        partial_manifest = {
+            "spack": {
+                "definitions": [
+                    {"_name": [root_spec_name]},
+                    {"_version": [root_spec_version]},
+                ],
+                "specs": [root_spec_name],
+                "modules": {
+                    "default": {
+                        "tcl": {
+                            "projections": {
+                                root_spec_name: root_spec_projection
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        result_projections = update_projection_for_root_spec_or_raise(partial_manifest, root_spec_name, root_spec_projection)
+
+        assert result_projections == {root_spec_name: f"{{name}}{{variants.ad}}/{root_spec_version}"}
+
+    def test_update_projection_for_root_spec_or_raise__projection_without_default_name(self):
         root_spec_name="access-issm"
         root_spec_version="2025.12.000"
         root_spec_projection="ISSM{variants.ad}/{version}"
@@ -168,7 +199,7 @@ class TestGenerateProjectionForRootSpecOrRaise:
             }
         }
 
-        result_projections = generate_projection_for_root_spec_or_raise(partial_manifest, root_spec_name, root_spec_projection)
+        result_projections = update_projection_for_root_spec_or_raise(partial_manifest, root_spec_name, root_spec_projection)
 
         assert result_projections == {root_spec_name: f"ISSM{{variants.ad}}/{root_spec_version}"}
 

--- a/tests/scripts/spack_manifest/injection/test_prerelease.py
+++ b/tests/scripts/spack_manifest/injection/test_prerelease.py
@@ -163,15 +163,14 @@ class TestUpdateRootSpecProjectionsVersion:
                     {"_version": ["2025.12.000"]},
                 ],
                 "specs": [
-                    "access-issm+ad",
-                    "access-issm~ad"
+                    "access-issm+ad"
                 ],
                 "modules": {
                     "default": {
                         "tcl": {
                             "projections": {
-                                "access-om2+ad": "{name}-AD/2025.12.000",
-                                "access-om2~ad": "{name}/2025.12.000",
+                                "access-issm+ad": "{name}-AD/2025.12.000",
+                                "access-issm~ad": "{name}/2025.12.000",
                                 "dependency": "{name}/2025.12.001"
                             }
                         }
@@ -179,15 +178,15 @@ class TestUpdateRootSpecProjectionsVersion:
                 }
             }
         }
-        root_spec_name = "access-om2"
+        root_spec_name = "access-issm"
         root_spec_version = "pr12-2"
 
         updated_manifest = update_root_spec_projections_version(manifest, root_spec_name, root_spec_version)
 
         updated_projections = updated_manifest["spack"]["modules"]["default"]["tcl"]["projections"]
 
-        assert updated_projections["access-om2+ad"] == f"{{name}}-AD/{root_spec_version}"
-        assert updated_projections["access-om2~ad"] == f"{{name}}/{root_spec_version}"
+        assert updated_projections["access-issm+ad"] == f"{{name}}-AD/{root_spec_version}"
+        assert updated_projections["access-issm~ad"] == f"{{name}}/{root_spec_version}"
         assert updated_projections["dependency"] == "{name}/2025.12.001"
 
 class TestAddPrereleaseReposSection:

--- a/tests/scripts/spack_manifest/injection/test_prerelease.py
+++ b/tests/scripts/spack_manifest/injection/test_prerelease.py
@@ -3,13 +3,13 @@ import pytest
 from scripts.spack_manifest.injection.prerelease import (
     inject_prerelease_information,
     add_prerelease_repos_section,
-    update_root_spec_projection_version,
+    update_root_spec_projections_version,
     add_namespace_to_other_projection_versions,
     parse_args
 )
 
-class TestUpdateRootSpecProjectionVersion:
-    def test_update_root_spec_projection_version__valid_existing_single_spec(self):
+class TestUpdateRootSpecProjectionsVersion:
+    def test_update_root_spec_projections_version__valid_existing_single_spec(self):
         manifest = {
             "spack": {
                 "definitions": [
@@ -34,11 +34,11 @@ class TestUpdateRootSpecProjectionVersion:
         root_spec_name = "access-om2"
         root_spec_version = "pr12-2"
 
-        updated_manifest = update_root_spec_projection_version(manifest, root_spec_name, root_spec_version)
+        updated_manifest = update_root_spec_projections_version(manifest, root_spec_name, root_spec_version)
 
         assert updated_manifest["spack"]["modules"]["default"]["tcl"]["projections"][root_spec_name] == f"{{name}}/{root_spec_version}/1.0.0"
 
-    def test_update_root_spec_projection_version__valid_existing_multi_spec(self):
+    def test_update_root_spec_projections_version__valid_existing_multi_spec(self):
         manifest = {
             "spack": {
                 "definitions": [
@@ -64,12 +64,12 @@ class TestUpdateRootSpecProjectionVersion:
         root_spec_name = "access-om2"
         root_spec_version = "pr12-2"
 
-        updated_manifest = update_root_spec_projection_version(manifest, root_spec_name, root_spec_version)
+        updated_manifest = update_root_spec_projections_version(manifest, root_spec_name, root_spec_version)
 
         assert updated_manifest["spack"]["modules"]["default"]["tcl"]["projections"][root_spec_name] == f"{{name}}/{root_spec_version}/1.0.0"
 
 
-    def test_update_root_spec_projection_version__valid_new_single_spec(self):
+    def test_update_root_spec_projections_version__valid_new_single_spec(self):
         manifest = {
             "spack": {
                 "specs": [
@@ -87,11 +87,11 @@ class TestUpdateRootSpecProjectionVersion:
         root_spec_name = "access-om2"
         root_spec_version = "pr12-2"
 
-        updated_manifest = update_root_spec_projection_version(manifest, root_spec_name, root_spec_version)
+        updated_manifest = update_root_spec_projections_version(manifest, root_spec_name, root_spec_version)
 
         assert updated_manifest["spack"]["modules"]["default"]["tcl"]["projections"][root_spec_name] == f"{{name}}/{root_spec_version}"
 
-    def test_update_root_spec_projection_version__valid_new_multi_spec(self):
+    def test_update_root_spec_projections_version__valid_new_multi_spec(self):
         manifest = {
             "spack": {
                 "specs": [
@@ -110,11 +110,11 @@ class TestUpdateRootSpecProjectionVersion:
         root_spec_name = "access-om2"
         root_spec_version = "pr12-2"
 
-        updated_manifest = update_root_spec_projection_version(manifest, root_spec_name, root_spec_version)
+        updated_manifest = update_root_spec_projections_version(manifest, root_spec_name, root_spec_version)
 
         assert updated_manifest["spack"]["modules"]["default"]["tcl"]["projections"][root_spec_name] == f"{{name}}/{root_spec_version}/{{hash:7}}"
 
-    def test_update_root_spec_projection_version__no_projections_single_spec(self):
+    def test_update_root_spec_projections_version__no_projections_single_spec(self):
         manifest = {
             "spack": {
                 "specs": [
@@ -130,11 +130,11 @@ class TestUpdateRootSpecProjectionVersion:
         root_spec_name = "access-om2"
         root_spec_version = "pr12-2"
 
-        updated_manifest = update_root_spec_projection_version(manifest, root_spec_name, root_spec_version)
+        updated_manifest = update_root_spec_projections_version(manifest, root_spec_name, root_spec_version)
 
         assert updated_manifest["spack"]["modules"]["default"]["tcl"]["projections"][root_spec_name] == f"{{name}}/{root_spec_version}"
 
-    def test_update_root_spec_projection_version__no_projections_multi_spec(self):
+    def test_update_root_spec_projections_version__no_projections_multi_spec(self):
         manifest = {
             "spack": {
                 "specs": [
@@ -151,9 +151,46 @@ class TestUpdateRootSpecProjectionVersion:
         root_spec_name = "access-om2"
         root_spec_version = "pr12-2"
 
-        updated_manifest = update_root_spec_projection_version(manifest, root_spec_name, root_spec_version)
+        updated_manifest = update_root_spec_projections_version(manifest, root_spec_name, root_spec_version)
 
         assert updated_manifest["spack"]["modules"]["default"]["tcl"]["projections"][root_spec_name] == f"{{name}}/{root_spec_version}/{{hash:7}}"
+
+    def test_update_root_spec_projections_version__updates_multiple_root_like_projection_keys(self):
+        manifest = {
+            "spack": {
+                "definitions": [
+                    {"_name": ["access-om2"]},
+                    {"_version": ["2025.12.000"]},
+                ],
+                "specs": [
+                    "access-om2 +var",
+                    "access-om2 ~var"
+                ],
+                "modules": {
+                    "default": {
+                        "tcl": {
+                            "projections": {
+                                "access-om2": "{name}/2025.12.000",
+                                "access-om2 +var": "{name}/2025.12.000/plus",
+                                "access-om2 ~var": "{name}/2025.12.000/minus",
+                                "dependency": "{name}/2025.12.000/2.0.0"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        root_spec_name = "access-om2"
+        root_spec_version = "pr12-2"
+
+        updated_manifest = update_root_spec_projections_version(manifest, root_spec_name, root_spec_version)
+
+        updated_projections = updated_manifest["spack"]["modules"]["default"]["tcl"]["projections"]
+
+        assert updated_projections["access-om2"] == f"{{name}}/{root_spec_version}/{{hash:7}}"
+        assert updated_projections["access-om2 +var"] == f"{{name}}/{root_spec_version}/plus"
+        assert updated_projections["access-om2 ~var"] == f"{{name}}/{root_spec_version}/minus"
+        assert updated_projections["dependency"] == "{name}/2025.12.000/2.0.0"
 
 class TestAddPrereleaseReposSection:
     def test_add_prerelease_repos_section__valid(self):

--- a/tests/scripts/spack_manifest/injection/test_prerelease.py
+++ b/tests/scripts/spack_manifest/injection/test_prerelease.py
@@ -159,21 +159,20 @@ class TestUpdateRootSpecProjectionsVersion:
         manifest = {
             "spack": {
                 "definitions": [
-                    {"_name": ["access-om2"]},
+                    {"_name": ["access-issm"]},
                     {"_version": ["2025.12.000"]},
                 ],
                 "specs": [
-                    "access-om2 +var",
-                    "access-om2 ~var"
+                    "access-issm+ad",
+                    "access-issm~ad"
                 ],
                 "modules": {
                     "default": {
                         "tcl": {
                             "projections": {
-                                "access-om2": "{name}/2025.12.000",
-                                "access-om2 +var": "{name}/2025.12.000/plus",
-                                "access-om2 ~var": "{name}/2025.12.000/minus",
-                                "dependency": "{name}/2025.12.000/2.0.0"
+                                "access-om2+ad": "{name}-AD/2025.12.000",
+                                "access-om2~ad": "{name}/2025.12.000",
+                                "dependency": "{name}/2025.12.001"
                             }
                         }
                     }
@@ -187,10 +186,9 @@ class TestUpdateRootSpecProjectionsVersion:
 
         updated_projections = updated_manifest["spack"]["modules"]["default"]["tcl"]["projections"]
 
-        assert updated_projections["access-om2"] == f"{{name}}/{root_spec_version}/{{hash:7}}"
-        assert updated_projections["access-om2 +var"] == f"{{name}}/{root_spec_version}/plus"
-        assert updated_projections["access-om2 ~var"] == f"{{name}}/{root_spec_version}/minus"
-        assert updated_projections["dependency"] == "{name}/2025.12.000/2.0.0"
+        assert updated_projections["access-om2+ad"] == f"{{name}}-AD/{root_spec_version}"
+        assert updated_projections["access-om2~ad"] == f"{{name}}/{root_spec_version}"
+        assert updated_projections["dependency"] == "{name}/2025.12.001"
 
 class TestAddPrereleaseReposSection:
     def test_add_prerelease_repos_section__valid(self):


### PR DESCRIPTION
## Background

Currently, the modules injection only supports a single root spec in the projections, eg: 

```yaml
access-issm: {name}/{version}
```

But there are cases where there can be multiple - for example, having different module names depending on variants of a given spec, eg:

```yaml
access-issm+ad: {name}-AD/{version}
access-issm~ad: {name}/{version}
```

Currently, our infrastructure doesn't support it - it doesn't see the above two as root specs, and so it erroneously add a base root spec, and treats the existing ones as dependencies:

```yaml
access-issm: {name}/2026.05.0
access-issm+ad: {name}/latest-abcdef
access-issm~ad: {name}/latest-qwerty
```

Instead, the pre/release injection should treat partial specs that include the root specs, as root specs. 

## The PR

- **modules.py: Make partial specs that start with the root spec name count as root specs**
- **prerelease.py:Account for possibly multiple partial root specs in the projections**

## Testing

### Unit Tests

Ran locally, passed (probably should automate this!)

### Tested via MDRs

Given the existing MDR:

```yaml
# ...
  modules:
    default:
      tcl:
        projections:
          access-issm+ad: '{name}-AD/{version}'
          access-issm~ad: '{name}/{version}'
```

#### Release

```yaml
# ...
  modules:
    default:
      tcl:
        projections:
          access-issm+ad: '{name}-AD/2026.05.0'
          access-issm~ad: '{name}/2026.05.0'
          access-triangle: '{name}/1.6.1-{hash:7}'
          issm: '{name}/2026.05.18-{hash:7}'
```

#### Prerelease

```yaml
# ...
  modules:
    default:
      tcl:
        projections:
          access-issm+ad: '{name}-AD/prX-Y'
          access-issm~ad: '{name}/prX-Y'
          access-triangle: 'access-issm/dependencies/prX-Y/{name}/1.6.1-{hash:7}'
          issm: 'access-issm/dependencies/prX-Y/{name}/2026.05.18-{hash:7}'
```