### PR TITLE
PR cleanup: keep build dependencies when garbage collecting

### DIFF
--- a/.github/workflows/undeploy-1-start.yml
+++ b/.github/workflows/undeploy-1-start.yml
@@ -82,12 +82,12 @@ jobs:
           done
 
           # Base scope cleanup (most environments are in this scope)
-          spack gc --except-any-environment --yes-to-all
+          spack gc --except-any-environment --keep-build-dependencies --yes-to-all
 
           # Custom scopes cleanup (like restricted scopes, etc)
           scopes=$(find ${{ steps.path.outputs.spack-config }}/custom/cd -mindepth 1 -maxdepth 1 -type d -printf '%p ')
           for scope in $scopes; do
-            spack --config-scope $scope gc --except-any-environment --yes-to-all
+            spack --config-scope $scope gc --except-any-environment --keep-build-dependencies --yes-to-all
           done
           EOT
 


### PR DESCRIPTION
## Background

During manual garbage collection of the release instance, I noticed that build-time dependencies would be cleaned up with `spack gc --except-any-environment` - including things like `cmake`. Maybe this is contributing to the lack of reuse of low-level dependencies in Prerelease?

When I added `--keep-build-dependencies`, it kept those installs of `cmake`, etc. Maybe it's worth keeping those around for a while to see if it aids reuse?

## The PR

* When cleaning up PRs in the Prerelease instance, `--keep-build-dependencies` so hopefully installs of `cmake` and other low-level deps are reused in Prerelease.
