### PR TITLE
Use Spack Modules in Infra

### DIFF
--- a/.github/workflows/create-deployment-spack.yml
+++ b/.github/workflows/create-deployment-spack.yml
@@ -84,7 +84,10 @@ jobs:
             ${{ env.ROOT_VERSION_LOCATION }}/restricted $TMPDIR/restricted
           EOT
 
-          . ${{ env.ROOT_VERSION_LOCATION }}/spack/share/spack/setup-env.sh
+          # Enable spack
+          module use ${{ vars.ADMIN_MODULES_DIR }}
+          module load spack/${{ steps.strip.outputs.version }}
+
           spack -d bootstrap now
 
       - name: Checkout build-cd for modulefiles

--- a/.github/workflows/deploy-2-start.yml
+++ b/.github/workflows/deploy-2-start.yml
@@ -194,16 +194,9 @@ jobs:
             exit 1
           fi
 
-          # Export vars.DEPLOYMENT_TARGET
-          export DEPLOYMENT_TARGET="${{ vars.DEPLOYMENT_TARGET }}"
-          echo "DEPLOYMENT_TARGET exported as $DEPLOYMENT_TARGET"
-
-          #FIXME: Remove this once spack modules are deployed for admins
-          export SPACK_USER_CACHE_PATH=${{ steps.path.outputs.spack }}/../spack-admin-cache
-          export SPACK_PYTHON=/usr/bin/python3.12
-
           # Enable spack
-          . ${{ steps.path.outputs.spack }}/share/spack/setup-env.sh
+          module use ${{ vars.ADMIN_MODULES_DIR }}
+          module load spack/${{ steps.versions.outputs.spack }}
 
           # Create and activate environment
           spack env activate ${{ inputs.env-name }} --create --envfile ${{ vars.SPACK_YAML_LOCATION }}/${{ inputs.expected-root-spec-name }}-${{ github.run_id }}.spack.yaml
@@ -245,14 +238,11 @@ jobs:
             ${{ secrets.USER }}@${{ secrets.HOST }}:${{ steps.path.outputs.spack-environment }}/
 
           ssh ${{ secrets.USER }}@${{ secrets.HOST }} -i ${{ steps.ssh.outputs.private-key-path }} /bin/bash <<'EOT'
-          # Export vars.DEPLOYMENT_TARGET
-          export DEPLOYMENT_TARGET="${{ vars.DEPLOYMENT_TARGET }}"
-          echo "DEPLOYMENT_TARGET exported as $DEPLOYMENT_TARGET"
 
-          #FIXME: Remove this once spack modules are deployed
-          export SPACK_USER_CACHE_PATH=${{ steps.path.outputs.spack }}/../spack-admin-cache
+          # Enable spack
+          module use ${{ vars.ADMIN_MODULES_DIR }}
+          module load spack/${{ steps.versions.outputs.spack }}
 
-          . ${{ steps.path.outputs.spack }}/share/spack/setup-env.sh
           ${{ steps.path.outputs.spack-environment }}/get_data_from_deployment.py \
             --environment ${{ steps.path.outputs.spack-environment }} \
             --deployment-name ${{ inputs.expected-root-spec-name }} \

--- a/.github/workflows/settings-2-deploy.yml
+++ b/.github/workflows/settings-2-deploy.yml
@@ -120,7 +120,9 @@ jobs:
                 echo "::error::Error: ${{ inputs.deployment-environment }} ${{ inputs.spack-type }} $version spack-config failed checkout from $current_head_commit to $new_commit"
               else
                 echo "::notice::Changed: ${{ inputs.deployment-environment }} ${{ inputs.spack-type }} $version spack-config changed from $current_head_commit to $new_commit"
-                . ${{ secrets.SPACK_INSTALLS_ROOT_LOCATION }}/$version/spack/share/spack/setup-env.sh
+
+                module use ${{ vars.ADMIN_MODULES_DIR }}
+                module load spack/$version
                 spack repo update
               fi
 

--- a/.github/workflows/undeploy-1-start.yml
+++ b/.github/workflows/undeploy-1-start.yml
@@ -70,11 +70,10 @@ jobs:
         run: |
           ssh ${{ secrets.USER}}@${{ secrets.HOST }} -i ${{ steps.ssh.outputs.private-key-path }} /bin/bash <<'EOT'
 
-          # Export vars.DEPLOYMENT_TARGET
-          export DEPLOYMENT_TARGET="${{ vars.DEPLOYMENT_TARGET }}"
-          echo "DEPLOYMENT_TARGET exported as $DEPLOYMENT_TARGET"
-
-          . ${{ steps.path.outputs.spack }}/share/spack/setup-env.sh
+          # Enable spack
+          module use ${{ vars.ADMIN_MODULES_DIR }}
+          module load spack/${{ steps.versions.outputs.spack }}
+          
           envs=$(find ${{ steps.path.outputs.spack }}/../environments -type d -name '${{ inputs.version-pattern }}' -printf '%f ')
 
           for env in $envs; do


### PR DESCRIPTION
Closes #376
Requires #367

> [!IMPORTANT]
> The merging of this change requires that `vars.ADMIN_MODULES_DIR` is set in the MDR. Since this is a new required addition, it should technically be a major update...but it's not a code change, so I can just `gh variable set ADMIN_MODULES_DIR --env "Gadi TYPE" --body "..." --repo access-nri/ALL_THE_MDRS` pre-merge. EDIT: Done!

## Background

We now have a `module use/load` for `spack`, for both an admin and non-admin version of `spack`. We should transition to this for our `build-cd` infrastructure.

The directory structure for these admin modules are as follows:

```
.
└── vk83/
    ├── apps/
    │   └── spack/
    │       └── 1.1/
    │           ├── spack
    │           ├── spack-config
    │           └── ...
    ├── admin/
    │   └── modules/
    │       └── spack/
    │           └── 1.1
    └── prerelease/
        ├── apps/
        │   └── spack/
        │       └── 1.1/
        │           ├── spack
        │           ├── spack-config
        │           └── ...
        └── admin/
            └── modules/
                └── spack/
                    └── 1.1
```

Since the modules handle all of the environment variable setting, we can have a simpler infrastructure.

## The PR

- **Replace usage of bare setup-env.sh script with module use/load**

## Testing

Tested via https://github.com/ACCESS-NRI/ACCESS-TEST/pull/70 - noting that the [prerelease](https://github.com/ACCESS-NRI/ACCESS-TEST/actions/runs/27391756393/job/80950744055?pr=70#step:15:42) and [cleanup](https://github.com/ACCESS-NRI/ACCESS-TEST/actions/runs/27393006443/job/80954448840#step:6:26) were successful!
